### PR TITLE
Percolator OOM fixes

### DIFF
--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -384,6 +384,7 @@ function print_performance_report(timings, println_func; kwargs...)
     println_func(repeat("-", 90))
 
     # Calculate totals
+    peak_memory = peak_rss()
     total_time = 0.0
     total_memory = 0
     total_gc = 0.0
@@ -420,7 +421,6 @@ function print_performance_report(timings, println_func; kwargs...)
     println_func("\nPerformance Summary:")
     println_func(repeat("-", 90))
     println_func("Total Runtime: $(round(total_time/60, digits=2)) minutes")
-    println_func("Peak Memory Usage: $(round(total_memory/1024^3, digits=2)) GB")
     println_func("Total Garbage Collection Time: $(round(total_gc, digits=2)) seconds")
     println_func("Number of Steps: $(length(timings))")
     println_func("Average Step Runtime: $(round(total_time/length(timings), digits=2)) seconds")
@@ -430,6 +430,7 @@ function print_performance_report(timings, println_func; kwargs...)
     println_func(repeat("-", 90))
     current_mem = Sys.total_memory() / 1024^3
     println_func("Total Memory Allocated: $(round(total_memory/1024^3, digits=2)) GB")
+    println_func("Peak  Memory Usage: $(round(peak_memory/1024^3, digits=2)) GB")
     println_func("Total Available System Memory: $(round(current_mem, digits=2)) GB")
     println_func("Peak Memory Usage: $(round(maximum([t.bytes for t in values(timings)])/1024^3, digits=2)) GB")
     

--- a/src/Routines/BuildSpecLib/importScripts.jl
+++ b/src/Routines/BuildSpecLib/importScripts.jl
@@ -46,4 +46,6 @@ function importScripts()
     include(joinpath(root_path, "chronologer", "chronologer_prep.jl"))
     include(joinpath(root_path, "chronologer", "chronologer_predict.jl"))
     include(joinpath(root_path, "chronologer", "chronologer_parse.jl"))
+    # Profiling
+    include(joinpath(package_root, "src", "utils", "profile.jl"))
 end

