### PR TITLE
JDL2 0.5.0 must be installed explicitely

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ shell> cd Pioneer.jl
 4) Return to julia by hitting the backspace key. Activate the julia package manager by typing "]" into the REPL and enter the following:
 ```
 (@v1.10) pkg> activate
+(@v1.10) pkg> add https://github.com/JuliaIO/JLD2.jl#v0.5.0
 (@v1.10) pkg> develop ./
 (@v1.10) pkg> add ./
 ```


### PR DESCRIPTION
Running `develop ./` without installing version 0.5.0 of JDL2 gives

```
(@v1.10) pkg> develop ./
   Resolving package versions...
ERROR: Unsatisfiable requirements detected for package JLD2 [033835bb]:
 JLD2 [033835bb] log:
 ├─possible versions are: 0.1.0-0.4.46 or uninstalled
 └─restricted to versions 0.5.0 by Pioneer [585db54e] — no versions left
   └─Pioneer [585db54e] log:
     ├─possible versions are: 1.0.0 or uninstalled
     └─Pioneer [585db54e] is fixed to version 1.0.0-DEV
```