### PR TITLE
MBR, PEP, and MaxLFQ alignment

### DIFF
--- a/src/Routines/SearchDIA.jl
+++ b/src/Routines/SearchDIA.jl
@@ -137,6 +137,31 @@ function SearchDIA(params_path::String)
                 @error "No .arrow files found in ms_data directory: " * MS_DATA_DIR
                 return
             end
+
+            # Disable match-between-runs if only a single run is provided
+            if length(MS_TABLE_PATHS) == 1 && params.global_settings.match_between_runs
+                @warn "Only one run detected; disabling match_between_runs (MBR)."
+
+                params_dict = JSON.parse(params_string)
+                params_dict["global"]["match_between_runs"] = false
+                params_string = JSON.json(params_dict, 4)
+
+                updated_global = (; params.global_settings..., match_between_runs=false)
+                params = PioneerParameters(
+                    updated_global,
+                    params.parameter_tuning,
+                    params.first_search,
+                    params.quant_search,
+                    params.acquisition,
+                    params.rt_alignment,
+                    params.optimization,
+                    params.protein_inference,
+                    params.maxLFQ,
+                    params.output,
+                    params.paths,
+                )
+            end
+            
             nothing
         end
         timings["Parameter Loading"] = params_timing

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
@@ -232,7 +232,7 @@ function summarize_results!(
                                reverse=[true, true])
 
             merged_df = DataFrame(Arrow.Table(merged_scores_path))
-            log_n_runs = floor(Int64, log2(length(getFilePaths(getMSData(search_context)))))
+            sqrt_n_runs = floor(Int64, sqrt(length(getFilePaths(getMSData(search_context)))))
 
             if params.match_between_runs
                 prob_col = apply_mbr_filter!(
@@ -250,7 +250,7 @@ function summarize_results!(
                            Float32(prob)
                        end) => :prec_prob)
             transform!(groupby(merged_df, :precursor_idx),
-                       :prec_prob => (p -> logodds(p, log_n_runs)) => :global_prob)
+                       :prec_prob => (p -> logodds(p, sqrt_n_runs)) => :global_prob)
             prob_col == :_filtered_prob && select!(merged_df, Not(:_filtered_prob)) # drop temp trace prob TODO maybe we want this for getting best traces
 
             # Write updated data back to individual files

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
@@ -38,6 +38,7 @@ struct ScoringSearchResults <: SearchResults
     best_traces::Dict{Int64, Float32}
     precursor_global_qval_interp::Base.Ref{Any} # Interpolation for global q-values
     precursor_qval_interp::Base.Ref{Any} # Interpolation for run-specific q-values
+    precursor_pep_interp::Base.Ref{Any}  # Interpolation for experiment-wide PEPs
     pg_qval_interp::Base.Ref{Any}       # Protein group q-value interpolation
     merged_quant_path::String # Path to merged quantification results
 end
@@ -105,6 +106,7 @@ function init_search_results(::ScoringSearchParameters, search_context::SearchCo
         Dict{Int64, Float32}(),  # best_traces
         Ref(undef),  # precursor_global_qval_interp
         Ref(undef),  # precursor_qval_interp
+        Ref(undef),  # precursor_pep_interp
         Ref(undef),  # pg_qval_interp
         joinpath(getDataOutDir(search_context), "merged_quant.arrow")
     )