--- a/src/Routines/SearchDIA.jl
+++ b/src/Routines/SearchDIA.jl
@@ -199,6 +199,7 @@ function print_performance_report(timings, ms_table_paths, search_context, print
     println_func(repeat("-", 90))
 
     # Calculate totals
+    peak_memory = peak_rss()
     total_time = 0.0
     total_memory = 0
     total_gc = 0.0
@@ -225,7 +226,7 @@ function print_performance_report(timings, ms_table_paths, search_context, print
 
     # Print summary statistics
     print_summary_statistics(
-        total_time, total_memory, total_gc,
+        total_time, total_memory, peak_memory, total_gc,
         length(timings), length(ms_table_paths),
         println_func, search_context
     )
@@ -234,7 +235,7 @@ end
 """
 Helper function to print summary statistics
 """
-function print_summary_statistics(total_time, total_memory, total_gc, 
+function print_summary_statistics(total_time, total_memory, peak_memory, total_gc, 
                                 n_steps, n_files, println_func, search_context)
     # Print totals
     println_func(repeat("-", 90))
@@ -249,6 +250,7 @@ function print_summary_statistics(total_time, total_memory, total_gc,
     println_func(repeat("-", 90))
     current_mem = Sys.total_memory() / 1024^3
     println_func("Total Memory Allocated: $(round(total_memory/1024^3, digits=2)) GB")
+    println_func("Peak  Memory Allocated: $(round(peak_memory/1024^3, digits=2)) GB")
     println_func("Total Available Memory: $(round(current_mem, digits=2)) GB")
     
     # Runtime summary

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/integrate_chrom.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/integrate_chrom.jl
@@ -326,7 +326,7 @@ function integrate_chrom(chrom::SubDataFrame{DataFrame, DataFrames.Index, Vector
         @inbounds @fastmath for i in scan_start:scan_stop
             xi = x[i]
             baseline = lmin + (xi - x_left) * slope
-            u[i] -= baseline
+            u[i] = max(0, u[i] - baseline)
         end
     
         return nothing
@@ -402,7 +402,7 @@ function integrate_chrom(chrom::SubDataFrame{DataFrame, DataFrames.Index, Vector
     )
     
     if isplot
-    #if chrom.precursor_idx[1] == 4910216
+    #if chrom.precursor_idx[1] == 2098
         mi = state.max_index
         start = max(apex_scan - 18, 1)
         stop = min(apex_scan + 18, length(chrom.rt))

--- a/src/Routines/SearchDIA/importScripts.jl
+++ b/src/Routines/SearchDIA/importScripts.jl
@@ -82,7 +82,8 @@ function importScripts()
             "isotopeSplines.jl",
             "maxLFQ.jl",
                         "writeArrow.jl",
-            "proteinInference.jl"
+            "proteinInference.jl",
+            "profile.jl"
         ]
     )
 

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -14,34 +14,7 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
                   iter_scheme::Vector{Int} = [100, 100, 200],
                   print_importance::Bool = true)
     
-    function summarize_precursors!(psms::SubDataFrame)
-        # Collect the grouped pairs so we can iterate in a threaded for loop.
-        grouped_data = collect(pairs(groupby(psms, [:pair_id, :isotopes_captured])))
-
-        Threads.@threads for idx in eachindex(grouped_data)
-            key, sub_psms = grouped_data[idx]
-            
-            min_prob, max_prob, mean_prob = summarize_prob(sub_psms[!,:prob])
-            best_idx = argmax(sub_psms.prob)
-            best_log2_weights = log2.(sub_psms.weights[best_idx])
-            best_iRTs = sub_psms.irts[best_idx]
-
-            for i in 1:nrow(sub_psms)
-                best_log2_weights_padded, weights_padded = pad_equal_length(best_log2_weights, log2.(sub_psms.weights[i]))
-                best_iRTs_padded, iRTs_padded = pad_rt_equal_length(best_iRTs, sub_psms.irts[i])
-                        
-                best_irt_at_apex = sub_psms.irts[best_idx][argmax(best_log2_weights)]
-                sub_psms.best_irt_diff[i] = abs(best_irt_at_apex - sub_psms.irts[i][argmax(sub_psms.weights[i])])
-                sub_psms.rv_coefficient[i] = rv_coefficient(best_log2_weights_padded, best_iRTs_padded, weights_padded, iRTs_padded)
-                sub_psms.min_prob[i] = min_prob
-                sub_psms.max_prob[i] = max_prob
-                sub_psms.mean_prob[i] = mean_prob
-                sub_psms.is_best_decoy[i] = sub_psms.decoy[best_idx]
-                sub_psms.num_runs[i] = nrow(sub_psms)
-            end
-        end
-
-    end
+    
     # Helper functions for fold selection
     selectTestFold(cv_fold::UInt8, test_fold::UInt8)::Bool = cv_fold == test_fold
     excludeTestFold(cv_fold::UInt8, test_fold::UInt8)::Bool = cv_fold != test_fold
@@ -71,6 +44,8 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
         #Each round updates, max_prob, mean_prob, and min_prob, and uses these as training features in the next round 
         for (itr, num_round) in enumerate(iter_scheme)
             
+            
+
             psms_train_itr = get_training_data_for_iteration!(psms_train, 
                                                                 itr,
                                                                 match_between_runs, 
@@ -132,15 +107,6 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
     end
     return models
 end
-
-
-
-
-
-
-
-
-
 
 
 
@@ -260,12 +226,15 @@ function sort_of_percolator_out_of_memory!(psms::DataFrame,
                     psms_subset.best_irt_diff[i] = abs(best_irt_at_apex - psms_subset.irts[i][argmax(psms_subset.weights[i])])
                     psms_subset.rv_coefficient[i] = rv_coefficient(best_log2_weights_padded, best_iRTs_padded, weights_padded, iRTs_padded)
                     psms_subset.is_best_decoy[i] = is_best_decoy
-                    psms_subset.num_runs[i] = nrow(psms_subset)
+                    psms_subset.num_runs[i] = n
                 end
             end
 
             # update global prob
-            psms_subset.global_prob = zeros(Float32, size(psms_subset, 1))
+            if !("global_prob" in names(psms_subset))
+                psms_subset.global_prob = zeros(Float32, size(psms_subset, 1))
+            end
+
             for (i, precursor_idx) in enumerate(psms_subset[!,:precursor_idx])
                 if !test_fold_filter(psms_subset[i,:cv_fold], test_fold_idx)::Bool continue end
                 if haskey(prec_to_global_score, precursor_idx)
@@ -278,36 +247,8 @@ function sort_of_percolator_out_of_memory!(psms::DataFrame,
             else
                 Arrow.write(file_path, convert_subarrays(psms_subset))
             end
-            
         end
         return prec_to_best_score_new
-    end
-    
-    function getBestScorePerPrec!(
-        prec_to_best_score_new::Dictionary,
-        psms::DataFrame)
-        m = 0
-        for (i, pair_id) in enumerate(psms[!,:pair_id])
-            key = (pair_id = pair_id, isotopes = psms[i,:isotopes_captured])
-            if haskey(prec_to_best_score_new, key)
-                max_prob, mean_prob, min_prob, n, best_log2_weights, best_irts, is_best_decoy = prec_to_best_score_new[key]
-
-                best_log2_weights_padded, weights_padded = pad_equal_length(best_log2_weights, log2.(psms.weights[i]))
-                best_iRTs_padded, iRTs_padded = pad_rt_equal_length(best_irts, psms.irts[i])
-                best_irt_at_apex = best_irts[argmax(best_log2_weights)]
-
-                psms[i,:best_irt_diff] = abs(best_irt_at_apex - psms.irts[i][argmax(psms.weights[i])])
-                psms[i,:rv_coefficient] = rv_coefficient(best_log2_weights_padded, best_iRTs_padded, weights_padded, iRTs_padded)
-                psms[i,:max_prob] = max_prob
-                psms[i,:min_prob] = min_prob
-                psms[i,:mean_prob] = mean_prob/n
-                psms[i,:is_best_decoy] = is_best_decoy
-                psms[i,:num_runs] = n
-
-                m += 1
-                    
-            end
-        end
     end
                     
     function selectTestFold(cv_fold::UInt8, test_fold::UInt8)::Bool
@@ -318,24 +259,16 @@ function sort_of_percolator_out_of_memory!(psms::DataFrame,
         return cv_fold != test_fold
     end
 
-    folds = psms[!,:cv_fold]
-    unique_cv_folds = unique(folds)
+    unique_cv_folds = unique(psms[!, :cv_fold])
     #Train the model for 1:K-1 cross validation folds and apply to the held-out fold
     models = Dictionary{UInt8, Vector{Booster}}()
     pbar = ProgressBar(total=length(unique_cv_folds)*length(iter_scheme))
     Random.seed!(1776);
     for test_fold_idx in unique_cv_folds#(0, 1)#range(1, n_folds)
-        train_fold_idxs_all = findall(x->x!=test_fold_idx, folds)
-        psms_train = psms[train_fold_idxs_all,:]
-        prec_to_best_score = Dictionary{@NamedTuple{pair_id::UInt32,
-                                                    isotopes::Tuple{Int8,Int8}}, 
-                                        @NamedTuple{max_prob::Float32,
-                                                    mean_prob::Float32, 
-                                                    min_prob::Float32, 
-                                                    n::UInt16,
-                                                    best_log2_weights::Vector{Float32},
-                                                    best_irts::Vector{Float32},
-                                                    is_best_decoy::Bool}}()
+        #Clear prob stats 
+        clear_prob_and_group_features!(psms, match_between_runs)
+        # Get training data
+        psms_train = @view(psms[findall(x -> x != test_fold_idx, psms[!, :cv_fold]), :])
 
         for (itr, num_round) in enumerate(iter_scheme)
 
@@ -373,24 +306,14 @@ function sort_of_percolator_out_of_memory!(psms::DataFrame,
                 push!(models[test_fold_idx], bst)
             end
             bst.feature_names = [string(x) for x in features]
-            print_importance ? println(collect(zip(importance(bst)))[1:30]) : nothing
+            print_importance ? println(collect(zip(importance(bst)))) : nothing
 
-            #println(collect(zip(importance(bst)))[1:5])
-            prec_to_best_score = getBestScorePerPrec!(
-                prec_to_best_score,
-                excludeTestFold,
-                test_fold_idx,
-                file_paths,
-                bst,
-                features
-            )
-            getBestScorePerPrec!(
-                prec_to_best_score,
-                psms_train
-            )
-            
             # Get probabilities for training sample so we can get q-values
-            psms_train[!,:prob] =  XGBoost.predict(bst, psms_train[!, features])
+            psms_train[!,:prob] = XGBoost.predict(bst, psms_train[!, features])
+            
+            if match_between_runs
+                summarize_precursors!(psms_train)
+            end
 
             update(pbar)
         end
@@ -437,6 +360,35 @@ end
 
 
 
+
+function summarize_precursors!(psms::AbstractDataFrame)
+    # Collect the grouped pairs so we can iterate in a threaded for loop.
+    grouped_data = collect(pairs(groupby(psms, [:pair_id, :isotopes_captured])))
+
+    Threads.@threads for idx in eachindex(grouped_data)
+        key, sub_psms = grouped_data[idx]
+        
+        min_prob, max_prob, mean_prob = summarize_prob(sub_psms[!,:prob])
+        best_idx = argmax(sub_psms.prob)
+        best_log2_weights = log2.(sub_psms.weights[best_idx])
+        best_iRTs = sub_psms.irts[best_idx]
+
+        for i in 1:nrow(sub_psms)
+            best_log2_weights_padded, weights_padded = pad_equal_length(best_log2_weights, log2.(sub_psms.weights[i]))
+            best_iRTs_padded, iRTs_padded = pad_rt_equal_length(best_iRTs, sub_psms.irts[i])
+                    
+            best_irt_at_apex = sub_psms.irts[best_idx][argmax(best_log2_weights)]
+            sub_psms.best_irt_diff[i] = abs(best_irt_at_apex - sub_psms.irts[i][argmax(sub_psms.weights[i])])
+            sub_psms.rv_coefficient[i] = rv_coefficient(best_log2_weights_padded, best_iRTs_padded, weights_padded, iRTs_padded)
+            sub_psms.min_prob[i] = min_prob
+            sub_psms.max_prob[i] = max_prob
+            sub_psms.mean_prob[i] = mean_prob
+            sub_psms.is_best_decoy[i] = sub_psms.decoy[best_idx]
+            sub_psms.num_runs[i] = nrow(sub_psms)
+        end
+    end
+
+end
 
 function clear_prob_and_group_features!(
     psms::AbstractDataFrame,

--- a/src/utils/profile.jl
+++ b/src/utils/profile.jl
@@ -1,0 +1,30 @@
+
+### ───────────── POSIX (Linux, macOS, …) ─────────────
+if Sys.isunix()
+    const RUSAGE_SELF = 0    # from sys/resource.h
+
+    """
+        peak_rss  →  Int64
+
+    Maximum resident‑set size (bytes) of the current process so far.
+    """
+    function peak_rss()::Int64
+        return Sys.maxrss()
+    end
+
+### ───────────── Windows ─────────────
+elseif Sys.iswindows()
+    # bring in WinAPI function GetProcessMemoryInfo
+    const PROCESS_MEMORY_COUNTERS = NTuple{11, UInt64}
+
+    function peak_rss()::Int64
+        pmc   = zero(PROCESS_MEMORY_COUNTERS)
+        hProc = ccall(("GetCurrentProcess", "kernel32"), Ptr{Cvoid}, ())
+        ok = ccall(("GetProcessMemoryInfo", "psapi"),
+                   Int32,
+                   (Ptr{Cvoid}, Ref{PROCESS_MEMORY_COUNTERS}, UInt32),
+                   hProc, pmc, sizeof(pmc))
+        ok == 0 && error("GetProcessMemoryInfo failed")
+        return Int64(pmc[3])    # WorkingSetSize (bytes)
+    end
+end


### PR DESCRIPTION
- Half the rows weren't getting a global prob in the OOM version. Fixed.
- OOM version supports turning off MBR now
- Unrelated: the peak memory usage statistic is now kinda right instead of being the total memory allocation through the search. The peak memory statistic is per Julia session, so if you do the search twice without restarting the session, then the peak usage could be from the first search. In the compiled Pioneer version the session should be getting reset during each search.
