### PR TITLE
Quad fitting of extreme cases

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/utils.jl
@@ -637,7 +637,7 @@ function perform_quad_transmission_search(
                 weight = weights[colid],
                 iso_idx = isotope_idx,
                 center_mz = center_mz,
-                n_matches = n_matches,
+                n_matches = n_matches
             ))
         end
         #Arrow.write("/Users/n.t.wamsley/Desktop/test.arrow", DataFrame(tuning_results))

--- a/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/utils.jl
@@ -638,7 +638,6 @@ function perform_quad_transmission_search(
                 iso_idx = isotope_idx,
                 center_mz = center_mz,
                 n_matches = n_matches,
-               # isolation_width = isolation_width
             ))
         end
         #Arrow.write("/Users/n.t.wamsley/Desktop/test.arrow", DataFrame(tuning_results))


### PR DESCRIPTION
Assumes a log2 ratio of 10 or -10 if we observed only the M0 or M1 isotope. Has a tiny effect on most runs, usually a little bit better. But helps fit extremely boxy (wide) or extremely narrow isolation windows.