### PR TITLE
FTR control and variable names

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
@@ -332,7 +332,8 @@ function train_xgboost_model_in_memory(
             :MBR_log2_weight_ratio, 
             :MBR_log2_explained_ratio,
             :MBR_rv_coefficient, 
-            :MBR_best_irt_diff
+            :MBR_best_irt_diff,
+            :MBR_is_missing
         ])
     end
     


### PR DESCRIPTION
MBR_transfer_candidates computed based off last non-MBR iteration.
Improved FTR variable names.
MBR_num_runs no longer counts the current precursor.