### PR TITLE
use isolation width to insure proper bounds of quad fit plot

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/QuadTuningSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/QuadTuningSearch.jl
@@ -243,8 +243,11 @@ function process_file!(
         # Fit quad model
         window_width = parse(Float64, first(window_widths))
 
-        fitted_model = fit_quad_model(total_psms, window_width)
-        setQuadModel(results, RazoQuadModel(fitted_model))
+        fitted_model = RazoQuadModel(fit_quad_model(total_psms, window_width))
+        setQuadModel(results, fitted_model)
+
+        # Plot quad model
+        plot_quad_model(fitted_model, window_width, results, getFileIdToName(getMSData(search_context), ms_file_idx))
         
     catch e
         throw(e)
@@ -275,16 +278,6 @@ function summarize_results!(
     search_context::SearchContext
 ) where {P<:QuadTuningSearchParameters}
     
-    plot_bins = LinRange(0-3, 0+3, 100)
-    for (ms_file_idx, quad_model) in pairs(search_context.quad_transmission_model)
-        fname = getFileIdToName(getMSData(search_context), ms_file_idx)
-        quad_func = getQuadTransmissionFunction(quad_model, 0.0f0, 2.0f0)
-        p = plot(plot_bins, quad_func.(plot_bins), lw = 2, alpha = 0.5, title = "$fname")
-        savefig(p, joinpath(results.quad_plot_dir, "quad_models", fname*".pdf"))
-    end
-
-
-
     models_path = joinpath(results.quad_plot_dir, "quad_models", "quad_model_plots.pdf")
     data_path = joinpath(results.quad_plot_dir, "quad_data", "quad_data_plots.pdf")
     try

--- a/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/utils.jl
@@ -844,6 +844,32 @@ end
 
 
 """
+    plot_quad_model(quad_model::QuadTransmissionModel, window_width::Float32, results::QuadTuningSearchResults, fname::String)
+
+Generate visualization of quadrupole transmission fit.
+
+# Arguments
+- `quad_model`: fitted quad model
+- `window_width`: isolation width used to model the quad
+- `results`: Quad tuning results containing plot directory
+- `fname`: Filename for plot
+
+Creates line plot of m/z offset vs transmission for the fitted model.
+Saves plot to quad_plot_dir/quad_models directory.
+"""
+
+function plot_quad_model(quad_model::QuadTransmissionModel, window_width::Float64, results::QuadTuningSearchResults, fname::String)
+    padding = 2
+    half_width = padding + window_width/2
+    plot_bins = LinRange(-half_width, half_width, 100)
+
+    quad_func = getQuadTransmissionFunction(quad_model, 0.0f0, 2.0f0)
+    p = plot(plot_bins, quad_func.(plot_bins), lw = 2, alpha = 0.5, title = "$fname")
+    savefig(p, joinpath(results.quad_plot_dir, "quad_models", fname*".pdf"))
+end
+
+
+"""
     fit_quad_model(psms::DataFrame, window_width::Float64) -> QuadTransmissionModel
 
 Fit quadrupole transmission model to binned PSM data.


### PR DESCRIPTION
With 14.7 m/z wide Exploris data it was plotting from -3 to 3 and I couldn't tell if the fit was good or not. Now it will use the isolation width and add 2m/z padding on each side.