### PR TITLE
Delete existing temp folder

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/SearchMethods.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SearchMethods.jl
@@ -191,6 +191,8 @@ function setDataOutDir!(s::SearchContext, dir::String)
     s.mass_err_plot_folder[] = mass_error_folder
 
     temp_data_dir = joinpath(dir, "temp_data")
+    # Delete previous temp data if it exists
+    rm(temp_data_dir, recursive=true, force=true)
     !isdir(temp_data_dir) && mkdir(temp_data_dir)
 
     s.data_out_dir[] = dir


### PR DESCRIPTION
Avoids crashes during XGBoost if searching with a different number of files into the same results folder.