### PR TITLE
Parameter filepath checks and RTindex out of bounds

### DIFF
--- a/src/Routines/BuildSpecLib/utils/check_params.jl
+++ b/src/Routines/BuildSpecLib/utils/check_params.jl
@@ -86,6 +86,13 @@ function check_params_bsp(json_string::String)
         check_param(group, "label_name", String)
     end
 
+    # expand any home directories "~"
+    params["out_dir"] = expanduser(params["out_dir"])
+    params["library_params"]["calibration_raw_file"] = expanduser( params["library_params"]["calibration_raw_file"])
+    for i in range(1,length(params["fasta_paths"]))
+        params["fasta_paths"][i] = expanduser(params["fasta_paths"][i])
+    end
+
     # If all checks pass, return the validated parameters
     return params
 end
@@ -182,6 +189,10 @@ function checkParseSpecLibParams(json_path::String)
             check_param(group, "sulfur_count", Number)
         end
     end
+
+    # expand any home directories "~"
+    params["library_params"]["input_lib_path"] = expanduser(params["library_params"]["input_lib_path"])
+    params["library_params"]["output_lib_path"] = expanduser(params["library_params"]["input_lib_path"])
     
     return params
 end

--- a/src/Routines/GenerateParams.jl
+++ b/src/Routines/GenerateParams.jl
@@ -31,12 +31,15 @@ function GetSearchParams(lib_path::String, ms_data_path::String, results_path::S
     
     if ismissing(params_path)
         output_path = joinpath(pwd(), "search_parameters.json")
-    elseif isdir(params_path)
-        output_path = joinpath(params_path, "search_parameters.json")
-    elseif isfile(params_path)
-        output_path = params_path
     else
-        throw("User supplied `params_path` is not a path to a file or a directory")
+        params_path = expanduser(params_path)
+        name, ext = splitext(params_path)
+        if isempty(ext)
+            mkpath(params_path)
+            output_path = joinpath(params_path, "search_parameters.json")
+        else
+            output_path = params_path
+        end
     end
     
     # Read the JSON template and convert to OrderedDict
@@ -85,13 +88,16 @@ function GetBuildLibParams(out_dir::String, lib_name::String, fasta_dir::String;
     GC.gc()
 
     if ismissing(params_path)
-        output_path = pwd()
-    elseif isdir(params_path)
-        output_path = joinpath(params_path)
-    elseif isfile(params_path)
-        output_path = params_path
+        output_path = joinpath(pwd(), "buildspeclib_params.json")
     else
-        throw("User supplied `params_path` is not a path to a file or a directory")
+        params_path = expanduser(params_path)
+        name, ext = splitext(params_path)
+        if isempty(ext)
+            mkpath(params_path)
+            output_path = joinpath(params_path, "buildspeclib_params.json")
+        else
+            output_path = params_path
+        end
     end
 
     # Parse JSON
@@ -119,7 +125,6 @@ function GetBuildLibParams(out_dir::String, lib_name::String, fasta_dir::String;
     config["out_name"] = basename(lib_name) * ".tsv"
     
     # Write output using the same formatting as template
-    output_path = joinpath(output_path, "buildspeclib_params.json")
     @info "Writing default parameters .json to: $output_path"
     open(output_path, "w") do io
         JSON.print(io, config, 4)  # indent with 4 spaces for readability

--- a/src/Routines/SearchDIA/LibrarySearch.jl
+++ b/src/Routines/SearchDIA/LibrarySearch.jl
@@ -31,7 +31,6 @@ function searchFragmentIndex(
         while rt_bin_idx > 1 && getLow(getRTBin(frag_index, rt_bin_idx)) > irt_lo
             rt_bin_idx -= 1
         end
-        rt_bin_idx = min(rt_bin_idx, length(getRTBins(frag_index)))
         
         # Fragment index search for matching precursors
         searchScan!(

--- a/src/Routines/SearchDIA/LibrarySearch.jl
+++ b/src/Routines/SearchDIA/LibrarySearch.jl
@@ -25,7 +25,7 @@ function searchFragmentIndex(
 
         # Update RT bin index based on iRT window
         irt_lo, irt_hi = getRTWindow(rt_to_irt_spline(getRetentionTime(spectra, scan_idx)), irt_tol)
-        while rt_bin_idx <= length(getRTBins(frag_index)) && getHigh(getRTBin(frag_index, rt_bin_idx)) < irt_lo
+        while rt_bin_idx < length(getRTBins(frag_index)) && getHigh(getRTBin(frag_index, rt_bin_idx)) < irt_lo
             rt_bin_idx += 1
         end
         while rt_bin_idx > 1 && getLow(getRTBin(frag_index, rt_bin_idx)) > irt_lo

--- a/src/Routines/SearchDIA/ParseInputs/parseParams.jl
+++ b/src/Routines/SearchDIA/ParseInputs/parseParams.jl
@@ -45,6 +45,13 @@ function parse_pioneer_parameters(json_path::String)
         return NamedTuple(symbol_pairs)
     end
 
+    function expand_user_paths(nt::NamedTuple)
+        vals_expanded = map(nt) do val
+            expanduser(val)
+        end
+        return vals_expanded
+    end
+
     # Parse each section
     global_settings = dict_to_namedtuple(params["global"])
     parameter_tuning = dict_to_namedtuple(params["parameter_tuning"])
@@ -55,7 +62,7 @@ function parse_pioneer_parameters(json_path::String)
     optimization = dict_to_namedtuple(params["optimization"])
     maxLFQ = dict_to_namedtuple(params["maxLFQ"])
     output = dict_to_namedtuple(params["output"])
-    paths = dict_to_namedtuple(params["paths"])
+    paths = expand_user_paths(dict_to_namedtuple(params["paths"]))
 
     return PioneerParameters(
         global_settings,

--- a/src/Routines/mzmlConverter/convertMzML.jl
+++ b/src/Routines/mzmlConverter/convertMzML.jl
@@ -289,6 +289,7 @@ function convertMzML(
 
     # Clean up any old file handlers in case the program crashed
     GC.gc()
+    mzml_dir = expanduser(mzml_dir)
 
     mzml_paths = missing
     if isdir(mzml_dir)


### PR DESCRIPTION
Allows ~ to be used in paths. Just need to call expanduser on every input path. Doesn't change anything if there isn't a ~ in the string.

Changed the checking of paths in GenerateParams. Specifying a file for the output json didn't work unless the file already existed. Now it will check if the path has an extension, if yes then that's the path to output to, if not then assume it's a directory and append the default filename to it.

Also fixed a bug in LibrarySearch where searching for an RTindex could go out of bounds. First time it ever happened to me. It was with a BSA file.