### PR TITLE
dropping pseudocounts

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/utils.jl
@@ -174,7 +174,6 @@ function get_qvalue_spline(
     bin_size = 0
     bin_idx = 0
     mean_prob, targets, decoys = 0.0f0, 0, 0
-    targets, decoys = 0, 0
     for i in range(1, Q)
         targets += psms_scores[!, :target][i]
         decoys += (1 - psms_scores[!, :target][i])

--- a/src/utils/ML/fdrUtilities.jl
+++ b/src/utils/ML/fdrUtilities.jl
@@ -56,7 +56,7 @@ function get_qvalues!(probs::AbstractVector{U}, labels::AbstractVector{Bool}, qv
     end
 
     targets = 0
-    decoys = 1 # pseudocount to guarantee finite sample control of the FDR
+    decoys = 0
     @inbounds @fastmath for i in order
             targets += labels[i]
             decoys += (1 - labels[i])


### PR DESCRIPTION
get_qvalues! had a decoy pseudocount of 1 but the qvalue splines didn't. It would create a slight disagreement in the final output. I got rid of the pseudocount from get_qvalues to make it consistent.