@@ -163,6 +165,16 @@ function get_precursor_qval_spline(merged_path::String, params::ScoringSearchPar
 end
 
 """
+Create experiment-wide precursor PEP interpolation (all precursors).
+"""
+function get_precursor_pep_interpolation(merged_path::String, params::ScoringSearchParameters, search_context::SearchContext)
+    return get_pep_interpolation(
+        merged_path, :prec_prob;
+        fdr_scale_factor = getLibraryFdrScaleFactor(search_context),
+    )
+end
+
+"""
 Create global protein q-value spline (unique protein groups only).
 """
 function get_protein_global_qval_spline(merged_path::String, params::ScoringSearchParameters)
@@ -179,6 +191,15 @@ function get_protein_qval_spline(merged_path::String, params::ScoringSearchParam
     return get_qvalue_spline(
         merged_path, :pg_score, false;
         min_pep_points_per_bin = params.pg_q_value_interpolation_points_per_bin
+    )
+end
+
+"""
+Create experiment-wide protein group PEP interpolation (all protein groups).
+"""
+function get_protein_pep_interpolation(merged_path::String, params::ScoringSearchParameters)
+    return get_pep_interpolation(
+        merged_path, :pg_score;
     )
 end
 
@@ -314,10 +335,11 @@ function summarize_results!(
         end
         @info "Step 7 completed in $(round(step7_time, digits=2)) seconds"
 
-        # Step 8: Calculate experiment-wide precursor q-values
-        @info "Step 8: Calculating experiment-wide precursor q-values..."
+        # Step 8: Calculate experiment-wide precursor q-values and PEPs
+        @info "Step 8: Calculating experiment-wide precursor q-values and PEPs..."
         step8_time = @elapsed begin
             results.precursor_qval_interp[] = get_precursor_qval_spline(results.merged_quant_path, params, search_context)
+            results.precursor_pep_interp[]  = get_precursor_pep_interpolation(results.merged_quant_path, params, search_context)
         end
         @info "Step 8 completed in $(round(step8_time, digits=2)) seconds"
 
@@ -327,13 +349,11 @@ function summarize_results!(
             qvalue_filter_pipeline = TransformPipeline() |>
                 add_interpolated_column(:global_qval, :global_prob, results.precursor_global_qval_interp[]) |>
                 add_interpolated_column(:qval, :prec_prob, results.precursor_qval_interp[]) |>
-                add_pep_column(:pep, :prec_prob, :target;
-                               doSort=false,
-                               fdr_scale_factor=getLibraryFdrScaleFactor(search_context)) |>
+                add_interpolated_column(:pep, :prec_prob, results.precursor_pep_interp[]) |>
                 filter_by_multiple_thresholds([
                     (:global_qval, params.q_value_threshold),
                     (:qval, params.q_value_threshold)
-                ]) 
+                ])
                 
             
             passing_refs = apply_pipeline_batch(
@@ -434,10 +454,11 @@ function summarize_results!(
         end
         @info "Step 18 completed in $(round(step18_time, digits=2)) seconds"
 
-        # Step 19: Calculate experiment-wide protein q-values
-        @info "Step 19: Calculating experiment-wide protein q-values..."
+        # Step 19: Calculate experiment-wide protein q-values and PEPs
+        @info "Step 19: Calculating experiment-wide protein q-values and PEPs..."
         step19_time = @elapsed begin
             search_context.pg_score_to_qval[] = get_protein_qval_spline(sorted_pg_scores_path, params)
+            search_context.pg_score_to_pep[]  = get_protein_pep_interpolation(sorted_pg_scores_path, params)
         end
         @info "Step 19 completed in $(round(step19_time, digits=2)) seconds"
 
@@ -447,12 +468,11 @@ function summarize_results!(
             protein_qval_pipeline = TransformPipeline() |>
                 add_interpolated_column(:global_pg_qval, :global_pg_score, search_context.global_pg_score_to_qval[]) |>
                 add_interpolated_column(:pg_qval, :pg_score, search_context.pg_score_to_qval[]) |>
+                add_interpolated_column(:pg_pep, :pg_score, search_context.pg_score_to_pep[]) |> 
                 add_column(:passes_qval, df ->
                     (df.global_pg_qval .<= params.q_value_threshold) .&
-                    (df.pg_qval .<= params.q_value_threshold)) |>
-                add_pep_column(:pg_pep, :pg_score, :target;
-                            doSort=false,
-                            fdr_scale_factor=getLibraryFdrScaleFactor(search_context))
+                    (df.pg_qval .<= params.q_value_threshold))
+                
 
             apply_pipeline!(pg_refs, protein_qval_pipeline)
         end

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/protein_inference_pipeline.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/protein_inference_pipeline.jl
@@ -246,10 +246,11 @@ function group_psms_by_protein(df::DataFrame)
             entrap_id = UInt8[],
             n_peptides = Int64[],
             peptide_list = String[],
-            pg_score = Float32[]
+            pg_score = Float32[],
+            any_common_peps = Bool[]
         )
     end
-    
+
     # Group by protein
     grouped = groupby(df, [:inferred_protein_group, :target, :entrap_id])
     
@@ -273,12 +274,19 @@ function group_psms_by_protein(df::DataFrame)
                 end
             end
             pg_score = -sum(log.(1.0f0 .- unique_pep_probs))
-        end
+        end        
+
+        has_common = any(
+            (gdf.use_for_protein_quant .== true) .&
+            (gdf.missed_cleavage .== 0) .&
+            (gdf.Mox .== 0)
+        )
         
         DataFrame(
             n_peptides = n_peptides,
             peptide_list = join(quant_peptides, ";"),
-            pg_score = pg_score
+            pg_score = pg_score,
+            any_common_peps = has_common
         )
     end
     

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
@@ -321,6 +321,7 @@ function get_quant_necessary_columns()
         :rt,
         :irt_obs,
         :missed_cleavage,
+        :Mox,
         :isotopes_captured,
         :scan_idx,
         :entrapment_group_id,

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
@@ -32,7 +32,7 @@ Calculate global protein scores and add them to files via references.
 Returns the score dictionary for downstream use.
 """
 function calculate_and_add_global_scores!(pg_refs::Vector{ProteinGroupFileReference})
-    log_n_runs = max(1, floor(Int, log2(length(pg_refs))))
+    sqrt_n_runs = max(1, floor(Int, sqrt(length(pg_refs))))
     acc_to_scores = Dict{ProteinKey, Vector{Float32}}()
 
     # First pass: collect scores per protein across all files
@@ -50,7 +50,7 @@ function calculate_and_add_global_scores!(pg_refs::Vector{ProteinGroupFileRefere
     # Compute global score using log-odds combination
     acc_to_global_score = Dict{ProteinKey, Float32}()
     for (key, scores) in acc_to_scores
-        acc_to_global_score[key] = logodds(scores, log_n_runs)
+        acc_to_global_score[key] = logodds(scores, sqrt_n_runs)
     end
     
     # Second pass: add global_pg_score column and sort

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/utils.jl
@@ -842,7 +842,7 @@ function perform_probit_analysis_oom(pg_refs::Vector{ProteinGroupFileReference},
     @info "Sampled $(nrow(sampled_protein_groups)) protein groups for training"
     
     # Define features to use
-    feature_names = [:pg_score, :peptide_coverage, :n_possible_peptides, :log_binom_coeff]
+    feature_names = [:pg_score, :peptide_coverage, :n_possible_peptides, :log_binom_coeff, :any_common_peps]
     X = Matrix{Float64}(sampled_protein_groups[:, feature_names])
     y = sampled_protein_groups.target
     
@@ -914,7 +914,7 @@ function perform_probit_analysis(all_protein_groups::DataFrame, qc_folder::Strin
     n_decoys = sum(.!all_protein_groups.target)
     @info "In memory probit regression analysis" n_targets=n_targets n_decoys=n_decoys total_protein_groups=nrow(all_protein_groups)
     # Define features to use
-    feature_names = [:pg_score, :peptide_coverage, :n_possible_peptides] # :log_binom_coeff] 
+    feature_names = [:pg_score, :peptide_coverage, :n_possible_peptides, :any_common_peps] # :log_binom_coeff] 
     X = Matrix{Float64}(all_protein_groups[:, feature_names])
     y = all_protein_groups.target
     

--- a/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SearchTypes.jl
@@ -211,6 +211,7 @@ mutable struct SearchContext{N,L<:SpectralLibrary,M<:MassSpecDataReference}
     irt_obs::Dict{UInt32, Float32}
     pg_score_to_qval::Ref{Any}
     global_pg_score_to_qval::Ref{Any}
+    pg_score_to_pep::Ref{Any}
     
     # Method results storage
     method_results::Dict{Type{<:SearchMethod}, Any}
@@ -248,7 +249,7 @@ mutable struct SearchContext{N,L<:SpectralLibrary,M<:MassSpecDataReference}
             Ref{Vector{String}}(),
             Dict{Int64, Float32}(),
             Dict{UInt32, Float32}(),
-            Ref{Any}(), Ref{Any}(),
+            Ref{Any}(), Ref{Any}(), Ref{Any}(),
             Dict{Type{<:SearchMethod}, Any}(),  # Initialize method_results
             n_threads, n_precursors, buffer_size,
             0, 0, 1.0f0  # Initialize library stats with defaults

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -31,7 +31,7 @@ function sort_of_percolator_in_memory!(psms::DataFrame,
                   max_depth::Int = 10,
                   iter_scheme::Vector{Int} = [100, 200, 200],
                   print_importance::Bool = true)
-    
+
     
     #Faster if sorted first
     sort!(psms, [:pair_id, :isotopes_captured])
@@ -630,7 +630,7 @@ function get_training_data_for_iteration!(
             # Take all decoys and targets passing q_thresh (all 0's now) or mbr_q_thresh
             psms_train_itr = subset(
                 psms_train_itr,
-                [:target, :q_value] => ByRow((t,q) -> (!t) || (t && q <= max_q_value_xgboost_mbr_rescore))
+                [:target, :q_value, :MBR_is_best_decoy] => ByRow((t,q,MBR_d) -> (!t) || (t && !ismissing(MBR_d) && !MBR_d && q <= max_q_value_xgboost_mbr_rescore))
             )
         else
             # Take all decoys and targets passing q_thresh

--- a/src/utils/maxLFQ.jl
+++ b/src/utils/maxLFQ.jl
@@ -279,16 +279,33 @@ function getProtAbundance(protein::String,
         end
 
 
-        pep_val = peps[1]
+        # Map experiment → metrics using the first occurrence for each experiment
+        pep_map = Dict{UInt32, Float32}()
+        score_map = Dict{UInt32, Float32}()
+        global_score_map = Dict{UInt32, Float32}()
+        qval_map = Dict{UInt32, Float32}()
+        global_qval_map = Dict{UInt32, Float32}()
+        for j in eachindex(experiments)
+            exp = UInt32(experiments[j])
+            if !haskey(pep_map, exp)
+                pep_map[exp] = peps[j]
+                score_map[exp] = pg_scores[j]
+                global_score_map[exp] = global_pg_scores[j]
+                qval_map[exp] = qvals[j]
+                global_qval_map[exp] = global_qvals[j]
+            end
+        end
+
         for i in range(0, N-1)
+            exp = UInt32(unique_experiments[i + 1])
             log2_abundance_out[row_idx + i] = log2_abundances[i + 1]
-            global_qval_out[row_idx + i] = global_qvals[i + 1]
-            qval_out[row_idx + i] = qvals[i + 1]
-            pg_score_out[row_idx + i] = pg_scores[i + 1]
-            global_pg_score_out[row_idx + i] = global_pg_scores[i + 1]
-            experiments_out[row_idx + i] = unique_experiments[i + 1]
+            global_qval_out[row_idx + i] = global_qval_map[exp]
+            qval_out[row_idx + i] = qval_map[exp]
+            pg_score_out[row_idx + i] = score_map[exp]
+            global_pg_score_out[row_idx + i] = global_score_map[exp]
+            experiments_out[row_idx + i] = exp
             protein_out[row_idx + i] = protein
-            pep_out[row_idx + i] = pep_val
+            pep_out[row_idx + i] = pep_map[exp]
             species_out[row_idx + i] = species
             target_out[row_idx + i] = target
             entrap_id_out[row_idx + i] = entrap_id


### PR DESCRIPTION
- computing log odds global scores using sqrt(num runs) instead of log2(num runs). Slight improvement.
- if MBR is on but there's only 1 file, override MBR to false
- compute experiment-wide precursor and protein-group PEP interpolations (used to be run-specific and not interpolated)
- Some MaxLFQ PEP and q-values were being assigned to the wrong runs. The abundance was fine though. 