### PR TITLE
Posterior error probability

### DIFF
--- a/data/ecoli_test/ecoli_test_params.json
+++ b/data/ecoli_test/ecoli_test_params.json
@@ -56,7 +56,7 @@
             "n_train_rounds": 2,
             "max_iterations": 20,
             "max_q_value_probit_rescore": 0.05,
-            "max_local_fdr": 1.0
+            "max_PEP": 0.9
         },
         "irt_mapping": {
             "max_prob_to_impute_irt": 0.75,

--- a/data/example_config/LibrarySearch.json
+++ b/data/example_config/LibrarySearch.json
@@ -49,7 +49,7 @@
             "n_train_rounds": 2,
             "max_iterations": 20,
             "max_q_value_probit_rescore": 0.05,
-            "max_local_fdr": 1.0
+            "max_PEP": 0.9
         }
     },
     "quant_search": {

--- a/data/example_config/defaultSearchParams.json
+++ b/data/example_config/defaultSearchParams.json
@@ -58,7 +58,7 @@
             "n_train_rounds": 2,
             "max_iterations": 20,
             "max_q_value_probit_rescore": 0.05,
-            "max_local_fdr": 1.0
+            "max_PEP": 0.9
         },
         "irt_mapping": {
             "max_prob_to_impute_irt": 0.75,

--- a/data/param_test/search.json
+++ b/data/param_test/search.json
@@ -69,7 +69,7 @@
             "n_train_rounds": 2,
             "max_iterations": 20,
             "max_q_value_probit_rescore": 0.05,
-            "max_local_fdr": 1.0
+            "max_PEP": 0.9
         },
         "irt_mapping": {
             "max_prob_to_impute_irt": 0.75,

--- a/docs/src/user_guide/parameters.md
+++ b/docs/src/user_guide/parameters.md
@@ -79,7 +79,7 @@ Most parameters should not be changed, but the following may need adjustement.
 | `scoring_settings.n_train_rounds` | Int | Number of training rounds for scoring model (default: 2) |
 | `scoring_settings.max_iterations` | Int | Maximum iterations for scoring optimization (default: 20) |
 | `scoring_settings.max_q_value_probit_rescore` | Float | Maximum q-value threshold for semi-supervised learning durning probit regression (default: 0.05) |
-| `scoring_settings.max_local_fdr` | Int | Maximum local FDR threshold for passing the first search (default: 1.0) |
+| `scoring_settings.max_PEP` | Int | Maximum local FDR threshold for passing the first search (default: 0.9) |
 | `irt_mapping.max_prob_to_impute_irt` | Int | If probability of the psm is less then x in the first-pass search, then impute irt for the precursor with globably determined value from the other runs (default: 0.75) |
 | `irt_mapping.fwhm_nstd` | Float | Number of standard deviations of the fwhm to add to the retention time tolerance (default: 4) |
 | `irt_mapping.irt_nstd` | Int | Number of standard deviations of run-to-run irt tolerance to add to the retention time tolerance (default: 4) |

--- a/src/Routines/SearchDIA/ParseInputs/paramsChecks.jl
+++ b/src/Routines/SearchDIA/ParseInputs/paramsChecks.jl
@@ -82,7 +82,7 @@ function checkParams(json_path::String)
     check_param(score_settings, "n_train_rounds", Integer)
     check_param(score_settings, "max_iterations", Integer)
     check_param(score_settings, "max_q_value_probit_rescore", Real)
-    check_param(score_settings, "max_local_fdr", Real)
+    check_param(score_settings, "max_PEP", Real)
 
     score_settings = first_search["irt_mapping"]
     check_param(score_settings, "max_prob_to_impute_irt", Real)

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -88,7 +88,7 @@ struct FirstPassSearchParameters{P<:PrecEstimation} <: FragmentIndexSearchParame
     n_train_rounds_probit::Int64
     max_iter_probit::Int64
     max_q_value_probit_rescore::Float32
-    max_local_fdr::Float32
+    max_PEP::Float32
     
     # RT parameters
     min_inference_points::Int64
@@ -134,7 +134,7 @@ struct FirstPassSearchParameters{P<:PrecEstimation} <: FragmentIndexSearchParame
             Int64(score_params.n_train_rounds),
             Int64(score_params.max_iterations),
             Float32(score_params.max_q_value_probit_rescore),
-            Float32(score_params.max_local_fdr),
+            Float32(score_params.max_PEP),
             
             Int64(1000), # Default min_inference_points
             Float32(rt_params.min_probability),
@@ -230,7 +230,7 @@ function process_file!(
             get_best_psms!(
                 psms,
                 precursor_mzs,
-                max_local_fdr=params.max_local_fdr,
+                max_PEP=params.max_PEP,
                 fdr_scale_factor=fdr_scale_factor
             )
         end

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
@@ -171,7 +171,7 @@ function score_presearch!(psms::DataFrame)
 end
 
 
-# Note: get_qvalues! and get_local_FDR! functions have been moved to src/utils/ML/fdrUtilities.jl
+# Note: get_qvalues! and get_PEP! functions have been moved to src/utils/ML/fdrUtilities.jl
 # They are imported through the module loading system and are available in the Pioneer module namespace
 
 #==========================================================

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
@@ -139,7 +139,7 @@ function get_quant_necessary_columns()
         :global_qval,
         :run_specific_qval,
         :prec_mz,
-        #:pep,  # Commented out as in original
+        :pep,
         :weight,
         :target,
         :rt,

--- a/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
+++ b/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
@@ -109,6 +109,7 @@ function writePrecursorCSV(
     "use_for_protein_quant"
     "precursor_idx"
     "target"
+    "entrapment_group_id"
     ]
 
     long_columns_exclude = [:isotopes_captured, :scan_idx, :protein_idx, :weight, :ms_file_idx]
@@ -141,19 +142,20 @@ function writePrecursorCSV(
                              :run_specific_prob,
                              :global_qval,
                              :qval,
+                             :pep,
                              :peak_area,
                              :peak_area_normalized,
                              :points_integrated,
                              :precursor_fraction_transmitted,
                              :isotopes_captured,
-                             #:irt_obs,
                              :rt,
                              :apex_scan,
                              :global_pg_score,
                              :run_specific_pg_score,
                              :use_for_protein_quant,
                              :precursor_idx,
-                             :target])
+                             :target,
+                             :entrapment_group_id])
 
     sorted_columns = vcat(wide_columns, file_names)
     open(long_precursors_path,"w") do io1
