### PR TITLE
Added option to use run-to-run normalization at protein-level and wide precursor output

### DIFF
--- a/data/ecoli_test/ecoli_test_params.json
+++ b/data/ecoli_test/ecoli_test_params.json
@@ -106,6 +106,9 @@
             "interpolation_points": 10
         }
     },
+    "maxLFQ": {
+        "run_to_run_normalization": false
+    },
     "output": {
         "write_csv": true,
         "delete_temp": true,

--- a/data/example_config/LibrarySearch.json
+++ b/data/example_config/LibrarySearch.json
@@ -96,6 +96,9 @@
             "interpolation_points": 10
         }
     },
+    "maxLFQ": {
+        "run_to_run_normalization": true
+    },
     "output": {
         "write_csv": true,
         "delete_temp": true,

--- a/data/example_config/defaultSearchParams.json
+++ b/data/example_config/defaultSearchParams.json
@@ -107,6 +107,9 @@
             "interpolation_points": 10
         }
     },
+    "maxLFQ": {
+        "run_to_run_normalization": true
+    },
     "output": {
         "write_csv": true,
         "delete_temp": true,

--- a/docs/src/user_guide/parameters.md
+++ b/docs/src/user_guide/parameters.md
@@ -128,6 +128,12 @@ Most parameters should not be changed, but the following may need adjustement.
 | `machine_learning.spline_points` | Int | Number of points for probability spline (default: 500) |
 | `machine_learning.interpolation_points` | Int | Number of interpolation points (default: 10) |
 
+### MaxLFQ Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `run_to_run_normalization` | Boolean | Whether to use run-to-run normalized abundances for precursor and protein quantification (default: true) |
+
 ### Output Parameters
 
 | Parameter | Type | Description |

--- a/src/Routines/SearchDIA/ParseInputs/paramsChecks.jl
+++ b/src/Routines/SearchDIA/ParseInputs/paramsChecks.jl
@@ -138,6 +138,10 @@ function checkParams(json_path::String)
     check_param(ml_params, "spline_points", Integer)
     check_param(ml_params, "interpolation_points", Integer)
 
+    # Validate MaxLFQ parameters
+    output = params["maxLFQ"]
+    check_param(output, "run_to_run_normalization", Bool)
+
     # Validate output parameters
     output = params["output"]
     check_param(output, "write_csv", Bool)

--- a/src/Routines/SearchDIA/ParseInputs/parseParams.jl
+++ b/src/Routines/SearchDIA/ParseInputs/parseParams.jl
@@ -6,6 +6,7 @@ struct PioneerParameters
     acquisition::NamedTuple
     rt_alignment::NamedTuple
     optimization::NamedTuple
+    maxLFQ::NamedTuple
     output::NamedTuple
     paths::NamedTuple
 end
@@ -52,6 +53,7 @@ function parse_pioneer_parameters(json_path::String)
     acquisition = dict_to_namedtuple(params["acquisition"])
     rt_alignment = dict_to_namedtuple(params["rt_alignment"])
     optimization = dict_to_namedtuple(params["optimization"])
+    maxLFQ = dict_to_namedtuple(params["maxLFQ"])
     output = dict_to_namedtuple(params["output"])
     paths = dict_to_namedtuple(params["paths"])
 
@@ -63,6 +65,7 @@ function parse_pioneer_parameters(json_path::String)
         acquisition,
         rt_alignment,
         optimization,
+        maxLFQ,
         output,
         paths
     )


### PR DESCRIPTION
Defaulted it to true because I think that will be the case for most applications.