### PR TITLE
MBR overhaul and controlling the false transfer rate

### DIFF
--- a/data/example_config/LibrarySearch.json
+++ b/data/example_config/LibrarySearch.json
@@ -95,10 +95,8 @@
         "machine_learning": {
             "max_samples": 10000000,
             "min_trace_prob": 0.75,
-            "max_q_value_xgboost_rescore": 0.01,
 			"max_q_value_xgboost_mbr_rescore": 0.20,
             "min_PEP_neg_threshold_xgboost_rescore": 0.90,
-            "max_MBR_false_transfer_rate": 0.01,
             "spline_points": 500,
             "interpolation_points": 10
         }

--- a/data/example_config/LibrarySearch.json
+++ b/data/example_config/LibrarySearch.json
@@ -97,6 +97,8 @@
             "min_trace_prob": 0.75,
             "max_q_value_xgboost_rescore": 0.01,
 			"max_q_value_xgboost_mbr_rescore": 0.20,
+            "min_PEP_neg_threshold_xgboost_rescore": 0.90,
+            "max_MBR_false_transfer_rate": 0.01,
             "spline_points": 500,
             "interpolation_points": 10
         }

--- a/data/example_config/defaultSearchParams.json
+++ b/data/example_config/defaultSearchParams.json
@@ -115,6 +115,8 @@
             "min_trace_prob": 0.75,
             "max_q_value_xgboost_rescore": 0.01,
 			"max_q_value_xgboost_mbr_rescore": 0.20,
+            "min_PEP_neg_threshold_xgboost_rescore": 0.90,
+            "max_MBR_false_transfer_rate": 0.01,
             "spline_points": 500,
             "interpolation_points": 10
         }

--- a/data/example_config/defaultSearchParams.json
+++ b/data/example_config/defaultSearchParams.json
@@ -113,10 +113,8 @@
         "machine_learning": {
             "max_psms_in_memory": 50000000,
             "min_trace_prob": 0.75,
-            "max_q_value_xgboost_rescore": 0.01,
 			"max_q_value_xgboost_mbr_rescore": 0.20,
             "min_PEP_neg_threshold_xgboost_rescore": 0.90,
-            "max_MBR_false_transfer_rate": 0.01,
             "spline_points": 500,
             "interpolation_points": 10
         }

--- a/docs/src/user_guide/parameters.md
+++ b/docs/src/user_guide/parameters.md
@@ -134,6 +134,8 @@ Most parameters should not be changed, but the following may need adjustement.
 | `machine_learning.min_trace_prob` | Float | Minimum trace probability threshold (default: 0.75) |
 | `machine_learning.max_q_value_xgboost_rescore` | Float | q-value threshold for semi-supervised learning with XGBoost (default: 0.01) |
 | `machine_learning.max_q_value_xgboost_mbr_rescore` | Float | q-value threshold for match-between-runs candidates during semi-supervised learning with XGBoost (default: 0.20) |
+| `machine_learning.min_PEP_neg_threshold_xgboost_rescore` | Float | Minimum posterior error probabilility threshold for poor scoring targets to be relabeled as negative examples during semi-supervised learning with XGBoost (default: 0.20) |
+| `machine_learning.max_MBR_false_transfer_rate` | Float | False transfer rate threshold for match-between-runs (default: 0.01) |
 | `machine_learning.spline_points` | Int | Number of points for probability spline (default: 500) |
 | `machine_learning.interpolation_points` | Int | Number of interpolation points (default: 10) |
 

--- a/docs/src/user_guide/parameters.md
+++ b/docs/src/user_guide/parameters.md
@@ -39,7 +39,7 @@ Most parameters should not be changed, but the following may need adjustement.
 | `isotope_settings.combine_traces` | Boolean | Whether to combine precursor isotope traces in quantification. Experimental, so set to false (default: false) |
 | `isotope_settings.partial_capture` | Boolean | Whether to estimate the conditional fragment isotope distribution (true) or assume complete transmission the entire precursor isotopic envelope (default: true) |
 | `isotope_settings.min_fraction_transmitted` | Float | Minimum fraction of the precursor isotope distribution that must be isolated for scoring and quantitation (default: 0.25) |
-| `scoring.q_value_threshold` | Float | Global q-value threshold for filtering results (default: 0.01) |
+| `scoring.q_value_threshold` | Float | Global q-value threshold for filtering results. Also controls false transfer rate of MBR (default: 0.01) |
 | `normalization.n_rt_bins` | Int | Number of retention time bins for quant normalization (default: 100) |
 | `normalization.spline_n_knots` | Int | Number of knots in quant normalization spline (default: 7) |
 | `match_between_runs` | Boolean | Whether to attempt to transfer peptide identifications across runs. Turning this on will add additional features to the XGBoost model (default: true) |
@@ -132,10 +132,8 @@ Most parameters should not be changed, but the following may need adjustement.
 | `deconvolution.max_diff` | Float | Relative convergence threshold - maximum relative change in weights between iterations. Also used as relative tolerance for Newton's method (default: 0.01) |
 | `machine_learning.max_samples` | Int | Maximum number of samples for XGBoost training (default: 5000000) |
 | `machine_learning.min_trace_prob` | Float | Minimum trace probability threshold (default: 0.75) |
-| `machine_learning.max_q_value_xgboost_rescore` | Float | q-value threshold for semi-supervised learning with XGBoost (default: 0.01) |
 | `machine_learning.max_q_value_xgboost_mbr_rescore` | Float | q-value threshold for match-between-runs candidates during semi-supervised learning with XGBoost (default: 0.20) |
 | `machine_learning.min_PEP_neg_threshold_xgboost_rescore` | Float | Minimum posterior error probabilility threshold for poor scoring targets to be relabeled as negative examples during semi-supervised learning with XGBoost (default: 0.20) |
-| `machine_learning.max_MBR_false_transfer_rate` | Float | False transfer rate threshold for match-between-runs (default: 0.01) |
 | `machine_learning.spline_points` | Int | Number of points for probability spline (default: 500) |
 | `machine_learning.interpolation_points` | Int | Number of interpolation points (default: 10) |
 

--- a/src/Routines/SearchDIA/ParseInputs/paramsChecks.jl
+++ b/src/Routines/SearchDIA/ParseInputs/paramsChecks.jl
@@ -158,10 +158,8 @@ function checkParams(json_path::String)
     ml_params = opt_params["machine_learning"]
     check_param(ml_params, "max_psms_in_memory", Integer)
     check_param(ml_params, "min_trace_prob", Real)
-    check_param(ml_params, "max_q_value_xgboost_rescore", Real)
     check_param(ml_params, "max_q_value_xgboost_mbr_rescore", Real)
     check_param(ml_params, "min_PEP_neg_threshold_xgboost_rescore", Real)
-    check_param(ml_params, "max_MBR_false_transfer_rate", Real)
     check_param(ml_params, "spline_points", Integer)
     check_param(ml_params, "interpolation_points", Integer)
 

--- a/src/Routines/SearchDIA/ParseInputs/paramsChecks.jl
+++ b/src/Routines/SearchDIA/ParseInputs/paramsChecks.jl
@@ -160,6 +160,8 @@ function checkParams(json_path::String)
     check_param(ml_params, "min_trace_prob", Real)
     check_param(ml_params, "max_q_value_xgboost_rescore", Real)
     check_param(ml_params, "max_q_value_xgboost_mbr_rescore", Real)
