### PR TITLE
Handle very few PSMs. Trim long file names.

### DIFF
--- a/src/Routines/SearchDIA/CommonSearchUtils/normalizeQuant.jl
+++ b/src/Routines/SearchDIA/CommonSearchUtils/normalizeQuant.jl
@@ -6,6 +6,7 @@ function getQuantSplines(psms_paths::Vector{String},
     min_rt, max_rt = typemax(Float32), typemin(Float32)
     for fpath in psms_paths
         psms = DataFrame(Tables.columntable(Arrow.Table(fpath)))
+        N_sample = min(N, size(psms, 1))
         #psms = psms[psms[!,:species].=="HUMAN",:]
         sort!(psms, :irt_obs, alg = QuickSort)
         if minimum(psms[!,:irt_obs])<min_rt
@@ -15,10 +16,10 @@ function getQuantSplines(psms_paths::Vector{String},
             max_rt = maximum(psms[!,:irt_obs])
         end
         nprecs = size(psms, 1)
-        bin_size = nprecs÷N
-        median_quant = zeros(Float64,N);
-        median_rts = zeros(Float64, N);
-        for bin_idx in range(1, N)
+        bin_size = nprecs÷N_sample
+        median_quant = zeros(Float64,N_sample);
+        median_rts = zeros(Float64, N_sample);
+        for bin_idx in range(1, N_sample)
             bin_start = (bin_idx - 1)*bin_size + 1
             bin_stop = bin_idx*bin_size
             median_rts[bin_idx] = median(@view(psms[bin_start:bin_stop,:irt_obs]));

--- a/src/Routines/SearchDIA/LibrarySearch.jl
+++ b/src/Routines/SearchDIA/LibrarySearch.jl
@@ -422,7 +422,9 @@ function LibrarySearchNceTuning(
         vcat(skipmissing(fetch.(tasks))...)
     end
 
-    return vcat(all_results...)
+    # filter out empty DFs (which are actually Vectors instead of DataFrames)
+    nonempty_dfs = filter(df -> df isa DataFrame, all_results)
+    return vcat(nonempty_dfs...)
 end
 
 function collectFragErrs(all_fmatches::Vector{M}, new_fmatches::Vector{M}, nmatches::Int, n::Int) where {M<:MatchIon{Float32}}

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
@@ -155,12 +155,16 @@ function score_presearch!(psms::DataFrame)
     psms[!,:prob] = zeros(Float32, size(psms, 1))
 
     M = size(psms, 1)
-    tasks_per_thread = 10
-    chunk_size = max(1, M ÷ (tasks_per_thread * Threads.nthreads()))
-    data_chunks = partition(1:M, chunk_size) # partition your data into chunks that
-    β = zeros(Float64, length(features))
-    β = ProbitRegression(β, psms[!,features], psms[!,:target], data_chunks, max_iter = 20)
-    ModelPredictProbs!(psms[!,:prob], psms[!,features], β, data_chunks)
+    if M > 10
+        tasks_per_thread = 10
+        chunk_size = max(1, M ÷ (tasks_per_thread * Threads.nthreads()))
+        data_chunks = partition(1:M, chunk_size) # partition your data into chunks that
+        β = zeros(Float64, length(features))
+        β = ProbitRegression(β, psms[!,features], psms[!,:target], data_chunks, max_iter = 20)
+        ModelPredictProbs!(psms[!,:prob], psms[!,features], β, data_chunks)
+    else
+        psms[!,:prob] = ones(Float32, size(psms, 1))
+    end
 end
 
 

--- a/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/QuadTuningSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/QuadTuningSearch.jl
@@ -232,7 +232,8 @@ function process_file!(
         # Collect and process PSMs
         total_psms = collect_psms(spectra, search_context, results, params, ms_file_idx)
         
-        if nrow(total_psms) == 0
+        if nrow(total_psms) < 1000
+            @warn "Too few psms found for quad modeling. Using default model."
             setQuadModel(results, GeneralGaussModel(5.0f0, 0.0f0))
             return results
         end

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
@@ -167,24 +167,36 @@ function score_precursor_isotope_traces_in_memory!(
                                 print_importance = false);
         return models;#best_psms
     else
-        @warn "Less than 100,000 psms. Training with simplified target-decoy discrimination model..."
+        if size(best_psms, 1) > 1000
+            @warn "Less than 100,000 psms. Training with simplified target-decoy discrimination model..."
+            features = [ 
+                :missed_cleavage,
+                :Mox,
+                :sequence_length,
+                :charge,
+                :irt_error,
+                :irt_diff,
+                :y_count,
+                :max_fitted_manhattan_distance,
+                :max_matched_residual,
+                :max_unmatched_residual,
+                :max_gof,
+                :err_norm,
+                :weight,
+                :log2_intensity_explained,
+            ];
+        else
+             @warn "Less than 1,000 psms. Training with super simplified target-decoy discrimination model..."
+             features = [ 
+                :fitted_spectral_contrast,
+                :max_matched_residual,
+                :max_unmatched_residual,
+                :err_norm,
+                :log2_intensity_explained,
+            ];
+        end
         file_paths = [fpath for fpath in file_paths if endswith(fpath,".arrow")]
-        features = [ 
-            :missed_cleavage,
-            :Mox,
-            :sequence_length,
-            :charge,
-            :irt_error,
-            :irt_diff,
-            :y_count,
-            :max_fitted_manhattan_distance,
-            :max_matched_residual,
-            :max_unmatched_residual,
-            :max_gof,
-            :err_norm,
-            :weight,
-            :log2_intensity_explained,
-        ];
+        
         best_psms[!,:accession_numbers] = [getAccessionNumbers(precursors)[pid] for pid in best_psms[!,:precursor_idx]]
         best_psms[!,:q_value] = zeros(Float32, size(best_psms, 1));
         best_psms[!,:decoy] = best_psms[!,:target].==false;
@@ -204,7 +216,7 @@ function score_precursor_isotope_traces_in_memory!(
                                 eta = 0.01, 
                                 iter_scheme = [200],
                                 print_importance = false);
-        return models;#best_psms
+        return models
     end
 end
 


### PR DESCRIPTION
This seems to work well for a couple BSA runs, searched together or individually. Identified 30-40 precursors for BSA, and it was the only protein that passed the 1% FDR.

Essentially it's a few checks for small psm sizes, and defaulting to simpler models or constant values.

Quad fitting needs at least 1000 psms (arbitrary)
Probit regression needs at least 10 psms (defaults to probability 1.0, assuming accurate probabilities will be computed later)
Super simple XGBoost if <1000 psms. I picked the features with the assumption that the RT fit will be bad and there's minimal interference.

And unrelated: for the QC plots if the files have very different names then the filenames in the plots take up all the space. Added a function to trim them from the center and have a maximum length of 20 when plotting. "my_super_long_file_name_rep12345" -> "my_super...rep12345"