### PR TITLE
Update MBR prob handling

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/ScoringSearch.jl
@@ -272,7 +272,6 @@ function summarize_results!(
                        end) => :prec_prob)
             transform!(groupby(merged_df, :precursor_idx),
                        :prec_prob => (p -> logodds(p, sqrt_n_runs)) => :global_prob)
-            prob_col == :_filtered_prob && select!(merged_df, Not(:_filtered_prob)) # drop temp trace prob TODO maybe we want this for getting best traces
 
             # Write updated data back to individual files
             for (idx, ref) in enumerate(second_pass_refs)

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
@@ -214,26 +214,23 @@ function apply_mbr_filter!(
     fdr_scale_factor::Float32,
 )
     n = nrow(merged_df)
-
-    # 1) compute trace_qval locally
+    
+    # 1) compute q-values only for non-transfer candidates
+    candidate_mask = merged_df.MBR_transfer_candidate
+    non_mbr_mask = .!candidate_mask
     trace_qval = Vector{Float32}(undef, n)
     get_qvalues!(
-        merged_df.prob,
-        merged_df.target,
-        trace_qval;
-        fdr_scale_factor = fdr_scale_factor
+        merged_df.prob[non_mbr_mask],
+        merged_df.target[non_mbr_mask],
+        trace_qval[non_mbr_mask];
+        fdr_scale_factor = fdr_scale_factor,
     )
 
-    # 2) build boolean masks locally
-    candidate_mask = 
-        (trace_qval .> params.q_value_threshold) .& 
-        .!ismissing.(merged_df.MBR_is_best_decoy)
-
-    bad_mask =
-        candidate_mask .& (
+    # 2) identify bad transfers
+    bad_mask = candidate_mask .& (
         (merged_df.target .& coalesce.(merged_df.MBR_is_best_decoy, false)) .|
         (merged_df.decoy  .& .!coalesce.(merged_df.MBR_is_best_decoy, true))
-        )
+    )
 
     # 3) compute threshold using the local bad_mask
     τ = get_ftr_threshold(
@@ -241,14 +238,14 @@ function apply_mbr_filter!(
         merged_df.target,
         bad_mask,
         params.max_MBR_false_transfer_rate;
-        mask = candidate_mask
+        mask = candidate_mask,
     )
 
     # 4) one fused pass to clamp probs
     merged_df._filtered_prob = ifelse.(
         candidate_mask .& (merged_df.MBR_prob .< τ),
         0.0f0,
-        merged_df.MBR_prob
+        merged_df.MBR_prob,
     )
 
     # if downstream code expects a Symbol for the prob-column

--- a/src/utils/ML/ftrUtilities.jl
+++ b/src/utils/ML/ftrUtilities.jl
@@ -49,6 +49,8 @@ function get_ftr_threshold(scores::AbstractVector{U},
         end
     end
 
+    println(best_count, " ", τ, " ",  transfer_cum, " ",  target_cum, " ", transfer_cum / target_cum, " ", alpha, "\n\n")
+
     return τ
 end
 


### PR DESCRIPTION
No more clamping of MBR prob (used to be capped by the paired precursor prob)
No longer only setting MBR transfer candidates' prob to the MBR prob (now all precursors are updated)
Keeping track of transfer candidates explicitly so any that don't pass the false transfer rate are set to a prob of 0.