### PR TITLE
Chroma integration

### DIFF
--- a/data/ecoli_test/ecoli_test_params.json
+++ b/data/ecoli_test/ecoli_test_params.json
@@ -75,8 +75,8 @@
             "n_isotopes": 2
         },
         "chromatogram": {
-            "smoothing_strength": 0.0002,
-            "padding": 20,
+            "smoothing_strength": 1e-6,
+            "padding": 0,
             "max_apex_offset": 2
         }
     },

--- a/data/example_config/LibrarySearch.json
+++ b/data/example_config/LibrarySearch.json
@@ -63,8 +63,8 @@
             "n_isotopes": 2
         },
         "chromatogram": {
-            "smoothing_strength": 0.0002,
-            "padding": 20,
+            "smoothing_strength": 1e-6,
+            "padding": 0,
             "max_apex_offset": 2
         }
     },

--- a/data/example_config/defaultSearchParams.json
+++ b/data/example_config/defaultSearchParams.json
@@ -77,8 +77,8 @@
             "n_isotopes": 2
         },
         "chromatogram": {
-            "smoothing_strength": 0.0002,
-            "padding": 20,
+            "smoothing_strength": 1e-6,
+            "padding": 0,
             "max_apex_offset": 2
         }
     },

--- a/data/param_test/search.json
+++ b/data/param_test/search.json
@@ -91,8 +91,8 @@
             "n_isotopes": 2
         },
         "chromatogram": {
-            "smoothing_strength": 0.0002,
-            "padding": 20,
+            "smoothing_strength": 1e-6,
+            "padding": 0,
             "max_apex_offset": 2
         }
     },

--- a/docs/src/user_guide/parameters.md
+++ b/docs/src/user_guide/parameters.md
@@ -95,8 +95,8 @@ Most parameters should not be changed, but the following may need adjustement.
 | `fragment_settings.min_log2_ratio` | Float | Minimum log2 ratio of intensities (default: -1.7) |
 | `fragment_settings.min_top_n` | [Int, Int] | Minimum top N matches - [requirement, denominator]. Default: `[2, 3]` |
 | `fragment_settings.n_isotopes` | Int | Number of isotopes for quantification (default: 2, include the M1 and M2 isotopes) |
-| `chromatogram.smoothing_strength` | Float | Strength of chromatogram smoothing (default: 0.0002) |
-| `chromatogram.padding` | Int | Number of zeros to pad chromatograms on either side (default: 20) |
+| `chromatogram.smoothing_strength` | Float | Strength of chromatogram smoothing (default: 1e-6) |
+| `chromatogram.padding` | Int | Number of zeros to pad chromatograms on either side (default: 0) |
 | `chromatogram.max_apex_offset` | Int | Maximum allowed apex offset in #scans where the precursor could have been detected between the second-pass search and re-integration with 1 percent FDR precursors (default: 2) |
 
 ### Acquisition Parameters

