### PR TITLE
Generate Decoys before adding charge states. Generate entrapment and …

### DIFF
--- a/src/Routines/BuildSpecLib/chronologer/chronologer_prep.jl
+++ b/src/Routines/BuildSpecLib/chronologer/chronologer_prep.jl
@@ -137,6 +137,18 @@ function prepare_chronologer_input(
     # Process FASTA files
     fasta_entries = Vector{FastaEntry}()
     protein_entries = Vector{FastaEntry}()
+    @info "params[fasta_names]", params["fasta_names"]
+    @info "params[fasta_paths]", params["fasta_paths"]
+
+    test_zip = collect(zip(
+            params["fasta_names"],
+            params["fasta_paths"],
+            accession_rgxs,
+            gene_rgxs,
+            protein_rgxs,
+            organism_rgxs,
+        ))
+    @info "test_zip ", test_zip
     for (proteome_name, fasta, acc_rgx, gene_rgx, prot_rgx, org_rgx) in zip(
             params["fasta_names"],
             params["fasta_paths"],
@@ -174,7 +186,8 @@ function prepare_chronologer_input(
     # Add entrapment sequences if specified
     fasta_entries = add_entrapment_sequences(
         fasta_entries,
-        UInt8(_params.fasta_digest_params["entrapment_r"])
+        UInt8(_params.fasta_digest_params["entrapment_r"]),
+        fixed_chars = Vector{Char}([first(char) for char in _params.fasta_digest_params["fixed_chars"]])
     )
     #Fasta entries with the fixed and variable mods added 
     fasta_entries = add_mods(
@@ -182,16 +195,17 @@ function prepare_chronologer_input(
         fixed_mods, 
         var_mods,
         _params.fasta_digest_params["max_var_mods"])
-  
+
+    # Add decoy sequences
+    fasta_entries = add_reverse_decoys(fasta_entries,
+        fixed_chars = Vector{Char}([first(char) for char in _params.fasta_digest_params["fixed_chars"]])
+        )
+        
     fasta_entries = add_charge(
         fasta_entries,
         _params.fasta_digest_params["min_charge"],
         _params.fasta_digest_params["max_charge"]
     )
-
-    # Add decoy sequences
-    fasta_entries = add_reverse_decoys(fasta_entries)
-  
     # Build UniSpec input dataframe
     fasta_df = build_fasta_df(
         fasta_entries,


### PR DESCRIPTION
…decoy sequences by shuffling rather than by reversal

1) Decoy-by-shuffle
      Previously decoy sequences were generated by reversal and entrapment by shuffling. Now both entrapments and decoys are generated by shuffling their parent sequences 
2) Decoy-then-charge
      Previously the charge state variants of each precursor were added BEFORE generating decoys but after generating entrapments. When decoy sequences are made by shuffling, this meant that the different charge states had different sequences as well for the decoys. This is fixed by generating the decoy sequences first and then adding the charge state variants  
