### PR TITLE
Fix bounds error in rtIndexTransitionSelection

### DIFF
--- a/src/Routines/SearchDIA/CommonSearchUtils/selectTransitions/rtIndexTransitionSelection.jl
+++ b/src/Routines/SearchDIA/CommonSearchUtils/selectTransitions/rtIndexTransitionSelection.jl
@@ -88,6 +88,12 @@ function _select_transitions_impl!(
 
             # Update counters and temp storage
             precs_temp_size += 1
+            
+            # Resize array if needed to prevent bounds error
+            if precs_temp_size > length(precs_temp)
+                append!(precs_temp, Vector{UInt32}(undef, length(precs_temp)))
+            end
+            
             n += 1
             precs_temp[precs_temp_size] = prec_idx
 


### PR DESCRIPTION
Added bounds check before accessing precs_temp array to prevent BoundsError when precs_temp_size exceeds the initial array size of 5000. The fix follows the same pattern used in SecondPassSearch and IntegrateChromatogramsSearch, doubling the array size when needed.

This resolves the "attempt to access 5000-element Vector{UInt32} at index [5001]" error that occurred during Second Pass Search when processing files with many precursors in the RT window.

🤖 Generated with [Claude Code](https://claude.ai/code)