--- a/src/Routines/SearchDIA/PSMs/UnscoredPSMs.jl
+++ b/src/Routines/SearchDIA/PSMs/UnscoredPSMs.jl
@@ -217,7 +217,7 @@ function ModifyFeatures!(score::Ms1UnscoredPSM{T},  prec_id::UInt32, match::Prec
     precursor_idx = getPrecID(match)
     if getIsoIdx(match)==one(UInt8)#Is the m0
         m0 = true
-        m0_error = ppm_err
+        m0_error = abs(ppm_err)
     end
 
     return Ms1UnscoredPSM{T}(

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/integrate_chrom.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/integrate_chrom.jl
@@ -65,6 +65,7 @@ function integrate_chrom(chrom::SubDataFrame{DataFrame, DataFrames.Index, Vector
                                 b::Vector{Float32},
                                 u2::Vector{Float32},
                                 state::Chromatogram,
+                                avg_cycle_time::Float32,
                                 λ::Float32;
                                 max_apex_offset = 2,
                                 n_pad::Int64 = 0,
@@ -74,10 +75,12 @@ function integrate_chrom(chrom::SubDataFrame{DataFrame, DataFrames.Index, Vector
     #Helper Functions  
     #########
     function WHSmooth!( b::Vector{Float32}, 
-                        intensities::AbstractVector{Float32},
-                        n_pad::Int64)
+                        chrom::SubDataFrame{DataFrame, DataFrames.Index, Vector{Int64}},
+                        n_pad::Int64,
+                        λ::Float32)
         
         n = length(b)
+        m = size(chrom, 1)
 
         # Reset b and second derivative 
         @inbounds for i in range(1, n)
@@ -86,15 +89,15 @@ function integrate_chrom(chrom::SubDataFrame{DataFrame, DataFrames.Index, Vector
         end
        
         # Copy data to b
-        @inbounds for i in range(1, size(chrom, 1))
-            b[i+n_pad] = intensities[i]
+        @inbounds for i in range(1, m)
+            b[i+n_pad] = chrom[!, :intensity][i]
         end
 
         # Create weight matrix of precursor isolated percentage
         max_isolation = maximum(chrom[!, :precursor_fraction_transmitted])
         
         w = max_isolation*ones(Float32, n)
-        @inbounds for i in range(1, size(chrom, 1))
+        @inbounds for i in range(1, m)
             w[i+n_pad] = chrom[!, :precursor_fraction_transmitted][i]
         end
         
@@ -102,7 +105,7 @@ function integrate_chrom(chrom::SubDataFrame{DataFrame, DataFrames.Index, Vector
         rts = chrom[!, :rt]
         start_rt = rts[1]
         last_rt = rts[end]
-        default_spacing = size(chrom, 1) < 2 ? 1.0f0 : rts[2] - start_rt
+        default_spacing = m < 2 ? 1.0f0 : rts[2] - start_rt
 
         # Fill RT differences
         x = zeros(Float32, n)
@@ -112,98 +115,137 @@ function integrate_chrom(chrom::SubDataFrame{DataFrame, DataFrames.Index, Vector
             x[i] = start_rt - (default_spacing * ((n_pad - i) + 1))
         end
         # real values
-        for i in range(1, size(chrom, 1)-1 )
+        for i in range(1, m)
             x[i + n_pad] = rts[i]
         end
         # right padding
-        for i in range(n_pad + size(chrom, 1), n-1)
-            x[i] = last_rt + (default_spacing * (i - (n_pad + size(chrom, 1))))
+        for i in range(n_pad+m+1, n)
+            x[i] = last_rt + (default_spacing * (i - (n_pad + m)))
         end
 
         # normalize by RT width so the same smoothing parameter is about optimal for all cases
         rt_width = last_rt-start_rt
         x = x / rt_width
 
-        # solve
-        z = whitsmddw(x, b, w, λ)
+        if m <= 1
+            return b, x
+        end
 
-        return z
+        active_length = m + (2*n_pad)
+        z = whitsmddw(x, b, w, active_length, λ)
+
+        return z, x
     end
 
     function fillU2!(
         u2::Vector{Float32},
-        u::Vector{Float32})
-        #Get second-order descrete derivative 
-        u2[1], u2[end] = zero(Float32), zero(Float32)
-        @inbounds @fastmath for i in range(2, length(b) - 1)
-            u2[i] = u[i + 1] - 2*u[i] + u[i - 1]
+        u::Vector{Float32},
+        t::Vector{Float32}  # time points corresponding to u
+    )
+        u2[1], u2[end] = 0.0f0, 0.0f0
+        @inbounds @fastmath for i in 2:(length(u) - 1)
+            dt1 = t[i] - t[i - 1]
+            dt2 = t[i + 1] - t[i]
+            dt_total = t[i + 1] - t[i - 1]
+            a = (u[i + 1] - u[i]) / dt2
+            b = (u[i] - u[i - 1]) / dt1
+            u2[i] = 2f0 / dt_total * (a - b)
         end
     end
 
     function getApexScan(
         apex_scan::Int64,
-        max_offset::Int64,
+        n_pad::Int64,
         intensities::AbstractVector{<:AbstractFloat})
+
         N = length(intensities)
         max_intensity = zero(Float32)
-        for i in range(max(1, apex_scan - max_offset), min(N, apex_scan+max_offset))
+        apex_scan += n_pad
+        #for i in range(n_pad+1, length(intensities))
+        for i in range(max(1, apex_scan - 2), min(N, apex_scan+2))
             if intensities[i] > max_intensity#intensities[apex_scan]
                 apex_scan = i
                 max_intensity = intensities[i]
             end
         end
-        return apex_scan 
+        return apex_scan - n_pad
     end
 
+    """
+    getIntegrationBounds!(u2, u, N, apex_scan, n_pad) -> UnitRange
+
+    Find the start/stop scan indices of a chromatographic peak whose apex
+    (in the *unpadded* region) is at `apex_scan`.
+
+    * `u2` - second-derivative-like array (length = n_pad + N + n_pad)
+    * `u`  - intensity array (same length as `u2`)
+    * `N`  - length of the **central** window (without padding)
+    * `apex_scan` - 1-based apex position inside the central window
+    * `n_pad` - number of padded samples on each side
+
+    Returns a `UnitRange{Int}` with indices **in the un-padded domain** (`1:N`).
+    """
     function getIntegrationBounds!(u2::Vector{Float32},
-                                   u::Vector{Float32},
-                                   N::Int64,
-                                   apex_scan::Int64,
-                                   n_pad::Int64)
-        max_stop = N
-        start_search, stop_search = apex_scan + n_pad - 1, apex_scan + n_pad + 1
-        start, stop = start_search, stop_search
-        N += n_pad
+                                u::Vector{Float32},
+                                N::Int,
+                                apex_scan::Int,
+                                n_pad::Int)::UnitRange{Int}
 
-        #get RH boundary
-        @inbounds @fastmath begin 
+        # indices in the *padded* coordinate system
+        pad_start   = n_pad + 1                   # first index of the real window
+        pad_end     = n_pad + N
+        apex_padded = n_pad + apex_scan           # apex index in padded coords
+        
+        #return pad_start:pad_end
 
-            for i in range(stop_search, N-1)
-                if (u2[i-1] < u2[i]) & (u2[i+1]<u2[i])
-                    stop = i
-                    break
-                end
-            end
+        # initialise search bounds
+        start = apex_padded - 1
+        stop  = apex_padded + 1
 
-            for i in range(stop, N-1)
-                if u[i + 1] >= u[i]
-                    break
-                else
-                    stop = i
-                end
-            end
-
-            #get LH boundary 
-            for i in reverse(range(2, start_search))
-                if (u2[i] > u2[i - 1]) & (u2[i+1]<u2[i])
-                    start = i
-                    break
-                end
-            end
-
-            for i in reverse(range(2, start))
-                if u[i - 1] >= u[i]
-                    break
-                else
-                    start = i
-                end
+        # ──────────────── search to the right (RH boundary) ────────────────
+        # 1. advance to first local maximum of u2  (peak of d²/dt² < 0)
+        @inbounds @fastmath for i in stop:pad_end-1
+            if (u2[i-1] < u2[i]) && (u2[i+1] < u2[i])
+                stop = i
+                break
             end
         end
-        return range(max(start-n_pad, 1), min(stop-n_pad,  max_stop))#range(max(start-n_pad, 1), max(stop-n_pad, 1))#range( min(best_scan-3, start), max(stop,best_scan+3))
+        # 2. keep going while the intensity still decreases
+        @inbounds @fastmath for i in stop:pad_end-1
+            if u[i+1] >= u[i]
+                break
+            else
+                stop = i+1
+            end
+        end
+
+        # ──────────────── search to the left  (LH boundary) ────────────────
+        # 1. first local maximum of u2 when scanning left
+        @inbounds @fastmath for i in reverse(pad_start+1:start)
+            if (u2[i] > u2[i-1]) && (u2[i+1] < u2[i])
+                start = i
+                break
+            end
+        end
+        # 2. keep going left while intensity decreases
+        @inbounds @fastmath for i in reverse(pad_start+1:start)
+            if u[i-1] >= u[i]
+                break
+            else
+                start = i-1
+            end
+        end
+
+        # convert from padded indices back to 1…N
+        start_mid = max(start - n_pad, 1)
+        stop_mid  = min(stop  - n_pad, N)
+
+        return start_mid:stop_mid
     end
 
+
     function fillState!(state::Chromatogram,
-                        u::Vector{Float32},
+                        u::AbstractVector{Float32},
                         rt::AbstractVector{Float32},
                         start::Int64, 
                         stop::Int64,
@@ -232,70 +274,105 @@ function integrate_chrom(chrom::SubDataFrame{DataFrame, DataFrames.Index, Vector
         return norm_factor, start_rt, rt_width, best_rt
     end
 
-    #Baseline subtraction?
     function subtractBaseline!(
-        u::Vector{Float32}, #smoothed data
-        apex_scan::Int64, #peak apex
-        scan_range::UnitRange{Int64},
-        n_pad::Int64) #start and stop of integration bounds 
-        
-        apex_scan  = apex_scan + n_pad
-        scan_range = (first(scan_range) + n_pad, last(scan_range) + n_pad)
-        #Fine LH baseline 
-        lmin,li = typemax(Float32),first(scan_range)
-        @inbounds @fastmath for i in range(first(scan_range), apex_scan)
+        x::Vector{Float32},  # time (or x-axis values)
+        u::Vector{Float32},  # smoothed signal values
+        apex_scan::Int,      # peak apex index
+        scan_range::UnitRange{Int},
+        n_pad::Int
+    )
+        # Apply pad offset
+        apex_idx  = apex_scan + n_pad
+        scan_start = first(scan_range) + n_pad
+        scan_stop  = last(scan_range) + n_pad
+    
+        # Find left baseline: minimum value between scan_start and apex_idx
+        lmin, li = typemax(Float32), scan_start
+        @inbounds @fastmath for i in scan_start:apex_idx
             if u[i] < lmin
                 lmin = u[i]
                 li = i
             end
         end
-
-        #Find RH baseline 
-        rmin,ri = typemax(Float32),last(scan_range)
-        @inbounds @fastmath for i in range(apex_scan, last(scan_range))
+    
+        # Find right baseline: minimum value between apex_idx and scan_stop
+        rmin, ri = typemax(Float32), scan_stop
+        @inbounds @fastmath for i in apex_idx:scan_stop
             if u[i] < rmin
                 rmin = u[i]
                 ri = i
             end
         end
-
-        #Subtract the baseline 
-        
-        h = (rmin - lmin)/(ri - li)
-        @inbounds @fastmath for i in scan_range
-            u[i] = u[i]-(lmin + (i - li)*h)
+    
+        # Handle special case where li == apex_idx or ri == apex_idx
+        if li == apex_idx
+            lmin = rmin
+        end
+        if ri == apex_idx
+            rmin = lmin
         end
 
+        # Calculate slope based on actual x values, not index distance
+        x_left = x[li]
+        x_right = x[ri]
+        dx = x_right - x_left
+        if dx == 0
+            return nothing
+        end
+
+        slope = (rmin - lmin) / dx
+    
+        # Subtract interpolated baseline
+        @inbounds @fastmath for i in scan_start:scan_stop
+            xi = x[i]
+            baseline = lmin + (xi - x_left) * slope
+            u[i] -= baseline
+        end
+    
+        return nothing
     end
 
-    function integrateTrapezoidal(state::Chromatogram)
-        retval = state.data[2]
-        #Assumption that state.max_index is at least 4. 
-        for i in range(3, state.max_index - 1)
-            @inbounds retval = (state.t[2] - state.t[1])*(state.data[1] + state.data[2])
-            @inbounds @fastmath for i in 2:(state.max_index - 1)
-                retval += (state.t[i + 1] - state.t[i])*(state.data[i] + state.data[i + 1])
+
+    function integrateTrapezoidal(state::Chromatogram, avg_cycle_time::Float32)
+        if state.max_index == 1
+            # Special case: 1 point only, treat like a triangle on each side
+            height = state.data[1]
+            return avg_cycle_time * height
+        elseif state.max_index >= 2
+            retval = 0.0f0
+            retval += avg_cycle_time * (state.data[1] + state.data[state.max_index]) # triangle area on each side
+            @inbounds @fastmath for i in 1:(state.max_index - 1)
+                dt = state.t[i + 1] - state.t[i]
+                retval += dt * (state.data[i] + state.data[i + 1])
             end
+            return 0.5f0 * retval
+        else
+            # No points, no area
+            return 0.0f0
         end
-        return (1//2)*retval
     end
+
     #Whittaker Henderson Smoothing
-    z = WHSmooth!(
+    z, x = WHSmooth!(
         b,
-        chrom[!,:intensity],
-        n_pad
+        chrom,
+        n_pad,
+        λ
     )
+
     #Second discrete derivative of smoothed data
     fillU2!(
         u2,
         z,
+        x
     )
     
     apex_scan = getApexScan(
         apex_scan,
-        max_apex_offset,
-        chrom[!,:intensity]
+        n_pad,
+        z
     )
+
     #Integration boundaries based on smoothed second derivative 
     scan_range = getIntegrationBounds!(
         u2,
@@ -306,6 +383,7 @@ function integrate_chrom(chrom::SubDataFrame{DataFrame, DataFrames.Index, Vector
     )
 
     subtractBaseline!(
+        x,
         z,
         apex_scan,
         scan_range,
@@ -324,19 +402,21 @@ function integrate_chrom(chrom::SubDataFrame{DataFrame, DataFrames.Index, Vector
     )
     
     if isplot
+    #if chrom.precursor_idx[1] == 4910216
         mi = state.max_index
         start = max(apex_scan - 18, 1)
         stop = min(apex_scan + 18, length(chrom.rt))
         plot(chrom.rt[start:stop], chrom.intensity[start:stop], seriestype=:scatter, alpha = 0.5, show = true, label = "raw")
         vline!([chrom.rt[first(scan_range)], chrom.rt[last(scan_range)]], label = nothing)
-        plot!(state.t[1:mi].*rt_norm .+ start_rt, norm_factor.*state.data[1:mi], seriestype=:scatter, alpha = 0.5, show = true, label = "smooth")
+        plot!(state.t[1:mi].*rt_norm .+ start_rt, norm_factor.*state.data[1:mi], seriestype=:scatter, alpha = 1.0, show = true, label = "smooth", color = "purple")
+        #savefig("/Users/dennisgoldfarb/Downloads/" * string(chrom.precursor_idx[1]) * " " * string(chrom.intensity[1]) * ".png")
         #xbins = LinRange(state.t[1]-0.5, state.t[state.max_index]+0.5, 100)
         #plot!(xbins.*rt_norm .+ start_rt, [norm_factor*F(state, x) for x in xbins])
         #plot!(chrom.rt[start:stop], u2[start+n_pad:stop+n_pad])
         #hline!([norm_factor*0.95])
     end
 
-    trapezoid_area = rt_norm*norm_factor*integrateTrapezoidal(state)
+    trapezoid_area = rt_norm * norm_factor * integrateTrapezoidal(state, avg_cycle_time)
 
     #trapezoid_area = 0.0f0
     return trapezoid_area, chrom[!,:scan_idx][apex_scan]

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
@@ -78,6 +78,7 @@ function integrate_precursors(chromatograms::DataFrame,
                 end
 
                 sort!(chrom, :rt, alg = QuickSort)
+                avg_cycle_time = (chrom.rt[end] - chrom.rt[1]) /  length(chrom.rt)
                 first_pos = findfirst(x->x>0.0, chrom[!,:intensity]) # start from first positive weight
                 last_pos = findlast(x->x>0.0, chrom[!,:intensity]) # end at last positive weight
                 isnothing(first_pos) ? continue : nothing
@@ -100,22 +101,21 @@ function integrate_precursors(chromatograms::DataFrame,
                         end
                     end
                     apex_scan = nearest_idx#argmax(chrom[!,:intensity])
-                    #apex_scan = nearest_idx  # Use the index of the nearest scan
                 end
+
                 peak_area[i], new_best_scan[i] = integrate_chrom(
                                 chrom,
                                 apex_scan,
                                 b,
                                 u2,
                                 state,
+                                avg_cycle_time,
                                 λ,
                                 n_pad = n_pad,
                                 max_apex_offset = max_apex_offset,
                                 isplot = false
                                 );
-                #if test_print
-                #    println(" i $i")
-                #end
+
                 reset!(state)
             end
             return #chromdf

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -346,7 +346,7 @@ function process_scans!(
         ion_idx = 0
         for rt_bin_idx in irt_start:irt_stop
             precs = rt_index.rt_bins[rt_bin_idx].prec
-            for i in 1:length(precs)
+            for i in eachindex(precs)
                 prec_idx = first(precs[i])
                 if prec_idx in precursors_passing
                     prec_temp_size += 1
@@ -356,6 +356,9 @@ function process_scans!(
                     precs_temp[prec_temp_size] = prec_idx
                     for iso in isotopes_dict[prec_idx]
                         ion_idx += 1
+                        if ion_idx > length(ion_templates)
+                            append!(ion_templates, Vector{Isotope{Float32}}(undef, 10000))
+                        end
                         ion_templates[ion_idx] = iso
                     end
                 end


### PR DESCRIPTION
Sped up smoothing by only using the active length of the vectors when doing matrix algebra. 
Updated smoothing default params: less smoothing gives excellent fold-changes, lower CVs but on par with other tools.
Use RTs for second derivatives used in integration bounds. 
Cleaned up trapezoid integration.

abs(ppm error) for MS1 M0 feature.
Increased size of ion templates if needed. Hit the limit on Astral data.