@@ -224,15 +226,15 @@ function writeProteinGroupsCSV(
     function makeWideFormat(
         longdf::DataFrame)
         # First create a DataFrame with the non-abundance columns we want to keep
-        metadata_df = unique(longdf[:, [:species, :protein, :target]])#, :n_peptides]])
+        metadata_df = unique(longdf[:, [:species, :protein, :target, :entrap_id]])#, :n_peptides]])
         
         # Create the abundance wide format
         abundance_df = unstack(longdf,
-            [:species, :protein, :target],
+            [:species, :protein, :target, :entrap_id],
             :file_name, :abundance)
             
         # Join the metadata with the abundance data
-        return leftjoin(metadata_df, abundance_df, on=[:species, :protein, :target])
+        return leftjoin(metadata_df, abundance_df, on=[:species, :protein, :target, :entrap_id])
     end
 
     protein_groups_long = DataFrame(Arrow.Table(long_pg_path))
@@ -246,7 +248,7 @@ function writeProteinGroupsCSV(
         safeRm(wide_protein_groups_arrow, nothing)
     end
     # Update wide columns to include n_peptides
-    wide_columns = ["species", "protein", "target"]
+    wide_columns = ["species", "protein", "target", "entrap_id"]
 
     sorted_columns = vcat(wide_columns, file_names)
     open(long_protein_groups_path,"w") do io1

--- a/src/utils/ML/fdrUtilities.jl
+++ b/src/utils/ML/fdrUtilities.jl
@@ -60,74 +60,102 @@ end
 # DataFrame convenience method
 get_qvalues!(PSMs::DataFrame, probs::Vector{Float64}, labels::Vector{Bool}) = get_qvalues!(PSMs, allowmissing(probs), allowmissing(labels))
 
-
 """
-    get_local_FDR!(scores::AbstractVector{U}, is_target::AbstractVector{Bool}, fdrs::AbstractVector{T}; 
-                   window_size::Int=1000, doSort=true, fdr_scale_factor::Float32=1.0f0) where {T,U<:AbstractFloat}
-
-Calculates local FDR (False Discovery Rate) within a sliding window.
-
-# Arguments
-- `scores`: Vector of scores (higher = better)
-- `is_target`: Vector of target/decoy labels (true = target, false = decoy)
-- `fdrs`: Vector to store calculated local FDRs
-- `window_size`: Size of sliding window for local FDR calculation (default: 1000)
-- `doSort`: Whether to sort by scores (default: true)
-- `fdr_scale_factor`: Scale factor to correct for library target/decoy ratio (default: 1.0)
-
-# Process
-1. Sorts items by descending score (if doSort=true)
-2. Builds prefix sums for efficient window calculations
-3. For each position, calculates FDR within next window_size items
-4. Applies FDR scale factor to correct for library imbalance
-
-Local FDR provides a more granular estimate of FDR in specific score regions,
-useful for filtering when global FDR may be too conservative.
+    get_PEP!(scores::AbstractVector{U}, is_target::AbstractVector{Bool}, fdrs::AbstractVector{T};
+                    doSort=true, fdr_scale_factor::Float32=1.0f0) where {T,U<:AbstractFloat}
+    Estimate posterior error probability using isotonic regression.
+    The function fits a non-decreasing decoy probability curve over the score
+    distribution via a weighted Pool Adjacent Violators Algorithm (PAVA). Each
+    decoy observation is weighted by `fdr_scale_factor` to correct for library
+    target/decoy imbalance. The fitted decoy probabilities are converted to PEP
+    values (decoy_prob/(1 - decoy_prob)).
+    # Arguments
+    - `scores`: Vector of scores (higher = better)
+    - `is_target`: Vector of target/decoy labels (true = target, false = decoy)
+    - `fdrs`: Vector to store calculated local PEP values
+    - `doSort`: Whether to sort by scores before fitting (default: true)
+    - `fdr_scale_factor`: Scale factor to correct for library target/decoy ratio
 """
-function get_local_FDR!(scores::AbstractVector{U}, is_target::AbstractVector{Bool}, fdrs::AbstractVector{T}; 
-    window_size::Int=1000, doSort=true, fdr_scale_factor::Float32=1.0f0) where {T,U<:AbstractFloat}
+function get_PEP!(scores::AbstractVector{U}, is_target::AbstractVector{Bool}, fdrs::AbstractVector{T};
+    doSort::Bool=true, fdr_scale_factor::Float32=1.0f0) where {T,U<:AbstractFloat}
+
     @assert length(scores) == length(is_target)
     N = length(scores)
     if N == 0
         return
     end
-    # 1) Sort items by descending score
-    if doSort
-        idxs = sortperm(scores, rev = true, alg = QuickSort) #Sort class probabilities
-    else
-        idxs = eachindex(scores)
-    end
-    # We'll define rank i as the i-th item in that sorted order
-    # so rank 1 => idxs[1], rank N => idxs[N].
 
-    # 2) Build prefix sums for decoys & targets in sorted order
-    #    This lets us quickly count how many decoys/targets are in a range.
-    decoy_prefix = zeros(Int, N+1)   # decoy_prefix[i] = # decoys among top i items
-    target_prefix = zeros(Int, N+1)  # same for targets
+    # sort by score if requested
+    order = doSort ? sortperm(scores, rev=true, alg=QuickSort) : collect(eachindex(scores))
 
-    decoy_prefix[1]  = !is_target[1]
-    target_prefix[1] = is_target[1]
+    # prepare labels and weights
+    labels = Vector{Float64}(undef, N + 1)
+    weights = Vector{Float64}(undef, N + 1)
+    labels[1] = 0.5              # pseudo observation
+    weights[1] = 1.0
 
-    @inbounds @fastmath for rank in 2:N
-        i = idxs[rank] 
-        decoy_prefix[rank]  = decoy_prefix[rank-1]  + !is_target[i]
-        target_prefix[rank] = target_prefix[rank-1] + is_target[i]
+    @inbounds for j in 1:N
+        idx = order[j]
+        # decoy = 1.0, target = 0.0
+        labels[j+1] = is_target[idx] ? 0.0 : 1.0
+        weights[j+1] = is_target[idx] ? 1.0 : float(fdr_scale_factor)
     end
 
-    # 3) For each rank i, compute local FDR from this point to the next X entries
-    fdrs[idxs[1]] = ((decoy_prefix[window_size] + 1) * fdr_scale_factor) / max(1, target_prefix[window_size])
+    fitted = _weighted_pava(labels, weights)
+    fitted = fitted[2:end]  # remove pseudo row
 
-    for rank in 2:(N-window_size)
-        # Count decoys/targets in [L,R] using prefix sums
-        decs_in_window   = decoy_prefix[rank + window_size]  - decoy_prefix[rank-1]
-        targs_in_window  = target_prefix[rank + window_size] - target_prefix[rank-1]
+    pep = fitted ./ (1 .- fitted)
+    pep = clamp.(pep, 0.0, 1.0)
 
-        # local FDR = (#decoys * scale_factor) / max(1, #targets)
-        # adding a pseudocount to guarantee finite sample control of the FDR
-        fdrs[idxs[rank]] = ((decs_in_window + 1) * fdr_scale_factor) / max(1, targs_in_window)
+    @inbounds for (j, idx) in enumerate(order)
+        fdrs[idx] = T(pep[j])
+    end
+    return
+end
+
+""" Weighted pool adjacent violators algorithm used by `get_PEP!`."""
+function _weighted_pava(y::Vector{Float64}, w::Vector{Float64})
+    n = length(y)
+    # preallocate stacks of maximum size n
+    v    = Vector{Float64}(undef, n)
+    wt   = Vector{Float64}(undef, n)
+    lenv = Vector{Int}(undef,    n)
+
+    m = 0  # current stack height
+    for i in 1:n
+        # “push” y[i], w[i], 1 onto our stack
+        m += 1
+        @inbounds begin
+            v[m]    = y[i]
+            wt[m]   = w[i]
+            lenv[m] = 1
+        end
+
+        # merge down while out of order
+        while m > 1 && v[m-1] > v[m]
+            @inbounds begin
+                new_w   = wt[m-1] + wt[m]
+                new_v   = (v[m-1]*wt[m-1] + v[m]*wt[m]) / new_w
+                new_len = lenv[m-1] + lenv[m]
+                m -= 1
+                v[m]    = new_v
+                wt[m]   = new_w
+                lenv[m] = new_len
+            end
+        end
     end
 
-    return 
+    # now expand back out into result
+    result = Vector{Float64}(undef, n)
+    idx = 1
+    for j in 1:m
+        @inbounds for _ in 1:lenv[j]
+            result[idx] = v[j]
+            idx += 1
+        end
+    end
+
+    return result
 end
 
 

--- a/src/utils/ML/fdrUtilities.jl
+++ b/src/utils/ML/fdrUtilities.jl
@@ -91,7 +91,7 @@ function get_PEP!(scores::AbstractVector{U}, is_target::AbstractVector{Bool}, fd
     # prepare labels and weights
     labels = Vector{Float64}(undef, N + 1)
     weights = Vector{Float64}(undef, N + 1)
-    labels[1] = 0.5              # pseudo observation
+    labels[1] = 0.0              # pseudo observation
     weights[1] = 1.0
 
     @inbounds for j in 1:N

--- a/src/utils/ML/probitRegression.jl
+++ b/src/utils/ML/probitRegression.jl
@@ -14,7 +14,7 @@ function fillZandW!(Z::Vector{T}, W::Vector{T}, η::Vector{T}, y::Vector{Bool},d
                     η[i] = log(μ)
                 else
                     Z[i] = η[i] - μ/ϕ
-                    η[i] = 1- log(μ)
+                    η[i] = log1p(-μ)
                 end
                 W[i] = (ϕ^2)/(μ*(1 - μ))
             end

--- a/src/utils/ML/probitRegression.jl
+++ b/src/utils/ML/probitRegression.jl
@@ -119,9 +119,34 @@ function vecSum!(v::Vector{T}, data_chunks) where {T<:AbstractFloat}
     return sum(fetch.(tasks))
 end
 
+# Compute the log-likelihood for a coefficient vector without modifying
+# the current IRLS working variables. A temporary `η` vector must be
+# provided to avoid allocations inside the inner loop.
+function loglikelihood!(tmpη::Vector{T},
+                        X::DataFrame,
+                        β::Vector{T},
+                        y::Vector{Bool},
+                        bounds::Tuple{T,T},
+                        data_chunks::Base.Iterators.PartitionIterator{UnitRange{Int64}}) where {T<:AbstractFloat}
+    fillη!(tmpη, X, β, bounds, data_chunks)
+    tasks = map(data_chunks) do chunk
+        Threads.@spawn begin
+            local_sum = zero(T)
+            @inbounds @fastmath for i in chunk
+                μ = (1 + SpecialFunctions.erf(tmpη[i]/sqrt(2)))/2
+                local_sum += y[i] ? log(μ) : log1p(-μ)
+            end
+            return local_sum
+        end
+    end
+    return sum(fetch.(tasks))
+end
+
 function ProbitRegression(β::Vector{T}, X::DataFrame, y::Vector{Bool},
                             data_chunks::Base.Iterators.PartitionIterator{UnitRange{Int64}}; 
-                            max_iter::Int = 30, z_score_bounds::Tuple{Float64, Float64} = (-8.0, 8.0)
+                            max_iter::Int = 30, z_score_bounds::Tuple{Float64, Float64} = (-8.0, 8.0),
+                            tol::T = T(1e-2),
+                            step_size::T = one(T)
                             ) where {T<:AbstractFloat}
 
     W, η, Z = zeros(T, length(y)), zeros(T, length(y)), zeros(T, length(y))
@@ -129,18 +154,42 @@ function ProbitRegression(β::Vector{T}, X::DataFrame, y::Vector{Bool},
     XWX = zeros(T, (size(X, 2), size(X, 2)))
     old_loss = 0.0
 
+    β_old = similar(β)
+    tmpη = similar(η)
     for i in range(1, max_iter)#ProgressBar(range(1, max_iter))
+        copyto!(β_old, β)
         fillη!(η, X, β, z_score_bounds, data_chunks)        
         fillZandW!(Z, W, η, y, data_chunks)
         loss = vecSum!(η, data_chunks)
         fillXWX!(XWX, X, W)
         fillY!(Y, X, W, Z)
-        β = T.(XWX\Y)
-        if abs(1 - exp(loss - old_loss)) < 1e-2
+        
+        β_new = T.(XWX\Y)
+
+        Δβ = β_new .- β
+        step = step_size
+        new_loss = loss
+        while step > T(1e-4)
+            β_trial = β .+ step .* Δβ
+            trial_loss = loglikelihood!(tmpη, X, β_trial, y, z_score_bounds, data_chunks)
+            if trial_loss >= loss
+                β .= β_trial
+                new_loss = trial_loss
+                break
+            end
+            step *= T(0.5)
+        end
+        if step <= T(1e-4)
+            β .+= step .* Δβ
+            new_loss = loglikelihood!(tmpη, X, β, y, z_score_bounds, data_chunks)
+        end
+
+        if norm(β .- β_old) < tol || abs(new_loss - old_loss) < tol
             break
         end
-        old_loss = loss
+        old_loss = new_loss
     end
+
     return β
 
 end


### PR DESCRIPTION
Replaces the local_FDR function with a PEP calculation based on https://github.com/statisticalbiotechnology/smooth_q_to_pep

Computes PEP for precursors and proteins.
Adds PEP to long precursor and long protein output files
Added back entrap_id to precursor and protein output for testing purposes for now