### PR TITLE
fix: remove debug rethrows preventing error recovery in ParameterTuni…

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ParameterTuningSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ParameterTuningSearch.jl
@@ -770,7 +770,6 @@ function process_file!(
                 throw(ErrorException("No usable MS2 scans"))
             end
         catch e
-            throw(e)
             if isa(e, ErrorException) && e.msg == "No usable MS2 scans"
                 # Re-throw our controlled exception to handle in outer catch
                 rethrow(e)
@@ -873,9 +872,7 @@ function process_file!(
             @user_error sprint(showerror, e, bt)
         catch
         end
-        # During debugging, rethrow to stop the pipeline and surface the root cause
-        rethrow(e)
-        
+
         # Set conservative defaults to allow pipeline to continue
         converged = false
         iteration_state.failed_with_exception = true


### PR DESCRIPTION
…ngSearch

Remove debugging throw(e) and rethrow(e) statements left from commit d2d0026c that prevented fallback/recovery logic from executing when errors occurred.

Changes:
- Line 773: Removed unconditional throw(e) in FilteredSpectra creation catch
- Line 877: Removed unconditional rethrow(e) in outer catch block

This restores intended behavior where files with errors use conservative default parameters and allow the pipeline to continue rather than aborting.

Fixes issue where File 3 TaskFailedException caused pipeline abort instead of graceful degradation to defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)