+    check_param(ml_params, "min_PEP_neg_threshold_xgboost_rescore", Real)
+    check_param(ml_params, "max_MBR_false_transfer_rate", Real)
     check_param(ml_params, "spline_points", Integer)
     check_param(ml_params, "interpolation_points", Integer)
 

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/CLAUDE.md
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/CLAUDE.md
@@ -79,7 +79,7 @@ The scoring search performs these steps:
 - `n_peptides`: Number of unique peptides
 - `peptide_coverage`: Fraction of possible peptides observed
 - `n_possible_peptides`: Total peptides in library
-- `global_pg_score`: Max score across all files
+- `global_pg_score`: Log-odds combination of scores across all files
 
 ## Memory Management
 

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
@@ -213,8 +213,6 @@ function summarize_results!(
                 params.max_q_value_xgboost_rescore,
                 params.max_q_value_xgboost_mbr_rescore,
                 params.min_PEP_neg_threshold_xgboost_rescore,
-                params.q_value_threshold,
-                params.max_MBR_false_transfer_rate,
                 params.max_psms_in_memory
             )
         end

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
@@ -57,6 +57,8 @@ struct ScoringSearchParameters{I<:IsotopeTraceType} <: SearchParameters
     min_peptides::Int64
     max_q_value_xgboost_rescore::Float32
     max_q_value_xgboost_mbr_rescore::Float32
+    min_PEP_neg_threshold_xgboost_rescore::Float32
+    max_MBR_false_transfer_rate::Float32
     q_value_threshold::Float32
     isotope_tracetype::I
 
@@ -84,6 +86,8 @@ struct ScoringSearchParameters{I<:IsotopeTraceType} <: SearchParameters
             Int64(protein_inference_params.min_peptides),
             Float32(ml_params.max_q_value_xgboost_rescore),
             Float32(ml_params.max_q_value_xgboost_mbr_rescore),
+            Float32(ml_params.min_PEP_neg_threshold_xgboost_rescore),
+            Float32(ml_params.max_MBR_false_transfer_rate),
             Float32(global_params.scoring.q_value_threshold),
             isotope_trace_type
         )
@@ -208,6 +212,9 @@ function summarize_results!(
                 params.match_between_runs,
                 params.max_q_value_xgboost_rescore,
                 params.max_q_value_xgboost_mbr_rescore,
+                params.min_PEP_neg_threshold_xgboost_rescore,
+                params.q_value_threshold,
+                params.max_MBR_false_transfer_rate,
                 params.max_psms_in_memory
             )
         end

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
@@ -84,10 +84,10 @@ struct ScoringSearchParameters{I<:IsotopeTraceType} <: SearchParameters
             Int64(ml_params.interpolation_points), # Using same value for protein groups
             Bool(global_params.match_between_runs),
             Int64(protein_inference_params.min_peptides),
-            Float32(ml_params.max_q_value_xgboost_rescore),
+            Float32(global_params.scoring.q_value_threshold),
             Float32(ml_params.max_q_value_xgboost_mbr_rescore),
             Float32(ml_params.min_PEP_neg_threshold_xgboost_rescore),
-            Float32(ml_params.max_MBR_false_transfer_rate),
+            Float32(global_params.scoring.q_value_threshold),
             Float32(global_params.scoring.q_value_threshold),
             isotope_trace_type
         )

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
@@ -57,8 +57,6 @@ function score_precursor_isotope_traces(
     max_q_value_xgboost_rescore::Float32,
     max_q_value_xgboost_mbr_rescore::Float32,
     min_PEP_neg_threshold_xgboost_rescore::Float32,
-    q_value_threshold::Float32,
-    max_MBR_false_transfer_rate::Float32,
     max_psms_in_memory::Int64
 )
     # Count total PSMs
@@ -74,9 +72,7 @@ function score_precursor_isotope_traces(
             match_between_runs,
             max_q_value_xgboost_rescore,
             max_q_value_xgboost_mbr_rescore,
-            min_PEP_neg_threshold_xgboost_rescore,
-            q_value_threshold,
-            max_MBR_false_transfer_rate
+            min_PEP_neg_threshold_xgboost_rescore
         )
     else
         # Use in-memory algorithm
@@ -88,9 +84,7 @@ function score_precursor_isotope_traces(
             match_between_runs,
             max_q_value_xgboost_rescore,
             max_q_value_xgboost_mbr_rescore,
-            min_PEP_neg_threshold_xgboost_rescore,
-            q_value_threshold,
-            max_MBR_false_transfer_rate
+            min_PEP_neg_threshold_xgboost_rescore
         )
     end
     
@@ -200,9 +194,7 @@ function score_precursor_isotope_traces_in_memory!(
     match_between_runs::Bool,
     max_q_value_xgboost_rescore::Float32,
     max_q_value_xgboost_mbr_rescore::Float32,
-    min_PEP_neg_threshold_xgboost_rescore::Float32,
-    q_value_threshold::Float32,
-    max_MBR_false_transfer_rate::Float32,
+    min_PEP_neg_threshold_xgboost_rescore::Float32
 )
     if size(best_psms, 1) > 100000
         file_paths = [fpath for fpath in file_paths if endswith(fpath,".arrow")]
