### PR TITLE
Grab bag of stuff

### DIFF
--- a/data/ecoli_test/ecoli_test_params.json
+++ b/data/ecoli_test/ecoli_test_params.json
@@ -17,7 +17,8 @@
         "huber_override": {
             "override_huber_delta_fit": true,
             "huber_delta": 1500.0
-        }
+        }, 
+		"match_between_runs": true
     },
     "parameter_tuning": {
         "fragment_settings": {

--- a/data/example_config/LibrarySearch.json
+++ b/data/example_config/LibrarySearch.json
@@ -12,7 +12,8 @@
         "normalization": {
             "n_rt_bins": 100,
             "spline_n_knots": 7
-        }
+        }, 
+		"match_between_runs": true
     },
     "parameter_tuning": {
         "fragment_settings": {

--- a/data/example_config/defaultSearchParams.json
+++ b/data/example_config/defaultSearchParams.json
@@ -17,7 +17,8 @@
         "huber_override": {
             "override_huber_delta_fit": true,
             "huber_delta": 1500.0
-        }
+        }, 
+		"match_between_runs": true
     },
     "parameter_tuning": {
         "fragment_settings": {

--- a/docs/src/user_guide/parameters.md
+++ b/docs/src/user_guide/parameters.md
@@ -42,6 +42,7 @@ Most parameters should not be changed, but the following may need adjustement.
 | `scoring.q_value_threshold` | Float | Global q-value threshold for filtering results (default: 0.01) |
 | `normalization.n_rt_bins` | Int | Number of retention time bins for quant normalization (default: 100) |
 | `normalization.spline_n_knots` | Int | Number of knots in quant normalization spline (default: 7) |
+| `match_between_runs` | Boolean | Whether to attempt to transfer peptide identifications across runs. Turning this on will add additional features to the XGBoost model (default: true) |
 
 ### Parameter Tuning Settings
 

--- a/src/Pioneer.jl
+++ b/src/Pioneer.jl
@@ -19,7 +19,7 @@ using Plots, PrettyPrinting, Polynomials, PDFmerger, ProgressBars, Pkg
 using Tables, Test
 using StatsPlots, SentinelArrays
 using Random
-using StaticArrays, StatsBase, SpecialFunctions, Statistics
+using StaticArrays, StatsBase, SpecialFunctions, Statistics, SparseArrays
 using XGBoost
 using KernelDensity
 using FastGaussQuadrature

--- a/src/Routines/BuildSpecLib/build/build_poin_lib.jl
+++ b/src/Routines/BuildSpecLib/build/build_poin_lib.jl
@@ -158,12 +158,6 @@ function buildPionLib(spec_lib_path::String,
         joinpath(spec_lib_path, "precursor_to_fragment_indices.jld2");
         pid_to_fid
     )
-    for  fname in ["fragments_table.arrow", "prec_to_frag.arrow", "precursors.arrow"]
-        fpath = joinpath(spec_lib_path, fname)
-        if isfile(fpath)
-            rm(fpath)
-        end
-    end
 
     return nothing
 end
@@ -331,6 +325,16 @@ function buildPionLib(spec_lib_path::String,
     )
 
     return nothing
+end
+
+function cleanUpLibrary(spec_lib_path::String)
+    GC.gc()
+    for fname in ["fragments_table.arrow", "prec_to_frag.arrow", "precursors.arrow"]
+        fpath = joinpath(spec_lib_path, fname)
+        if isfile(fpath)
+            rm(fpath, force=true)
+        end
+    end
 end
 
 function fragFilter(

--- a/src/Routines/SearchDIA/CommonSearchUtils/normalizeQuant.jl
+++ b/src/Routines/SearchDIA/CommonSearchUtils/normalizeQuant.jl
@@ -50,7 +50,7 @@ function getQuantCorrections(
         end
     end
     median_quant = reshape(median(median_quant, dims = 1), (N,))
-    median_quant = LinearInterpolation(rt_range, median_quant)
+    median_quant = linear_interpolation(rt_range, median_quant)
     corrections = Dictionary{String, Any}()
     for (key, spline) in pairs(quant_splines)
         offset = zeros(Float32, N)
@@ -60,7 +60,7 @@ function getQuantCorrections(
         insert!(
             corrections, 
             key,
-            LinearInterpolation(rt_range, offset)
+            linear_interpolation(rt_range, offset)
         )
     end
     return corrections 

--- a/src/Routines/SearchDIA/ParseInputs/paramsChecks.jl
+++ b/src/Routines/SearchDIA/ParseInputs/paramsChecks.jl
@@ -40,6 +40,8 @@ function checkParams(json_path::String)
     check_param(global_params["huber_override"], "override_huber_delta_fit", Bool)
     check_param(global_params["huber_override"], "huber_delta", Real)
 
+    check_param(global_params, "match_between_runs", Bool)
+
     # Validate parameter tuning parameters
     tuning_params = params["parameter_tuning"]
     check_param(tuning_params, "fragment_settings", Dict)

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -305,7 +305,7 @@ function process_file!(
         select!(psms, [:ms_file_idx, :score, :precursor_idx, :scan_idx,
             :q_value, :log2_summed_intensity, :irt, :rt, :irt_predicted])
         get_probs!(psms, psms[!,:score])
-        sort!(psms, :irt)
+        sort!(psms, :rt)
     end
 
     try

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -292,7 +292,7 @@ function get_best_psms!(psms::DataFrame,
         end
     end
     #delete!(psms, min(n, max_psms + 1):n)
-    delete!(psms, min(n, round(Int64, psms_10fdr*2.0) + 1):n)
+    deleteat!(psms, min(n, round(Int64, psms_10fdr*2.0) + 1):n)
 
     mz = zeros(T, size(psms, 1));
     precursor_idx = psms[!,:precursor_idx]::Vector{UInt32}

--- a/src/Routines/SearchDIA/SearchMethods/MaxLFQSearch/MaxLFQSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MaxLFQSearch/MaxLFQSearch.jl
@@ -42,6 +42,7 @@ struct MaxLFQSearchParameters <: SearchParameters
     
     # Output parameters
     write_csv::Bool
+    delete_temp::Bool
     params::Any  # Store full parameters for reference
 
     function MaxLFQSearchParameters(params::PioneerParameters)
@@ -58,6 +59,7 @@ struct MaxLFQSearchParameters <: SearchParameters
             Float32(global_params.scoring.q_value_threshold),
             Int64(100000),  # Default batch size
             Bool(output_params.write_csv),
+            Bool(output_params.delete_temp),
             params  # Store full parameters
         )
     end
@@ -191,6 +193,12 @@ function summarize_results!(
             precursors,
             params
         )
+
+        if params.delete_temp
+            @info "Removing temporary data..."
+            temp_path = joinpath(getDataOutDir(search_context), "temp_data")
+            isdir(temp_path) && rm(temp_path; recursive=true, force=true)
+        end
 
     catch e
         @error "MaxLFQ analysis failed" exception=e

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
@@ -237,7 +237,7 @@ function fit_irt_model(
     # Calculate residuals
     psms[!,:irt_observed] = rt_to_irt_map.(psms.rt::Vector{Float32})
     residuals = psms[!,:irt_observed] .- psms[!,:irt_predicted]
-    irt_mad = mad(residuals)::Float32
+    irt_mad = mad(residuals, normalize=false)::Float32
     
     # Remove outliers and refit
     valid_psms = psms[abs.(residuals) .< (irt_mad * getOutlierThreshold(params)), :]

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
@@ -97,14 +97,12 @@ Trained XGBoost models or simplified model if insufficient PSMs.
 function score_precursor_isotope_traces_in_memory!(
     best_psms::DataFrame,
     file_paths::Vector{String},
-    precursors::BasicLibraryPrecursors
+    precursors::BasicLibraryPrecursors,
+    match_between_runs::Bool
 )
     if size(best_psms, 1) > 100000
         file_paths = [fpath for fpath in file_paths if endswith(fpath,".arrow")]
-        features = [ 
-            :max_prob,
-            :mean_prob,
-            :min_prob,
+        features = [
             :missed_cleavage,
             :Mox,
             :prec_mz,
@@ -139,6 +137,15 @@ function score_precursor_isotope_traces_in_memory!(
             :log2_intensity_explained,
             :tic,
         ];
+
+        if match_between_runs
+            append!(features, [
+                :max_prob, 
+                :mean_prob, 
+                :min_prob
+                ])
+        end
+
         
         best_psms[!,:accession_numbers] = [getAccessionNumbers(precursors)[pid] for pid in best_psms[!,:precursor_idx]]
         best_psms[!,:q_value] = zeros(Float32, size(best_psms, 1));
@@ -148,6 +155,7 @@ function score_precursor_isotope_traces_in_memory!(
                                 best_psms, 
                                 file_paths,
                                 features,
+                                match_between_runs,
                                 colsample_bytree = 0.5, 
                                 colsample_bynode = 0.5,
                                 min_child_weight = 5, 
@@ -186,6 +194,7 @@ function score_precursor_isotope_traces_in_memory!(
                                 best_psms, 
                                 file_paths,
                                 features,
+                                match_between_runs,
                                 colsample_bytree = 1.0, 
                                 colsample_bynode = 1.0,
                                 min_child_weight = 1, 
@@ -216,67 +225,74 @@ Trained XGBoost models or simplified model if insufficient PSMs.
 function score_precursor_isotope_traces_out_of_memory!(
     best_psms::DataFrame,
     file_paths::Vector{String},
-    precursors::BasicLibraryPrecursors
+    precursors::BasicLibraryPrecursors,
+    match_between_runs::Bool
 )
     if size(best_psms, 1) > 100000
-    file_paths = [fpath for fpath in file_paths if endswith(fpath,".arrow")]
-    features = [ 
-        :max_prob,
-        :mean_prob,
-        :min_prob,
-        :missed_cleavage,
-        :Mox,
-        :prec_mz,
-        :sequence_length,
-        :charge,
-        :irt_pred,
-        :irt_error,
-        :irt_diff,
-        :max_y_ions,
-        :y_ions_sum,
-        :longest_y,
-        :y_count,
-        :b_count,
-        :isotope_count,
-        :total_ions,
-        :best_rank,
-        :best_rank_iso,
-        :topn,
-        :topn_iso,
-        :gof,
-        :max_fitted_manhattan_distance,
-        :max_fitted_spectral_contrast,
-        :max_matched_residual,
-        :max_unmatched_residual,
-        :max_gof,
-        :fitted_spectral_contrast,
-        :spectral_contrast,
-        :max_matched_ratio,
-        :err_norm,
-        :poisson,
-        :weight,
-        :log2_intensity_explained,
-        :tic,
-    ];
-    
-    best_psms[!,:accession_numbers] = [getAccessionNumbers(precursors)[pid] for pid in best_psms[!,:precursor_idx]]
-    best_psms[!,:q_value] = zeros(Float32, size(best_psms, 1));
-    best_psms[!,:decoy] = best_psms[!,:target].==false;
+        file_paths = [fpath for fpath in file_paths if endswith(fpath,".arrow")]
+        features = [ 
+            :missed_cleavage,
+            :Mox,
+            :prec_mz,
+            :sequence_length,
+            :charge,
+            :irt_pred,
+            :irt_error,
+            :irt_diff,
+            :max_y_ions,
+            :y_ions_sum,
+            :longest_y,
+            :y_count,
+            :b_count,
+            :isotope_count,
+            :total_ions,
+            :best_rank,
+            :best_rank_iso,
+            :topn,
+            :topn_iso,
+            :gof,
+            :max_fitted_manhattan_distance,
+            :max_fitted_spectral_contrast,
+            :max_matched_residual,
+            :max_unmatched_residual,
+            :max_gof,
+            :fitted_spectral_contrast,
+            :spectral_contrast,
+            :max_matched_ratio,
+            :err_norm,
+            :poisson,
+            :weight,
+            :log2_intensity_explained,
+            :tic,
+        ];
+        
+        if match_between_runs
+            append!(features, [
+                :max_prob, 
+                :mean_prob, 
+                :min_prob
+                ])
+        end
 
-    models = sort_of_percolator_out_of_memory!(
-                            best_psms, 
-                            file_paths,
-                            features,
-                            colsample_bytree = 0.5, 
-                            colsample_bynode = 0.5,
-                            min_child_weight = 5, 
-                            gamma = 1,
-                            subsample = 0.25, 
-                            max_depth = 10,
-                            eta = 0.05, 
-                            iter_scheme = [100, 100, 200],
-                            print_importance = false);
-    return models;#best_psms
+        best_psms[!,:accession_numbers] = [getAccessionNumbers(precursors)[pid] for pid in best_psms[!,:precursor_idx]]
+        best_psms[!,:q_value] = zeros(Float32, size(best_psms, 1));
+        best_psms[!,:decoy] = best_psms[!,:target].==false;
+
+        models = sort_of_percolator_out_of_memory!(
+                                best_psms, 
+                                file_paths,
+                                features,
+                                match_between_runs,
+                                colsample_bytree = 0.5, 
+                                colsample_bynode = 0.5,
+                                min_child_weight = 5, 
+                                gamma = 1,
+                                subsample = 0.25, 
+                                max_depth = 10,
+                                eta = 0.05, 
+                                iter_scheme = [100, 100, 200],
+                                print_importance = false);
+        return models;#best_psms
     else
         @warn "Less than 100,000 psms. Training with simplified target-decoy discrimination model..."
         file_paths = [fpath for fpath in file_paths if endswith(fpath,".arrow")]
@@ -303,9 +319,9 @@ function score_precursor_isotope_traces_out_of_memory!(
         #Train XGBoost model to score each precursor trace. Target-decoy descrimination
         models = sort_of_percolator_out_of_memory!(
                                 best_psms, 
-                                max_train_psms,
                                 file_paths,
                                 features,
+                                match_between_runs,
                                 colsample_bytree = 1.0, 
                                 colsample_bynode = 1.0,
                                 min_child_weight = 100, 


### PR DESCRIPTION
Fixed minor bug where first search PSMs were sorted by :irt instead of :rt, :rt was needed to properly compute FWHM. Sometimes the rts were out of order.

delete_temp parameter wasn't being used, now it will delete the temp folder if turned on.

Added a "match_between_run" parameter that defaults to true. It controls whether we use max_prob, median_prob, min_prob during XGBoost. This is essentially our version of MBR and sometimes a user might want to turn it off either during method development or if the samples are very unrelated.

Fixed a bug with OOM XGBoost. It was overwriting the psms variable that looks like it should have been out of scope, but I guess Julia works a little differently than I'm used to.

Silenced some warnings by updating deprecated function calls.

Fixed a unit test on windows related to file deletion.

Adding a missing import from my earlier commits.

