### PR TITLE
renamed *_prob columns to *_score. Added scores to protein output

### DIFF
--- a/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
+++ b/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
@@ -150,6 +150,7 @@ function writePrecursorCSV(
     "structural_mods"
     "isotopic_mods"
     "prec_mz"
+    "global_score"
     "global_qval"
     "use_for_protein_quant"
     "precursor_idx"
@@ -170,8 +171,8 @@ function writePrecursorCSV(
     # Build rename pairs dynamically to avoid conflicts
     rename_pairs = Pair{Symbol,Symbol}[]
     push!(rename_pairs, :new_best_scan => :apex_scan)
-    push!(rename_pairs, :prec_prob => :run_specific_prob)
-    push!(rename_pairs, :pg_score => :run_specific_pg_score)
+    push!(rename_pairs, :prec_prob => :score)
+    push!(rename_pairs, :global_prob => :global_score)
     push!(rename_pairs, :isotopes_captured_traces => :isotopes_captured)
     push!(rename_pairs, :precursor_fraction_transmitted_traces => :precursor_fraction_transmitted)
     
@@ -179,6 +180,7 @@ function writePrecursorCSV(
     if !isempty(rename_pairs)
         rename!(precursors_long, rename_pairs)
     end
+
     # order columns
     select!(precursors_long, [:file_name,
                              :species,
@@ -192,8 +194,8 @@ function writePrecursorCSV(
                              :isotopic_mods,
                              :prec_mz,
                              :missed_cleavage,
-                             :global_prob,
-                             :run_specific_prob,
+                             :global_score,
+                             :score,
                              :global_qval,
                              :qval,
                              :pep,
@@ -205,7 +207,7 @@ function writePrecursorCSV(
                              :rt,
                              :apex_scan,
                              :global_pg_score,
-                             :run_specific_pg_score,
+                             :pg_score,
                              :use_for_protein_quant,
                              :precursor_idx,
                              :target,
@@ -281,7 +283,7 @@ function writeProteinGroupsCSV(
     function makeWideFormat(
         longdf::DataFrame)
         # First create a DataFrame with the non-abundance columns we want to keep
-        metadata_df = unique(longdf[:, [:species, :gene_names, :protein_names, :protein, :target, :entrap_id]])#, :n_peptides]])
+        metadata_df = unique(longdf[:, [:species, :gene_names, :protein_names, :protein, :global_pg_score, :global_qval, :target, :entrap_id,]])#, :n_peptides]])
         
         # Create the abundance wide format
         abundance_df = unstack(longdf,
@@ -312,7 +314,7 @@ function writeProteinGroupsCSV(
     protein_groups_long[!, :protein_names] = _map_accession_vector(protein_groups_long.protein, prot_map)
 
     # Update wide columns to include n_peptides
-    wide_columns = ["species", "gene_names", "protein_names", "protein", "target", "entrap_id"]
+    wide_columns = ["species", "gene_names", "protein_names", "protein", "target", "entrap_id", "global_pg_score", "global_qval"]
 
     select!(protein_groups_long, [:file_name,
                              :species,
@@ -323,6 +325,8 @@ function writeProteinGroupsCSV(
                              :entrap_id,
                              :peptides,
                              :n_peptides,
+                             :global_pg_score,
+                             :pg_score,
                              :global_qval,
                              :qval,
                              :pg_pep,

--- a/src/utils/maxLFQ.jl
+++ b/src/utils/maxLFQ.jl
@@ -188,6 +188,8 @@ function getProtAbundance(protein::String,
                             global_qvals::AbstractVector{Float32},
                             qvals::AbstractVector{Float32},
                             peps::AbstractVector{Float32},
+                            pg_scores::AbstractVector{Float32},
+                            global_pg_scores::AbstractVector{Float32},
                             target_out::Vector{Union{Missing, Bool}},
                             entrap_id_out::Vector{Union{Missing, UInt8}},
                             species_out::Vector{Union{Missing, String}},
@@ -197,7 +199,9 @@ function getProtAbundance(protein::String,
                             log2_abundance_out::Vector{Union{Missing, Float32}},
                             global_qval_out::Vector{Union{Missing, Float32}},
                             qval_out::Vector{Union{Missing, Float32}},
-                            pep_out::Vector{Union{Missing, Float32}}) where {T <: Real}
+                            pep_out::Vector{Union{Missing, Float32}},
+                            pg_score_out::Vector{Union{Missing, Float32}},
+                            global_pg_score_out::Vector{Union{Missing, Float32}}) where {T <: Real}
 
     unique_experiments = unique(experiments)
     unique_peptides = unique(peptides)
@@ -220,6 +224,8 @@ function getProtAbundance(protein::String,
                             global_qvals::AbstractVector{Float32},
                             qvals::AbstractVector{Float32},
                             peps::AbstractVector{Float32},
+                            pg_scores::AbstractVector{Float32},
+                            global_pg_scores::AbstractVector{Float32},
                             target_out::Vector{Union{Missing, Bool}},
                             entrap_id_out::Vector{Union{Missing, UInt8}},
                             species_out::Vector{Union{Missing, String}}, 
@@ -229,6 +235,8 @@ function getProtAbundance(protein::String,
                             global_qval_out::Vector{Union{Missing, Float32}}, 
                             qval_out::Vector{Union{Missing, Float32}}, 
                             pep_out::Vector{Union{Missing, Float32}},
+                            pg_score_out::Vector{Union{Missing, Float32}},
+                            global_pg_score_out::Vector{Union{Missing, Float32}},
                             experiments_out::Vector{Union{Missing, I}}, 
                             S::Matrix{Union{Missing, T}}) where {T<:Real,I<:Integer}
         
@@ -259,6 +267,8 @@ function getProtAbundance(protein::String,
             log2_abundance_out[row_idx + i] = log2_abundances[i + 1]
             global_qval_out[row_idx + i] = global_qvals[i + 1]
             qval_out[row_idx + i] = qvals[i + 1]
+            pg_score_out[row_idx + i] = pg_scores[i + 1]
+            global_pg_score_out[row_idx + i] = global_pg_scores[i + 1]
             experiments_out[row_idx + i] = unique_experiments[i + 1]
             protein_out[row_idx + i] = protein
             pep_out[row_idx + i] = pep_val
@@ -303,6 +313,8 @@ function getProtAbundance(protein::String,
                    global_qvals,
                    qvals,
                    peps,
+                   pg_scores,
+                   global_pg_scores,
                    target_out,
                    entrap_id_out,
                    species_out,
@@ -312,6 +324,8 @@ function getProtAbundance(protein::String,
                    global_qval_out,
                    qval_out,
                    pep_out,
+                   pg_score_out,
+                   global_pg_score_out,
                    experiments_out,
                    S)
 
@@ -383,6 +397,8 @@ function LFQ(prot_ref,  # PSMFileReference - using Any to avoid dependency issue
             :global_qval => zeros(Union{Missing, Float32}, nrows),
             :qval => zeros(Union{Missing, Float32}, nrows),
             :pg_pep => zeros(Union{Missing, Float32}, nrows),
+            :pg_score => zeros(Union{Missing, Float32}, nrows),
+            :global_pg_score => zeros(Union{Missing, Float32}, nrows),
         )
         for i in range(1, nrows)
             out[:target][i] = missing
@@ -395,6 +411,8 @@ function LFQ(prot_ref,  # PSMFileReference - using Any to avoid dependency issue
             out[:global_qval][i] = missing
             out[:qval][i] = missing
             out[:pg_pep][i] = missing
+            out[:pg_score][i] = missing
+            out[:global_pg_score][i] = missing
         end
 
         for (group_idx, (protein, data)) in enumerate(pairs(gpsms))
@@ -410,6 +428,8 @@ function LFQ(prot_ref,  # PSMFileReference - using Any to avoid dependency issue
                                 data[!,:global_qval_pg],
                                 data[!,:pg_qval],
                                 data[!,:pg_pep],
+                                data[!,:pg_score],
+                                data[!,:global_pg_score],
                                 out[:target],
                                 out[:entrap_id],
                                 out[:species],
@@ -419,7 +439,9 @@ function LFQ(prot_ref,  # PSMFileReference - using Any to avoid dependency issue
                                 out[:log2_abundance],
                                 out[:global_qval],
                                 out[:qval],
-                                out[:pg_pep]
+                                out[:pg_pep],
+                                out[:pg_score],
+                                out[:global_pg_score]
                             )
         end
         out = DataFrame(out)
@@ -447,7 +469,7 @@ function LFQ(prot_ref,  # PSMFileReference - using Any to avoid dependency issue
                     [:file_name,
                     :target,
                     :entrap_id,
-                    :species,:protein,:peptides,:n_peptides,:global_qval,:qval,:pg_pep,:abundance]); 
+                    :species,:protein,:peptides,:n_peptides,:global_qval,:qval,:pg_pep,:pg_score,:global_pg_score,:abundance]);
                 file=false)  # file=false creates stream format
             end
         else
@@ -458,7 +480,7 @@ function LFQ(prot_ref,  # PSMFileReference - using Any to avoid dependency issue
                     [:file_name,
                     :target,
                     :entrap_id,
-                    :species,:protein,:peptides,:n_peptides,:global_qval,:qval,:pg_pep,:abundance])
+                    :species,:protein,:peptides,:n_peptides,:global_qval,:qval,:pg_pep,:pg_score,:global_pg_score,:abundance])
             )
         end
         n_writes += 1


### PR DESCRIPTION
The probabilities from the XGBoost and Probit aren't true probabilities, we're using them more like scores. It's the PEP column that should behave like a probability. In the future we should smooth it out like it was before.

Added the protein level scores and q_values to the protein output.  

Now everyone should have access to all the values they need to compute decoy and entrapment FDRs, at the precursor and protein level, and globally, experiment-wide, or run-specific on their own to validate our results.