### PR TITLE
Second search speed up - filter by min_fraction_transmitted before spectral linear deconvolution

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
@@ -240,11 +240,8 @@ function process_file!(
             getIsolationWidthMzs(spectra)
         )
 
-        # Assuming scans that isolated too little of the precursor are not reliable to quantify
-        filter!(row -> row.precursor_fraction_transmitted >= params.min_fraction_transmitted, chromatograms)
-        
         # Integrate chromatographic peaks for each precursor
-        # Updates peak_area and new_best_scan in passing_psms   
+        # Updates peak_area and new_best_scan in passing_psms
         integrate_precursors(
             chromatograms,
             params.isotope_tracetype,

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
@@ -284,7 +284,8 @@ function build_chromatograms(
                 (getLowMz(spectra, scan_idx), getHighMz(spectra, scan_idx));
                 precursors_passing = precursors_passing,
                 isotope_err_bounds = params.isotope_err_bounds,
-                block_size = 10000
+                block_size = 10000,
+                min_fraction_transmitted = params.min_fraction_transmitted
             )
         end
 

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -195,7 +195,8 @@ function process_scans!(
                 irt_start,
                 irt_stop,
                 (getLowMz(spectra, scan_idx), getHighMz(spectra, scan_idx));
-                block_size = 10000
+                block_size = 10000,
+                min_fraction_transmitted = params.min_fraction_transmitted
             )
         end
 


### PR DESCRIPTION
Refactored transition list handling to separate fillTransitionList! into a lightweight wrapper and a new fillTransitionListPrecomputed! helper. If you already computed precursor transmission, then you can called fillTransitionListPrecomputed! directly to avoid recomputing the transmission. Otherwise, continue using fillTransitionList and it will compute the transmission first.

The RT-indexed selector now calculates each precursor’s transmitted fraction, discards those below min_fraction_transmitted, and populates transitions via the precomputed helper.

No need to filter by min_fraction_transmitted during the chromatogram integration stage anymore.