### PR TITLE
Fix Bugs in convertMzML

### DIFF
--- a/src/Routines/mzmlConverter/convertMzML.jl
+++ b/src/Routines/mzmlConverter/convertMzML.jl
@@ -19,6 +19,7 @@ end
 function parseBinaryDataList(binary_data_list::EzXML.Node)
     mz_array, intensity_array = nothing, nothing
     is_mz_array, is_intensity_array = false, false
+    #Assumption here is that the intensities and m/z arrays both have the same precision
     precision = zero(Float32)
     for nl in eachelement(binary_data_list)
         is_mz_array, is_intensity_array = false, false

--- a/src/Routines/mzmlConverter/convertMzML.jl
+++ b/src/Routines/mzmlConverter/convertMzML.jl
@@ -192,7 +192,7 @@ end
 function readMzML(
     mzML_path::String,
     skip_scan_header::Bool)
-    root_elements = root(EzXML.readxml(mzML_path))
+    root_elements = EzXML.root(EzXML.readxml(mzML_path))
     # Create a namespace map
     ns = Dict("ms" => "http://psi.hupo.org/ms/mzml")
     # Use the namespace prefix in the XPath query


### PR DESCRIPTION
convertMzML now support mzML inputs with 64-bit precision in the mz and intensity arrays. However, in these cases the data will be converted to 32-bit precision before writing to the .arrow table. Also fixed a conflict between the LightXML and EzXML packages. LightXML is being used for the isotope splines. Ideally in the future Pioneer uses just EzXML for both MzML conversion and also for parsing the isotope splines. This will mean fewer dependencies. 