@@ -282,8 +274,6 @@ function score_precursor_isotope_traces_in_memory!(
                                 max_q_value_xgboost_rescore,
                                 max_q_value_xgboost_mbr_rescore,
                                 min_PEP_neg_threshold_xgboost_rescore,
-                                q_value_threshold = q_value_threshold,
-                                max_ftr = max_MBR_false_transfer_rate,
                                 colsample_bytree = 0.5, 
                                 colsample_bynode = 0.5,
                                 min_child_weight = 5, 
@@ -338,8 +328,6 @@ function score_precursor_isotope_traces_in_memory!(
                                 max_q_value_xgboost_rescore,
                                 max_q_value_xgboost_mbr_rescore,
                                 min_PEP_neg_threshold_xgboost_rescore,
-                                q_value_threshold = q_value_threshold,
-                                max_ftr = max_MBR_false_transfer_rate,
                                 colsample_bytree = 1.0, 
                                 colsample_bynode = 1.0,
                                 min_child_weight = 1, 
@@ -374,9 +362,7 @@ function score_precursor_isotope_traces_out_of_memory!(
     match_between_runs::Bool,
     max_q_value_xgboost_rescore::Float32,
     max_q_value_xgboost_mbr_rescore::Float32,
-    min_PEP_neg_threshold_xgboost_rescore::Float32,
-    q_value_threshold::Float32,
-    max_MBR_false_transfer_rate::Float32
+    min_PEP_neg_threshold_xgboost_rescore::Float32
 )
     if size(best_psms, 1) > 100000
         file_paths = [fpath for fpath in file_paths if endswith(fpath,".arrow")]
@@ -455,8 +441,6 @@ function score_precursor_isotope_traces_out_of_memory!(
                                 max_q_value_xgboost_rescore,
                                 max_q_value_xgboost_mbr_rescore,
                                 min_PEP_neg_threshold_xgboost_rescore,
-                                q_value_threshold = q_value_threshold,
-                                max_ftr = max_MBR_false_transfer_rate,
                                 colsample_bytree = 0.5, 
                                 colsample_bynode = 0.5,
                                 min_child_weight = 5, 
@@ -499,8 +483,6 @@ function score_precursor_isotope_traces_out_of_memory!(
                                 max_q_value_xgboost_rescore,
                                 max_q_value_xgboost_mbr_rescore,
                                 min_PEP_neg_threshold_xgboost_rescore,
-                                q_value_threshold = q_value_threshold,
-                                max_ftr = max_MBR_false_transfer_rate,
                                 colsample_bytree = 1.0, 
                                 colsample_bynode = 1.0,
                                 min_child_weight = 100, 

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
@@ -26,6 +26,9 @@ PSM sampling and scoring
                                   match_between_runs::Bool,
                                   max_q_value_xgboost_rescore::Float32,
                                   max_q_value_xgboost_mbr_rescore::Float32,
+                                  min_PEP_neg_threshold_xgboost_rescore::Float32,
+                                  q_value_threshold::Float32,
+                                  max_MBR_false_transfer_rate::Float32,
                                   max_psms_in_memory::Int64)
 
 Main entry point for PSM scoring. Automatically chooses between in-memory and out-of-memory
@@ -38,6 +41,9 @@ processing based on data size.
 - `match_between_runs`: Whether to perform match between runs
 - `max_q_value_xgboost_rescore`: Max q-value for XGBoost rescoring
 - `max_q_value_xgboost_mbr_rescore`: Max q-value for MBR rescoring
+- `min_PEP_neg_threshold_xgboost_rescore`: Min PEP for negative relabeling
+- `q_value_threshold`: Max q-value for final output
+- `max_MBR_false_transfer_rate`: Max FTR for MBR
 - `max_psms_in_memory`: Maximum PSMs to keep in memory
 
 # Returns
@@ -50,6 +56,9 @@ function score_precursor_isotope_traces(
     match_between_runs::Bool,
     max_q_value_xgboost_rescore::Float32,
     max_q_value_xgboost_mbr_rescore::Float32,
+    min_PEP_neg_threshold_xgboost_rescore::Float32,
+    q_value_threshold::Float32,
+    max_MBR_false_transfer_rate::Float32,
     max_psms_in_memory::Int64
 )
     # Count total PSMs
@@ -64,7 +73,10 @@ function score_precursor_isotope_traces(
             precursors,
             match_between_runs,
             max_q_value_xgboost_rescore,
-            max_q_value_xgboost_mbr_rescore
+            max_q_value_xgboost_mbr_rescore,
+            min_PEP_neg_threshold_xgboost_rescore,
+            q_value_threshold,
+            max_MBR_false_transfer_rate
         )
     else
         # Use in-memory algorithm
@@ -75,7 +87,10 @@ function score_precursor_isotope_traces(
             precursors,
             match_between_runs,
             max_q_value_xgboost_rescore,
-            max_q_value_xgboost_mbr_rescore
+            max_q_value_xgboost_mbr_rescore,
+            min_PEP_neg_threshold_xgboost_rescore,
+            q_value_threshold,
+            max_MBR_false_transfer_rate
         )
     end
     
@@ -184,7 +199,10 @@ function score_precursor_isotope_traces_in_memory!(
     precursors::LibraryPrecursors,
     match_between_runs::Bool,
     max_q_value_xgboost_rescore::Float32,
-    max_q_value_xgboost_mbr_rescore::Float32
+    max_q_value_xgboost_mbr_rescore::Float32,
+    min_PEP_neg_threshold_xgboost_rescore::Float32,
+    q_value_threshold::Float32,
+    max_MBR_false_transfer_rate::Float32,
 )
     if size(best_psms, 1) > 100000
         file_paths = [fpath for fpath in file_paths if endswith(fpath,".arrow")]
@@ -242,12 +260,12 @@ function score_precursor_isotope_traces_in_memory!(
         features = [f for f in features if hasproperty(best_psms, f)];
         if match_between_runs
             append!(features, [
-                :max_prob, 
-                :mean_prob, 
-                :min_prob,
-                :rv_coefficient,
-                :best_irt_diff,
-                :num_runs
+                :MBR_rv_coefficient,
+                :MBR_best_irt_diff,
+                :MBR_num_runs,
+                :MBR_max_pair_prob,
+                :MBR_log2_weight_ratio,
+                :MBR_log2_explained_ratio
                 ])
         end
 
@@ -263,6 +281,9 @@ function score_precursor_isotope_traces_in_memory!(
                                 match_between_runs;
                                 max_q_value_xgboost_rescore,
                                 max_q_value_xgboost_mbr_rescore,
+                                min_PEP_neg_threshold_xgboost_rescore,
+                                q_value_threshold = q_value_threshold,
+                                max_ftr = max_MBR_false_transfer_rate,
                                 colsample_bytree = 0.5, 
                                 colsample_bynode = 0.5,
                                 min_child_weight = 5, 
@@ -270,7 +291,7 @@ function score_precursor_isotope_traces_in_memory!(
                                 subsample = 0.25, 
                                 max_depth = 10,
                                 eta = 0.05, 
-                                iter_scheme = [100, 100, 200],
+                                iter_scheme = [100, 200, 200],
                                 print_importance = false);
         return models;#best_psms
     else
@@ -316,6 +337,9 @@ function score_precursor_isotope_traces_in_memory!(
                                 match_between_runs;
                                 max_q_value_xgboost_rescore,
                                 max_q_value_xgboost_mbr_rescore,
+                                min_PEP_neg_threshold_xgboost_rescore,
+                                q_value_threshold = q_value_threshold,
+                                max_ftr = max_MBR_false_transfer_rate,
                                 colsample_bytree = 1.0, 
                                 colsample_bynode = 1.0,
                                 min_child_weight = 1, 
@@ -349,7 +373,10 @@ function score_precursor_isotope_traces_out_of_memory!(
     precursors::LibraryPrecursors,
     match_between_runs::Bool,
     max_q_value_xgboost_rescore::Float32,
-    max_q_value_xgboost_mbr_rescore::Float32
+    max_q_value_xgboost_mbr_rescore::Float32,
+    min_PEP_neg_threshold_xgboost_rescore::Float32,
+    q_value_threshold::Float32,
+    max_MBR_false_transfer_rate::Float32
 )
     if size(best_psms, 1) > 100000
         file_paths = [fpath for fpath in file_paths if endswith(fpath,".arrow")]
@@ -407,12 +434,12 @@ function score_precursor_isotope_traces_out_of_memory!(
         features = [f for f in features if hasproperty(best_psms, f)];
         if match_between_runs
             append!(features, [
-                :max_prob, 
-                :mean_prob, 
-                :min_prob,
-                :rv_coefficient,
-                :best_irt_diff,
-                :num_runs,
+                :MBR_rv_coefficient,
+                :MBR_best_irt_diff,
+                :MBR_num_runs,
+                :MBR_max_pair_prob,
+                :MBR_log2_weight_ratio,
+                :MBR_log2_explained_ratio
                 ])
         end
 
@@ -427,6 +454,9 @@ function score_precursor_isotope_traces_out_of_memory!(
                                 match_between_runs;
                                 max_q_value_xgboost_rescore,
                                 max_q_value_xgboost_mbr_rescore,
+                                min_PEP_neg_threshold_xgboost_rescore,
+                                q_value_threshold = q_value_threshold,
+                                max_ftr = max_MBR_false_transfer_rate,
                                 colsample_bytree = 0.5, 
                                 colsample_bynode = 0.5,
                                 min_child_weight = 5, 
@@ -434,7 +464,7 @@ function score_precursor_isotope_traces_out_of_memory!(
                                 subsample = 0.25, 
                                 max_depth = 10,
                                 eta = 0.05, 
-                                iter_scheme = [100, 100, 200],
+                                iter_scheme = [100, 200, 200],
                                 print_importance = false);
         return models;#best_psms
     else
@@ -468,6 +498,9 @@ function score_precursor_isotope_traces_out_of_memory!(
                                 match_between_runs,
                                 max_q_value_xgboost_rescore,
                                 max_q_value_xgboost_mbr_rescore,
+                                min_PEP_neg_threshold_xgboost_rescore,
+                                q_value_threshold = q_value_threshold,
+                                max_ftr = max_MBR_false_transfer_rate,
                                 colsample_bytree = 1.0, 
                                 colsample_bynode = 1.0,
                                 min_child_weight = 100, 

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
@@ -147,14 +147,38 @@ function add_prec_prob(prob_col::Symbol)
 end
 
 """
+    logodds(probs::AbstractVector{T}, top_n::Int) where {T<:AbstractFloat}
+
+Combine probabilities using a log-odds average. 
+The final value is converted back to a probability via the logistic function.
+"""
+function logodds(probs::AbstractVector{T}, top_n::Int) where {T<:AbstractFloat}
+    isempty(probs) && return 0.0f0
+    n = min(length(probs), top_n)
+    # Sort descending and select the top n probabilities
+    sorted = sort(probs; rev=true)
+    selected = sorted[1:n]
+    eps = 1f-6
+    # Convert to log-odds, clip to avoid Inf or negative contribution
+    logodds = log.(clamp.(selected, 0.5f0, 1 - eps) ./ (1 .- clamp.(selected, 0.5f0, 1 - eps)))
+    avg = sum(logodds) / n
+    return 1.0f0 / (1 + exp(-avg))
+end
+
+
+"""
     add_global_prob(prob_col::Symbol)
 
-Compute experiment-wide precursor probabilities from the given probability column.
+Compute experiment-wide precursor probabilities from the given probability column
+by averaging log-odds across **all** runs. Each precursor's probabilities are
+converted to log-odds, summed, divided by the total number of runs in the
+experiment, and then mapped back to probability space. This prevents saturation
+when many runs are present.
 """
-function add_global_prob(prob_col::Symbol)
+function add_global_prob(prob_col::Symbol; top_n::Int=1)
     op = function(df)
-        transform!(groupby(df, :precursor_idx),
-                   prob_col => (p -> maximum(p)) => :global_prob)
+            transform!(groupby(df, :precursor_idx),
+                   prob_col => (p -> logodds_weighted(p, top_n)) => :global_prob)
         return df
     end
     return "add_global_prob" => op

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/SecondPassSearch.jl
@@ -378,7 +378,7 @@ function process_search_results!(
         )
 
         # Initialize probability scores (will be calculated later)
-        initialize_group_features!(psms, params.match_between_runs)
+        initialize_prob_group_features!(psms, params.match_between_runs)
         
         # Save processed results
         temp_path = joinpath(

--- a/src/Routines/SearchDIA/importScripts.jl
+++ b/src/Routines/SearchDIA/importScripts.jl
@@ -129,6 +129,7 @@ function importScripts()
         joinpath(package_root, "src", "utils", "ML"),
         [
             "fdrUtilities.jl",
+            "ftrUtilities.jl",
             "percolatorSortOf.jl",
             "piecewiseLinearFunction.jl",
             "probitRegression.jl",

--- a/src/utils/ML/ftrUtilities.jl
+++ b/src/utils/ML/ftrUtilities.jl
@@ -1,0 +1,87 @@
+"""
+False Transfer Rate (FTR) utilities.
+
+This module provides helpers to estimate score thresholds for
+match-between-runs workflows using transfer decoys.
+"""
+
+"""
+    get_ftr_threshold(scores::AbstractVector{U},
+                      is_target::AbstractVector{Bool},
+                      is_transfer_decoy::AbstractVector{Bool},
+                      alpha::Real; doSort::Bool = true,
+                      mask::Union{Nothing,AbstractVector{Bool}} = nothing) where {U<:Real}
+
+Return the minimum score threshold `τ` such that
+
+```
+FTR(τ) = (# of transfer decoys with score ≥ τ) / (# of targets with score ≥ τ)
+```
+
+is less than or equal to `alpha`.  The input vectors must be of equal
+length and correspond element-wise to candidate precursor–run pairs.
+"""
+function get_ftr_threshold(scores::AbstractVector{U},
+                           is_target::AbstractVector{Bool},
+                           is_transfer_decoy::AbstractVector{Bool},
+                           alpha::Real; doSort::Bool = true,
+                           mask::Union{Nothing,AbstractVector{Bool}} = nothing) where {U<:Real}
+    @assert length(scores) == length(is_target) == length(is_transfer_decoy)
+
+    if mask === nothing
+        order = doSort ? sortperm(scores, rev=true, alg=QuickSort) : collect(eachindex(scores))
+    else
+        selected = findall(mask)
+        order = doSort ? selected[sortperm(view(scores, selected), rev=true, alg=QuickSort)] : selected
+    end
+
+    target_cum = 0
+    transfer_cum = 0
+    τ = maximum(scores)
+    best_count = 0
+    for idx in order
+        target_cum += 1
+        transfer_cum += is_transfer_decoy[idx] ? 1 : 0
+        
+        if target_cum > 0 && (transfer_cum / target_cum) <= alpha
+            τ = scores[idx]
+            best_count = target_cum
+        end
+    end
+
+    return τ
+end
+
+"""
+    get_ftr!(scores::AbstractVector{U},
+             is_target::AbstractVector{Bool},
+             is_transfer_decoy::AbstractVector{Bool},
+             ftrs::AbstractVector{T}; doSort::Bool = true,
+             mask::Union{Nothing,AbstractVector{Bool}} = nothing) where {U<:Real,T<:Real}
+
+Compute the empirical FTR curve.  `ftrs[i]` contains the FTR for the
+candidate at `scores[i]`.
+"""
+function get_ftr!(scores::AbstractVector{U},
+                  is_target::AbstractVector{Bool},
+                  is_transfer_decoy::AbstractVector{Bool},
+                  ftrs::AbstractVector{T}; doSort::Bool = true,
+                  mask::Union{Nothing,AbstractVector{Bool}} = nothing) where {U<:Real,T<:Real}
+    @assert length(scores) == length(is_target) == length(is_transfer_decoy) == length(ftrs)
+
+    if mask === nothing
+        order = doSort ? sortperm(scores, rev=true, alg=QuickSort) : collect(eachindex(scores))
+    else
+        selected = findall(mask)
+        order = doSort ? selected[sortperm(view(scores, selected), rev=true, alg=QuickSort)] : selected
+    end
+
+    target_cum = 0
+    transfer_cum = 0
+    for idx in order
+        target_cum += is_target[idx] ? 1 : 0
+        transfer_cum += is_transfer_decoy[idx] ? 1 : 0
+        ftrs[idx] = target_cum > 0 ? (transfer_cum / target_cum) : Inf
+    end
+    return ftrs
+end

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -21,6 +21,9 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
                   match_between_runs::Bool = true;
                   max_q_value_xgboost_rescore::Float32 = 0.01f0,
                   max_q_value_xgboost_mbr_rescore::Float32 = 0.20f0,
+                  min_PEP_neg_threshold_xgboost_rescore = 0.90f0,
+                  q_value_threshold::Float32 = 0.01f0,
+                  max_ftr::Float32 = 0.01f0,
                   colsample_bytree::Float64 = 0.5,
                   colsample_bynode::Float64 = 0.5,
                   eta::Float64 = 0.15,
@@ -28,7 +31,7 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
                   subsample::Float64 = 0.5,
                   gamma::Int = 0,
                   max_depth::Int = 10,
-                  iter_scheme::Vector{Int} = [100, 100, 200],
+                  iter_scheme::Vector{Int} = [100, 200, 200],
                   print_importance::Bool = true)
     
     
@@ -42,32 +45,34 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
 
     #Final prob estimates
     prob_estimates = zeros(Float32, size(psms, 1))
-
-    #println(sum(psms.decoy), " ", sum(psms.target), " ", size(psms, 1), "\n")
+    prob_estimates_stage1 = zeros(Float32, size(psms, 1))
+    
 
     unique_cv_folds = unique(psms[!, :cv_fold])
     models = Dict{UInt8, Vector{Booster}}()
+    # Always doing MBR on the last iteration
+    mbr_start_iter = length(iter_scheme)
     
     # Train models for each fold
     Random.seed!(1776)
     pbar = ProgressBar(total=length(unique_cv_folds)*length(iter_scheme))
     for test_fold_idx in unique_cv_folds
-        #Clear prob stats 
-        clear_prob_and_group_features!(psms, match_between_runs)
+        # Clear prob stats 
+        initialize_prob_group_features!(psms, match_between_runs)
         # Get training data
         psms_train = @view(psms[findall(x -> x != test_fold_idx, psms[!, :cv_fold]), :])
         # Train models for each iteration
         fold_models = Vector{Booster}()
-        #Each round updates, max_prob, mean_prob, and min_prob, and uses these as training features in the next round 
+
         for (itr, num_round) in enumerate(iter_scheme)
-            
-            
 
             psms_train_itr = get_training_data_for_iteration!(psms_train, 
                                                                 itr,
                                                                 match_between_runs, 
                                                                 max_q_value_xgboost_rescore,
-                                                                max_q_value_xgboost_mbr_rescore)
+                                                                max_q_value_xgboost_mbr_rescore,
+                                                                min_PEP_neg_threshold_xgboost_rescore,
+                                                                itr >= mbr_start_iter)
                                          
             bst = xgboost(
                 (psms_train_itr[!, features], psms_train_itr[!, :target]),
@@ -98,12 +103,29 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
             test_fold_psms[!,:prob] = XGBoost.predict(bst, test_fold_psms[!,features])
             psms_train[!,:prob] =  XGBoost.predict(bst, psms_train[!, features])
 
+            # calculate training q-values to use for filtering the next iteration
+            get_qvalues!(psms_train.prob, psms_train.target, psms_train.q_value)
+
             if match_between_runs
-                summarize_precursors!(test_fold_psms)
-                summarize_precursors!(psms_train)
+                # Compute the MBR features if we're going to use them on the next iteration
+                if itr >= mbr_start_iter - 1
+                    # calculate q-values on hold-out to properly summarize precursors
+                    get_qvalues!(test_fold_psms.prob, test_fold_psms.target, test_fold_psms.q_value)
+                    summarize_precursors!(test_fold_psms, q_cutoff = max_q_value_xgboost_rescore)
+                    summarize_precursors!(psms_train, q_cutoff = max_q_value_xgboost_rescore)
+                end
+                # Keep track of the last non-MBR probabilites so we know which precursors are transfer candidates
+                if itr == mbr_start_iter - 1
+                    prob_estimates_stage1[test_fold_idxs] = test_fold_psms.prob
+                end
             end
 
             update(pbar)
+
+            # If we're not doing MBR, then skip the last iteration
+            if (!match_between_runs) && itr == (mbr_start_iter - 1)
+                break
+            end
         end
         # Make predictions on hold out data.
         test_fold_idxs = findall(x -> x == test_fold_idx, psms[!, :cv_fold])
@@ -112,7 +134,21 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
         models[test_fold_idx] = fold_models
     end
     psms[!,:prob] = prob_estimates
-    dropVectorColumns!(psms) # avoids writing issues
+    
+    if match_between_runs
+        # Label transfer candidates using the probabilities prior to MBR features
+        stage1_qvals = zeros(Float64, length(prob_estimates_stage1))
+        get_qvalues!(prob_estimates_stage1, psms.target, stage1_qvals)
+        psms.MBR_transfer_candidate .= (stage1_qvals .> q_value_threshold) .& !ismissing(psms.MBR_is_best_decoy)
+
+        # Estimate FTR and filter
+        is_bad_transfer = (psms.target .& [(!ismissing(d) && d) for d in psms.MBR_is_best_decoy]) .| (psms.decoy .& [(!ismissing(d) && !d) for d in psms.MBR_is_best_decoy])
+        τ = get_ftr_threshold(psms.prob, psms.target, is_bad_transfer, max_ftr; mask=psms.MBR_transfer_candidate)
+        filter!(
+            row -> !(row.MBR_transfer_candidate && row.prob < τ),
+            psms,
+        )
+    end
 
     transform!(
         groupby(psms, :precursor_idx),
@@ -123,7 +159,8 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
         groupby(psms, [:precursor_idx, :ms_file_idx]),
         :prob => (p -> 1.0f0-0.000001f0-exp(sum(log1p.(-p)))) => :prec_prob
     )
-    
+
+    dropVectorColumns!(psms) # avoids writing issues
     for (ms_file_idx, gpsms) in pairs(groupby(psms, :ms_file_idx))
         fpath = file_paths[ms_file_idx[:ms_file_idx]]
         writeArrow(fpath, gpsms)
@@ -140,6 +177,9 @@ function sort_of_percolator_out_of_memory!(psms::DataFrame,
                     match_between_runs::Bool = true; 
                     max_q_value_xgboost_rescore::Float32 = 0.01f0,
                     max_q_value_xgboost_mbr_rescore::Float32 = 0.20f0,
+                    min_PEP_neg_threshold_xgboost_rescore::Float32 = 0.90f0,
+                    q_value_threshold::Float32 = 0.01f0,
+                    max_ftr::Float32 = 0.01f0,
                     colsample_bytree::Float64 = 0.5, 
                     colsample_bynode::Float64 = 0.5,
                     eta::Float64 = 0.15, 
@@ -147,7 +187,7 @@ function sort_of_percolator_out_of_memory!(psms::DataFrame,
                     subsample::Float64 = 0.5, 
                     gamma::Int = 0, 
                     max_depth::Int = 10,
-                    iter_scheme::Vector{Int} = [100, 100, 200],
+                    iter_scheme::Vector{Int} = [100, 200, 200],
                     print_importance::Bool = true)
 
     function getBestScorePerPrec!(
@@ -164,14 +204,14 @@ function sort_of_percolator_out_of_memory!(psms::DataFrame,
     
         #Reset counts for new scores
         for (key, value) in pairs(prec_to_best_score_new)
-            max_prob, mean_prob, min_prob, n, best_log2_weights, best_irts, is_best_decoy = value
+            max_prob, mean_prob, min_prob, n, best_log2_weights, best_irts, MBR_is_best_decoy = value
             prec_to_best_score_new[key] = (max_prob = zero(Float32), 
                                             mean_prob = zero(Float32), 
                                             min_prob = one(Float32), 
                                             n = zero(UInt16),
                                             best_log2_weights = Vector{Float32}(),
                                             best_irts = Vector{Float32}(),
-                                            is_best_decoy = false)
+                                            MBR_is_best_decoy = false)
         end
             
         for file_path in file_paths
@@ -185,12 +225,12 @@ function sort_of_percolator_out_of_memory!(psms::DataFrame,
                     prob = probs[i]
                     key = (pair_id = pair_id, isotopes = psms_subset[i,:isotopes_captured])
                     if haskey(prec_to_best_score_new, key)
-                        max_prob, mean_prob, min_prob, n, best_log2_weights, best_irts, is_best_decoy = prec_to_best_score_new[key]
+                        max_prob, mean_prob, min_prob, n, best_log2_weights, best_irts, MBR_is_best_decoy = prec_to_best_score_new[key]
                         if max_prob < prob
                             max_prob = prob
                             best_log2_weights = log2.(psms_subset.weights[i])
                             best_irts = psms_subset.irts[i]
-                            is_best_decoy = psms_subset.decoy[i]
+                            MBR_is_best_decoy = psms_subset.decoy[i]
                         end
                         if min_prob > prob
                             min_prob = prob
@@ -203,7 +243,7 @@ function sort_of_percolator_out_of_memory!(psms::DataFrame,
                                                         n = n,
                                                         best_log2_weights = best_log2_weights,
                                                         best_irts = best_irts,
-                                                        is_best_decoy = is_best_decoy)
+                                                        MBR_is_best_decoy = MBR_is_best_decoy)
                     else
                         insert!(prec_to_best_score_new, key, (max_prob = prob, 
                                                                 mean_prob = prob, 
@@ -211,7 +251,7 @@ function sort_of_percolator_out_of_memory!(psms::DataFrame,
                                                                 n = one(UInt16),
                                                                 best_log2_weights = log2.(psms_subset.weights[i]),
                                                                 best_irts = psms_subset.irts[i],
-                                                                is_best_decoy = psms_subset.decoy[i]))
+                                                                MBR_is_best_decoy = psms_subset.decoy[i]))
                     end
                 end
             end
@@ -238,7 +278,7 @@ function sort_of_percolator_out_of_memory!(psms::DataFrame,
                 if match_between_runs
                     key = (pair_id = pair_id, isotopes = psms_subset[i,:isotopes_captured])
                     if haskey(prec_to_best_score_new, key)
-                        max_prob, mean_prob, min_prob, n, best_log2_weights, best_irts, is_best_decoy = prec_to_best_score_new[key]
+                        max_prob, mean_prob, min_prob, n, best_log2_weights, best_irts, MBR_is_best_decoy = prec_to_best_score_new[key]
                         psms_subset[i,:max_prob] = max_prob
                         psms_subset[i,:min_prob] = min_prob
                         if n > 0
@@ -251,10 +291,10 @@ function sort_of_percolator_out_of_memory!(psms::DataFrame,
                         best_iRTs_padded, iRTs_padded = pad_rt_equal_length(best_irts, psms_subset.irts[i])
 
                         best_irt_at_apex = best_irts[argmax(best_log2_weights)]
-                        psms_subset.best_irt_diff[i] = abs(best_irt_at_apex - psms_subset.irts[i][argmax(psms_subset.weights[i])])
-                        psms_subset.rv_coefficient[i] = rv_coefficient(best_log2_weights_padded, best_iRTs_padded, weights_padded, iRTs_padded)
-                        psms_subset.is_best_decoy[i] = is_best_decoy
-                        psms_subset.num_runs[i] = n
+                        psms_subset.MBR_best_irt_diff[i] = abs(best_irt_at_apex - psms_subset.irts[i][argmax(psms_subset.weights[i])])
+                        psms_subset.MBR_rv_coefficient[i] = MBR_rv_coefficient(best_log2_weights_padded, best_iRTs_padded, weights_padded, iRTs_padded)
+                        psms_subset.MBR_is_best_decoy[i] = MBR_is_best_decoy
+                        psms_subset.MBR_num_runs[i] = n
                     end
                 end
             end
@@ -301,7 +341,7 @@ function sort_of_percolator_out_of_memory!(psms::DataFrame,
     Random.seed!(1776);
     for test_fold_idx in unique_cv_folds#(0, 1)#range(1, n_folds)
         #Clear prob stats 
-        clear_prob_and_group_features!(psms, match_between_runs)
+        initialize_prob_group_features!(psms, match_between_runs)
         # Get training data
         psms_train = @view(psms[findall(x -> x != test_fold_idx, psms[!, :cv_fold]), :])
 
@@ -348,7 +388,7 @@ function sort_of_percolator_out_of_memory!(psms::DataFrame,
             psms_train[!,:prob] = XGBoost.predict(bst, psms_train[!, features])
             
             if match_between_runs
-                summarize_precursors!(psms_train)
+                summarize_precursors!(psms_train, q_cutoff = max_q_value_xgboost_rescore)
             end
 
             update(pbar)
@@ -364,7 +404,7 @@ function sort_of_percolator_out_of_memory!(psms::DataFrame,
                                                     n::UInt16,
                                                     best_log2_weights::Vector{Float32},
                                                     best_irts::Vector{Float32},
-                                                    is_best_decoy::Bool}}()
+                                                    MBR_is_best_decoy::Bool}}()
 
         for (train_iter, num_round) in enumerate(iter_scheme)
             model = models[test_fold_idx][train_iter]
@@ -398,72 +438,103 @@ end
 
 
 
-function summarize_precursors!(psms::AbstractDataFrame)
-    # Collect the grouped pairs so we can iterate in a threaded for loop.
-    grouped_data = collect(pairs(groupby(psms, [:pair_id, :isotopes_captured])))
-
-    Threads.@threads for idx in eachindex(grouped_data)
-        key, sub_psms = grouped_data[idx]
+function summarize_precursors!(psms::AbstractDataFrame; q_cutoff::Float32 = 0.01f0)   
+    # Compute pair specific features that rely on decoys and chromatograms
+    pair_groups = collect(pairs(groupby(psms, [:pair_id, :isotopes_captured])))
+    Threads.@threads for idx in eachindex(pair_groups)
+        _, sub_psms = pair_groups[idx]
         
-        min_prob, max_prob, mean_prob = summarize_prob(sub_psms[!,:prob])
-        best_idx = argmax(sub_psms.prob)
-        best_log2_weights = log2.(sub_psms.weights[best_idx])
-        best_iRTs = sub_psms.irts[best_idx]
+        # Efficient way to find the top 2 precursors so we can do MBR on the 
+        # best precursor match that isn't itself. It's always one of the top 2.
 
+        # single pass: record the best PSM index & prob per run
+        best_i = Dict{eltype(sub_psms.ms_file_idx), Int}()
+        best_p = Dict{eltype(sub_psms.ms_file_idx), eltype(sub_psms.prob)}()
+        for (i, run) in enumerate(sub_psms.ms_file_idx)
+            p = sub_psms.prob[i]
+            if !haskey(best_p, run) || p > best_p[run]
+                best_p[run] = p
+                best_i[run] = i
+            end
+        end
+
+        # if more than one run, find the global top-2 runs by their best-PSM prob
+        run_best_indices = Dict{eltype(sub_psms.ms_file_idx), Int}()
+        runs = collect(keys(best_i))
+        if length(runs) > 1
+            # track top two runs (r1 > r2)
+            r1 = nothing; p1 = -Inf
+            r2 = nothing; p2 = -Inf
+            for (run, p) in best_p
+                if p > p1
+                    r2, p2 = r1, p1
+                    r1, p1 = run, p
+                elseif p > p2
+                    r2, p2 = run, p
+                end
+            end
+
+            # assign, for each run, the best index in “any other” run
+            for run in runs
+                run_best_indices[run] = (run == r1 ? best_i[r2] : best_i[r1])
+            end
+        end
+
+        # Compute MBR features
         for i in 1:nrow(sub_psms)
+            sub_psms.MBR_num_runs[i] = length(unique(sub_psms.ms_file_idx[sub_psms.q_value .<= q_cutoff]))
+
+            if !haskey(run_best_indices, sub_psms.ms_file_idx[i])
+                sub_psms.MBR_best_irt_diff[i] = missing
+                sub_psms.MBR_rv_coefficient[i] = missing
+                sub_psms.MBR_is_best_decoy[i] = missing
+                sub_psms.MBR_log2_weight_ratio[i] = missing
+                sub_psms.MBR_log2_explained_ratio[i] = missing
+                sub_psms.MBR_max_pair_prob[i] = missing
+                continue
+            end
+
+            best_idx = run_best_indices[sub_psms.ms_file_idx[i]]
+            best_log2_weights = log2.(sub_psms.weights[best_idx])
+            best_iRTs = sub_psms.irts[best_idx]
             best_log2_weights_padded, weights_padded = pad_equal_length(best_log2_weights, log2.(sub_psms.weights[i]))
             best_iRTs_padded, iRTs_padded = pad_rt_equal_length(best_iRTs, sub_psms.irts[i])
-                    
+            
             best_irt_at_apex = sub_psms.irts[best_idx][argmax(best_log2_weights)]
-            sub_psms.best_irt_diff[i] = abs(best_irt_at_apex - sub_psms.irts[i][argmax(sub_psms.weights[i])])
-            sub_psms.rv_coefficient[i] = rv_coefficient(best_log2_weights_padded, best_iRTs_padded, weights_padded, iRTs_padded)
-            sub_psms.min_prob[i] = min_prob
-            sub_psms.max_prob[i] = max_prob
-            sub_psms.mean_prob[i] = mean_prob
-            sub_psms.is_best_decoy[i] = sub_psms.decoy[best_idx]
-            sub_psms.num_runs[i] = nrow(sub_psms)
+            sub_psms.MBR_max_pair_prob[i] = sub_psms.prob[best_idx]
+            sub_psms.MBR_best_irt_diff[i] = abs(best_irt_at_apex - sub_psms.irts[i][argmax(sub_psms.weights[i])])
+            sub_psms.MBR_rv_coefficient[i] = MBR_rv_coefficient(best_log2_weights_padded, best_iRTs_padded, weights_padded, iRTs_padded)
+            sub_psms.MBR_log2_weight_ratio[i] = log2(sub_psms.weight[i] / sub_psms.weight[best_idx])
+            sub_psms.MBR_log2_explained_ratio[i] = sub_psms.log2_intensity_explained[i] - sub_psms.log2_intensity_explained[best_idx]
+            sub_psms.MBR_is_best_decoy[i] = sub_psms.decoy[best_idx]
         end
     end
 
 end
 
-function clear_prob_and_group_features!(
-    psms::AbstractDataFrame,
-    match_between_runs::Bool
-)
-    # Clear main :prob column
-    psms[!, :prob] .= zero(Float32)
 
-    if match_between_runs
-        psms[!, :max_prob]       .= zero(Float32)
-        psms[!, :mean_prob]      .= zero(Float32)
-        psms[!, :min_prob]       .= zero(Float32)
-        psms[!, :rv_coefficient] .= zero(Float32)
-        psms[!, :best_irt_diff]  .= zero(Float32)
-        psms[!, :num_runs]       .= zero(Int32)
-        psms[!, :is_best_decoy]  .= zero(Bool)
-        psms[!, :q_value]        .= zero(Float64)
-    end
 
-    return psms
-end
 
-function initialize_group_features!(
+function initialize_prob_group_features!(
     psms::AbstractDataFrame,
     match_between_runs::Bool
 )
     n = nrow(psms)
-    psms[!, :prob] = zeros(Float32, n)
+    psms[!, :prob]      = zeros(Float32, n)
+    psms[!, :q_value]   = zeros(Float64, n)
 
     if match_between_runs
-        psms[!, :max_prob]       = zeros(Float32, n)
-        psms[!, :mean_prob]      = zeros(Float32, n)
-        psms[!, :min_prob]       = zeros(Float32, n)
-        psms[!, :rv_coefficient] = zeros(Float32, n)
-        psms[!, :best_irt_diff]  = zeros(Float32, n)
-        psms[!, :num_runs]       = zeros(Int32, n)
-        psms[!, :is_best_decoy]  = zeros(Bool, n)
-        psms[!, :q_value]        = zeros(Float64, n)
+        psms[!, :MBR_max_pair_prob]             = Vector{Union{Missing, Float32}}(missing, n)
+        psms[!, :MBR_best_irt_diff]             = Vector{Union{Missing, Float32}}(missing, n)
+        psms[!, :MBR_log2_weight_ratio]         = Vector{Union{Missing, Float32}}(missing, n)
+        psms[!, :MBR_log2_weight_ratio_min]     = Vector{Union{Missing, Float32}}(missing, n)
+        psms[!, :MBR_log2_explained_ratio]      = Vector{Union{Missing, Float32}}(missing, n)
+        psms[!, :MBR_rv_coefficient]            = Vector{Union{Missing, Float32}}(missing, n)
+        psms[!, :MBR_num_runs]                  = zeros(Int32, n)
+        psms[!, :MBR_is_best_decoy]                 = Vector{Union{Missing, Bool}}(missing, n)
+        psms[!, :MBR_transfer_candidate]            = falses(n)
+        allowmissing!(psms, [:MBR_max_pair_prob, :MBR_rv_coefficient,
+                              :MBR_best_irt_diff, :MBR_is_best_decoy, :MBR_log2_weight_ratio])
     end
 
     return psms
@@ -474,21 +545,33 @@ function get_training_data_for_iteration!(
     itr::Int,
     match_between_runs::Bool,
     max_q_value_xgboost_rescore::Float32,
-    max_q_value_xgboost_mbr_rescore::Float32
+    max_q_value_xgboost_mbr_rescore::Float32,
+    min_PEP_neg_threshold_xgboost_rescore::Float32,
+    last_iter::Bool
 )
-    # Train on all precursors during first iteration
-    psms_train_itr = psms_train
+   
+    if itr == 1
+        # Train on all precursors during first iteration. 
+        return psms_train
+    else
+        # Do a shallow copy to avoid overwriting target/decoy labels
+        psms_train_itr = copy(psms_train)
 
-    if itr > 1
-        # For subsequent iterations, train on top scoring precursors
-        get_qvalues!(
-            psms_train_itr[!,:prob],
-            psms_train_itr[!,:target],
-            psms_train_itr[!,:q_value]
-        )
+        # Convert the worst-scoring targets to negatives using PEP estimate
+        order = sortperm(psms_train_itr.prob, rev=true)
+        sorted_scores  = psms_train_itr.prob[order]
+        sorted_targets = psms_train_itr.target[order]
+        PEPs = Vector{Float32}(undef, length(order))
+        get_PEP!(sorted_scores, sorted_targets, PEPs; doSort=false)
+
+        idx_cutoff = findfirst(x -> x >= min_PEP_neg_threshold_xgboost_rescore, PEPs)
+        if !isnothing(idx_cutoff)
+            worst_idxs = order[idx_cutoff:end]
+            psms_train_itr.target[worst_idxs] .= false
+        end
 
         # Also train on top scoring MBR candidates if requested
-        if match_between_runs
+        if match_between_runs && last_iter
             # Determine prob threshold for precursors passing the q-value threshold
             max_prob_threshold = minimum(
                 psms_train_itr.prob[
@@ -498,40 +581,37 @@ function get_training_data_for_iteration!(
 
             # Hacky way to ensure anything passing the initial q-value threshold
             # will pass the next q-value threshold
-            psms_train.q_value[psms_train_itr.q_value .<= max_q_value_xgboost_rescore] .= 0.0
-            psms_train.q_value[psms_train_itr.q_value .> max_q_value_xgboost_rescore]  .= 1.0
+            psms_train_itr.q_value[psms_train_itr.q_value .<= max_q_value_xgboost_rescore] .= 0.0
+            psms_train_itr.q_value[psms_train_itr.q_value .> max_q_value_xgboost_rescore]  .= 1.0
 
             # Must have at least one precursor passing the q-value threshold,
             # and the best precursor can't be a decoy
             psms_train_mbr = subset(
                 psms_train_itr,
-                [:is_best_decoy, :max_prob, :prob] => ByRow((d, mp, p) ->
-                    (!d) && (mp >= max_prob_threshold) && (p < max_prob_threshold)
+                [:MBR_is_best_decoy, :MBR_max_pair_prob, :prob] => ByRow((d, mp, p) ->
+                    (!ismissing(d) && !d && !ismissing(mp) && !ismissing(p) && mp >= max_prob_threshold && p < max_prob_threshold)
                 );
                 view = true
             )
 
             # Compute MBR q-values.
-            get_qvalues!(
-                psms_train_mbr[!,:prob],
-                psms_train_mbr[!,:target],
-                psms_train_mbr[!,:q_value]
-            )
+            get_qvalues!(psms_train_mbr[!,:prob], psms_train_mbr[!,:target], psms_train_mbr[!,:q_value])
+
             # Take all decoys and targets passing q_thresh (all 0's now) or mbr_q_thresh
             psms_train_itr = subset(
-                psms_train,
+                psms_train_itr,
                 [:target, :q_value] => ByRow((t,q) -> (!t) || (t && q <= max_q_value_xgboost_mbr_rescore))
             )
         else
             # Take all decoys and targets passing q_thresh
             psms_train_itr = subset(
-                psms_train,
+                psms_train_itr,
                 [:target, :q_value] => ByRow((t,q) -> (!t) || (t && q <= max_q_value_xgboost_rescore))
             )
         end
-    end
 
-    return psms_train_itr
+        return psms_train_itr
+    end
 end
 
 
@@ -548,7 +628,7 @@ function dropVectorColumns!(df)
 end
 
 
-function rv_coefficient(weights_A::AbstractVector{<:Real},
+function MBR_rv_coefficient(weights_A::AbstractVector{<:Real},
     times_A::AbstractVector{<:Real},
     weights_B::AbstractVector{<:Real},
     times_B::AbstractVector{<:Real})

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -129,7 +129,11 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
         end
         # Make predictions on hold out data.
         test_fold_idxs = findall(x -> x == test_fold_idx, psms[!, :cv_fold])
-        MBR_estimates[test_fold_idxs] = psms[test_fold_idxs,:prob]
+        if match_between_runs
+            MBR_estimates[test_fold_idxs] = psms[test_fold_idxs,:prob]
+        else
+            prob_estimates[test_fold_idxs] = psms[test_fold_idxs,:prob]
+        end
         # Store models for this fold
         models[test_fold_idx] = fold_models
     end
@@ -143,9 +147,7 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
             max(psms.prob, coalesce(psms.MBR_max_pair_prob, psms.prob))
         )
     end
-
-
-
+    
     dropVectorColumns!(psms) # avoids writing issues
     for (ms_file_idx, gpsms) in pairs(groupby(psms, :ms_file_idx))
         fpath = file_paths[ms_file_idx[:ms_file_idx]]

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -554,11 +554,10 @@ function initialize_prob_group_features!(
     psms[!, :q_value]   = zeros(Float64, n)
 
     if match_between_runs
-        psms[!, :MBR_prob]                    = zeros(Float32, n)
+        psms[!, :MBR_prob]                      = zeros(Float32, n)
         psms[!, :MBR_max_pair_prob]             = Vector{Union{Missing, Float32}}(missing, n)
         psms[!, :MBR_best_irt_diff]             = Vector{Union{Missing, Float32}}(missing, n)
         psms[!, :MBR_log2_weight_ratio]         = Vector{Union{Missing, Float32}}(missing, n)
-        psms[!, :MBR_log2_weight_ratio_min]     = Vector{Union{Missing, Float32}}(missing, n)
         psms[!, :MBR_log2_explained_ratio]      = Vector{Union{Missing, Float32}}(missing, n)
         psms[!, :MBR_rv_coefficient]            = Vector{Union{Missing, Float32}}(missing, n)
         psms[!, :MBR_num_runs]                  = zeros(Int32, n)


### PR DESCRIPTION
1.  Updated MBR features to avoid bias towards targets.
        - dropped min and mean prob
        - max_prob is now max_pair_prob (max prob excluding itself and the match must pass the q-value threshold)
        - MBR_log2_weight_ratio - weight ratio between precursor and its best paired ID. Idea is that the low scoring one should be less abundant. 
        - MBR_log2_explained_ratio - explained ratio between precursor and its best paired ID. Idea is that the low scoring one should have more interference or be more chimeric. 			

2. Only the last iteration of XGBoost now uses MBR, and without MBR only 2 iterations are done. 

3. The last non-MBR iteration got bumped up to 200 XGBoost rounds.

4.  False transfer rate control
        - Precursors are labeled as transfer candidates if the they don't pass the q-value threshold after the last non-MBR iteration and they have an MBR match that did pass the q-value threshold
        - FTR is calculated as the number of transfer candidates where a target got matched to a decoy, plus the decoys that got matched to a target, divided by all transfer candidates (at specific MBR_prob thresholds). A decoy->decoy transfers are considered false IDs, but correct transfers. Transfer traces that don't pass this threshold are filtered out in ScoringSearch.jl
        - MBR probabilities are clamped to be max(non-MBR prob, max_pair_prob) so that they're never better than they were without MBR and never better than their MBR match.
			
5. During iterative XGBoost training, the worst scoring target precursors by PEP are relabeled as negative examples. 
        - Added a parameter for this: machine_learning.min_PEP_neg_threshold_xgboost_rescore = 0.90
			
6. Moved prec_prob and global_prob calculation from precolatorSortOf.jl to ScoringSearch.jl
			
7. Changed the global pg_score and global precursor score to from max(*) to an average log-odds score on the top log2(num_runs) for that precursor/protein. This seems to work better when the number of runs is high. 
			
8. Consolidated q-value params (max_q_value_xgboost_rescore is equal to the scoring.q_value_threshold param). The FTR threshold is also set to this value. Now if you change the scoring.q_value_threshold param to 0.05, you should actually get results up to that value. Same with 0.10.
			