### PR TITLE
 ci(macos): fix codesign verification to target real code objects; add pkg   validation

### DIFF
--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -285,8 +285,40 @@ jobs:
             codesign_with_retry "$f"
           done
 
-          # 6) Verify code signatures once
-          codesign --verify --deep --strict --verbose=2 "$PKGROOT/usr/local/$APP"
+          # 6) Verify code signatures on actual code objects (not plain directories)
+          echo "Verifying signed frameworks…"
+          find "$PKGROOT/usr/local/$APP" -type d -name "*.framework" -print0 | \
+          while IFS= read -r -d '' fw; do
+            echo "Verify framework: $fw"
+            codesign --verify --strict --verbose=2 "$fw"
+          done
+
+          echo "Verifying app bundle executables…"
+          find "$PKGROOT/usr/local/$APP" -type f -path '*/Contents/MacOS/*' -print0 | \
+          while IFS= read -r -d '' f; do
+            echo "Verify app binary: $f"
+            codesign --verify --strict --verbose=2 "$f"
+          done
+
+          echo "Verifying CLI Mach-O executables…"
+          if [ -d "$PKGROOT/usr/local/$APP/bin" ]; then
+            find "$PKGROOT/usr/local/$APP/bin" -type f -perm -111 -print0 | \
+            while IFS= read -r -d '' f; do
+              if file -b "$f" | grep -q 'Mach-O'; then
+                echo "Verify CLI: $f"
+                codesign --verify --strict --verbose=2 "$f"
+              fi
+            done
+          fi
+
+          echo "Verifying Mach-O dylibs/plugins…"
+          find "$PKGROOT/usr/local/$APP" \( -name '*.dylib' -o -name '*.so' \) -not -path '*/.framework/*' -print0 | \
+          while IFS= read -r -d '' f; do
+            if file -b "$f" | grep -q 'Mach-O'; then
+              echo "Verify dylib/plugin: $f"
+              codesign --verify --strict --verbose=2 "$f"
+            fi
+          done
 
           mkdir -p "$PKGROOT/usr/local/bin"
           ln -sf /usr/local/Pioneer/pioneer "$PKGROOT/usr/local/bin/pioneer"
@@ -342,6 +374,13 @@ jobs:
         run: |
           cd build/Pioneer_${{ matrix.identifier }}/Applications
           zip -qr ../../../Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.zip Pioneer
+
+      - name: Validate signed pkg (release tags only)
+        if: github.event_name != 'pull_request' && env.MACOS_CERT_P12 != '' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          PKG="Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.pkg"
+          echo "Validating pkg with spctl: $PKG"
+          spctl -a -vv -t install "$PKG"
 
       - name: Upload zipped binaries
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
  Body
  Summary

  - Fix macOS CI failure caused by verifying a non–code directory with codesign.
  - Verify actual code objects and add post-sign pkg validation for tagged releases.

  Background

  - macOS workflow failed with “pkgroot/usr/local/Pioneer: code object is not signed
  at all” during codesign verification.
  - Root cause: codesign --verify was run on a directory path ($PKGROOT/usr/local/
  $APP) instead of a Mach-O code object.

  Changes

  - Replace directory-level verification with targeted checks:
      - Verify each framework bundle (*.framework).
      - Verify app bundle executables (…/Contents/MacOS/*) if present.
      - Verify CLI executables in bin/ only when Mach-O.
      - Verify Mach-O dylibs/plugins (*.dylib, *.so) outside frameworks.
  - Add spctl validation of the signed package on release tags (when Apple cert
  secrets are present).
  - Preserve existing signing order and gating:
      - Signing/notarization/stapling still only run on tagged releases with
  secrets.

  Why this works

  - codesign --verify must run on code objects. Verifying a plain directory always
  fails.
  - Verifying each signed Mach-O ensures correctness while avoiding false failures.

  Notes

  - Precompile warning (UndefVarError: show_progress) is unrelated and can be
  addressed separately.
  - No changes to entitlements or identity selection.

  Testing

  - CI will exercise verification on next tag with certs. For a full end-to-end
  test, trigger a tag build (e.g., v0.0.0-rc.1) to include signing, notarization,
  and stapling.