### PR TITLE
Migrate github action to macos-15-intel

### DIFF
--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         include:
           - arch: x64
-            runner: macos-13
+            runner: macos-15-intel
             identifier: macos-x64
           - arch: arm64
             runner: macos-latest


### PR DESCRIPTION
The macOS 13 runner image will be retired by December 4th, 2025. We're using that to compile the osx Intel x64 version. This migrates us to the new intel runner: macos-15-intel