### PR TITLE
fix version extraction

### DIFF
--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -51,7 +51,7 @@ jobs:
           elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
             echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           else
-            echo "VERSION=0.0.0" >> "$GITHUB_OUTPUT"
+            echo "VERSION=v0.0.0" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Julia
@@ -140,10 +140,12 @@ jobs:
           PACKAGE=$(jq -r '.package' $info)
           MAINTAINER=$(jq -r '.maintainer' $info)
           DESCRIPTION=$(jq -r '.description' $info)
+          VERSION_WITH_V="${{ steps.get_version.outputs.VERSION }}"
+          VERSION=${VERSION_WITH_V#v}
           mkdir -p deb/DEBIAN
           cat <<EOF > deb/DEBIAN/control
           Package: $PACKAGE
-          Version: ${{ steps.get_version.outputs.VERSION }}
+          Version: $VERSION
           Architecture: amd64
           Maintainer: $MAINTAINER
           Description: $DESCRIPTION

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -55,7 +55,7 @@ jobs:
           elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
             echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           else
-            echo "VERSION=0.0.0" >> "$GITHUB_OUTPUT"
+            echo "VERSION=v0.0.0" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Julia

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -51,7 +51,7 @@ jobs:
           elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
             echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           else
-            echo "VERSION=0.0.0" >> "$GITHUB_OUTPUT"
+            echo "VERSION=v0.0.0" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Julia


### PR DESCRIPTION
Needed to strip off the "v" from the version info for linux debian because they don't allow it.
Updated the fallback version from 0.0.0 to v0.0.0 so it's consistent with how we're naming our versions