### PR TITLE
Fix windows and linux installer missing artifacts

### DIFF
--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -133,6 +133,15 @@ jobs:
             build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/
           chmod +x build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/pioneer
 
+      - name: Pre-download artifacts
+        shell: bash
+        run: |
+          pioneer_root="build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer"
+          dummy="$pioneer_root/dummy"
+          mkdir -p "$dummy"
+          "$pioneer_root/pioneer" params-predict "$dummy" dummy "$dummy" --params-path "$dummy/params.json"
+          rm -rf "$dummy"
+          
       - name: Package Linux .deb
         run: |
           mkdir -p deb/usr/local/Pioneer

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -129,6 +129,15 @@ jobs:
         run: |
           Copy-Item src\build\CLI\pioneer.bat build\Pioneer_${{ matrix.identifier }}/Applications/Pioneer/
 
+      - name: Pre-download artifacts
+        shell: pwsh
+        run: |
+          $pioneerRoot = "build\Pioneer_${{ matrix.identifier }}\Applications\Pioneer"
+          $dummy = "$pioneerRoot\dummy"
+          New-Item -ItemType Directory -Force -Path $dummy | Out-Null
+          & "$pioneerRoot\pioneer.bat" params-predict $dummy dummy $dummy --params-path "$dummy\params.json"
+          Remove-Item -Recurse -Force $dummy
+
       - name: Normalize version for MSI
         id: semver
         shell: pwsh

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pioneer --help
 ```
 Lists subcommands such as `predict`, `params-predict`, `search`, `params-search`, `convert-raw`, and `convert-mzml`.
 
-On the first run, Windows and Linux download IntelOpenMP and MKL; macOS performs a Gatekeeper security check.
+On the first run macOS performs a Gatekeeper security check.
 
 ## Quick Start
 A minimal end-to-end workflow is:

--- a/docs/src/user_guide/installation.md
+++ b/docs/src/user_guide/installation.md
@@ -13,7 +13,6 @@
 1. Download the installer for your operating system from the [releases page](https://github.com/nwamsley1/Pioneer.jl/releases).
 2. Run the installer. It places a `pioneer` executable on your `PATH`.
 3. On first launch:
-   * **Windows/Linux** – `pioneer` downloads IntelOpenMP and MKL the first time it runs.
    * **macOS** – Gatekeeper verifies the binary and the first run can take about a minute. Zipped binaries require manual Gatekeeper approval and are not recommended.
 4. Verify the installation:
    ```bash

--- a/docs/src/user_guide/quickstart.md
+++ b/docs/src/user_guide/quickstart.md
@@ -30,7 +30,7 @@ After installation, Pioneer is accessed from the command line. Running `pioneer 
 pioneer [options] <subcommand> [subcommand-args...]
 ```
 
-Subcommands include `search`, `predict`, `params-search`, `params-predict`, `convert-raw`, and `convert-mzml`. The first launch may download dependencies on Windows or Linux, while macOS performs a one-time Gatekeeper check.
+Subcommands include `search`, `predict`, `params-search`, `params-predict`, `convert-raw`, and `convert-mzml`. On the first launch macOS performs a one-time Gatekeeper check.
 
 A minimal end-to-end workflow is:
 


### PR DESCRIPTION
Previously, IntelOpenMP and MKL artifacts had to be downloaded the first time the binaries were executed. This caused an issue on Windows if 7zip wasn't already installed because it is needed to decompress the artifacts' .gz files. Instead the build action now executes the binaries to force their download before creating the .msi and .zip files.