### PR TITLE
fix: order regression search jobs by dataset order

### DIFF
--- a/.claude/plans/rt_dependent_tolerance_plan.md
+++ b/.claude/plans/rt_dependent_tolerance_plan.md
@@ -1,0 +1,303 @@
+# RT-Dependent Tolerance Implementation Plan
+
+## Current System Analysis
+
+### How RT Tolerance Currently Works
+
+**1. Calculation (FirstPassSearch/utils.jl:664-706)**
+```julia
+function get_irt_errs(fwhms, prec_to_irt, params)
+    # Peak width contribution: median_fwhm + n_std * MAD(fwhm)
+    fwhms = map(x -> x[:median_fwhm] + params.fwhm_nstd * x[:mad_fwhm], fwhms)
+
+    # Cross-run variance: sqrt(var_irt / (n-1)) for precursors in >2 runs
+    variance_ = collect(skipmissing(
+        map(x -> (x[:n] > 2) ? sqrt(x[:var_irt]/(x[:n] - 1)) : missing, prec_to_irt)
+    ))
+    irt_std = isempty(variance_) ? 0.0f0 : median(variance_) * params.irt_nstd
+
+    # Final: peak_fwhm + cross_run_std (single value per file)
+    return map(x -> Float32(x + irt_std), fwhms)
+end
+```
+
+**2. Storage (SearchTypes.jl:226)**
+```julia
+irt_errors::Dict{Int64, Float32}  # Single value per file
+```
+
+**3. Usage Pattern (11 locations across 5 search methods)**
+```julia
+irt_tol = getIrtErrors(search_context)[ms_file_idx]  # Static per file
+irt = getRtIrtModel(search_context, ms_file_idx)(observed_rt)
+window = [irt - irt_tol, irt + irt_tol]  # Symmetric, constant width
+```
+
+### The Problem
+
+- **Single tolerance value per file** - doesn't account for:
+  - Peak width variation across gradient (often wider at start/end)
+  - RT prediction accuracy varying with iRT (less calibration data at extremes)
+  - Chromatographic effects (band broadening at high RT)
+
+- **Real-world observation**: LC gradients typically show:
+  - Wider peaks at gradient start (loading effects)
+  - Narrower peaks in middle
+  - Broader peaks at end (column equilibration)
+
+---
+
+## Proposed Solution: iRT-Dependent Tolerance Spline
+
+### Approach Overview
+
+1. **Bin PSMs by iRT** during FirstPassSearch tolerance calculation
+2. **Calculate local tolerance** for each iRT bin
+3. **Fit a smoothing spline** to tolerance vs iRT
+4. **Store as callable model** (similar to existing RT conversion models)
+5. **Evaluate at query time** to get iRT-specific tolerance
+
+### Design Decision: Spline-Based Model
+
+**Why spline instead of lookup table?**
+- Smooth transitions between regions
+- Handles sparse data gracefully
+- Consistent with existing RT model infrastructure
+- Natural extrapolation at edges
+
+---
+
+## Implementation Details
+
+### Step 1: Create New Model Type
+
+**File: `src/Routines/SearchDIA/SearchMethods/SearchTypes.jl`**
+
+```julia
+# New struct for iRT-dependent tolerance
+struct IrtDependentTolerance
+    spline::UniformSpline    # Tolerance as function of iRT
+    min_tol::Float32         # Floor tolerance (prevent too narrow)
+    max_tol::Float32         # Ceiling tolerance (prevent too wide)
+end
+
+# Make it callable
+function (model::IrtDependentTolerance)(irt::Float32)
+    raw_tol = model.spline(irt)
+    return clamp(raw_tol, model.min_tol, model.max_tol)
+end
+
+# Fallback for backward compatibility
+struct ConstantTolerance
+    value::Float32
+end
+(model::ConstantTolerance)(irt::Float32) = model.value
+
+# Union type for storage
+const IrtTolerance = Union{IrtDependentTolerance, ConstantTolerance, Float32}
+```
+
+**Update storage type:**
+```julia
+# Change from:
+irt_errors::Dict{Int64, Float32}
+# To:
+irt_errors::Dict{Int64, IrtTolerance}
+```
+
+### Step 2: Modify Tolerance Calculation
+
+**File: `src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl`**
+
+```julia
+function get_irt_errs_dependent(
+    psms::DataFrame,          # PSMs with :irt_predicted, :fwhm columns
+    n_bins::Int = 10,         # Number of iRT bins
+    min_psms_per_bin::Int = 50,
+    params::FirstPassSearchParameters
+)::Dictionary{Int64, IrtTolerance}
+
+    result = Dictionary{Int64, IrtTolerance}()
+
+    for file_idx in unique(psms.ms_file_idx)
+        file_psms = filter(row -> row.ms_file_idx == file_idx, psms)
+
+        if nrow(file_psms) < min_psms_per_bin * 3
+            # Too few PSMs - fall back to constant tolerance
+            result[file_idx] = ConstantTolerance(calculate_constant_tolerance(file_psms, params))
+            continue
+        end
+
+        # Bin by iRT
+        irt_range = extrema(file_psms.irt_predicted)
+        bin_edges = range(irt_range[1], irt_range[2], length=n_bins+1)
+
+        bin_tolerances = Float32[]
+        bin_centers = Float32[]
+
+        for i in 1:n_bins
+            bin_mask = (file_psms.irt_predicted .>= bin_edges[i]) .&
+                       (file_psms.irt_predicted .< bin_edges[i+1])
+            bin_psms = file_psms[bin_mask, :]
+
+            if nrow(bin_psms) >= min_psms_per_bin
+                # Calculate local tolerance: median FWHM + MAD * scale
+                local_fwhm = median(bin_psms.fwhm)
+                local_mad = mad(bin_psms.fwhm, normalize=true)
+                local_tol = local_fwhm + params.fwhm_nstd * local_mad
+
+                push!(bin_tolerances, local_tol)
+                push!(bin_centers, (bin_edges[i] + bin_edges[i+1]) / 2)
+            end
+        end
+
+        if length(bin_tolerances) >= 3
+            # Fit smoothing spline
+            tol_spline = UniformSpline(
+                Float32.(bin_tolerances),
+                Float32.(bin_centers),
+                3,  # cubic
+                min(length(bin_tolerances) - 1, 5)  # limited knots for smoothness
+            )
+
+            result[file_idx] = IrtDependentTolerance(
+                tol_spline,
+                minimum(bin_tolerances) * 0.5f0,  # min floor
+                maximum(bin_tolerances) * 2.0f0   # max ceiling
+            )
+        else
+            # Fall back to constant
+            result[file_idx] = ConstantTolerance(median(bin_tolerances))
+        end
+    end
+
+    return result
+end
+```
+
+### Step 3: Update Usage Locations (11 places)
+
+**Pattern change:**
+
+```julia
+# OLD (constant tolerance):
+irt_tol = getIrtErrors(search_context)[ms_file_idx]
+
+# NEW (evaluate at specific iRT):
+irt_tol_model = getIrtErrors(search_context)[ms_file_idx]
+irt_tol = irt_tol_model(irt)  # Evaluate spline at current iRT
+```
+
+**Files to update:**
+1. `SecondPassSearch/utils.jl` - Lines 169, 374
+2. `HuberTuningSearch/utils.jl` - Line 218
+3. `IntegrateChromatogramsSearch/utils.jl` - Lines 244, 478
+4. `LibrarySearch.jl` - Lines 242, 263
+5. `ParameterTuningSearch.jl` - Lines 166, 855
+
+### Step 4: Backward Compatibility
+
+```julia
+# Getter that handles both old Float32 and new model types
+function get_irt_tolerance(search_context, file_idx, irt::Float32)
+    tol = getIrtErrors(search_context)[file_idx]
+    if tol isa Float32
+        return tol
+    else
+        return tol(irt)
+    end
+end
+```
+
+---
+
+## Alternative Approaches Considered
+
+### Option A: Percentile-Based Scaling
+```julia
+# Scale tolerance by RT percentile
+irt_percentile = (irt - irt_min) / (irt_max - irt_min)
+scale_factor = 1.0 + 0.5 * abs(irt_percentile - 0.5)  # Higher at edges
+adjusted_tol = base_tol * scale_factor
+```
+**Pros:** Simple, no spline fitting
+**Cons:** Assumes U-shaped pattern, not data-driven
+
+### Option B: Lookup Table with Interpolation
+```julia
+# Store tolerance array, interpolate at query time
+struct TolLookup
+    irt_points::Vector{Float32}
+    tol_values::Vector{Float32}
+end
+```
+**Pros:** Fast lookup
+**Cons:** Discrete jumps, more storage
+
+### Option C: Piecewise Linear (Selected for simplicity alternative)
+```julia
+# Three-region model: early, middle, late
+struct PiecewiseTolerance
+    early_tol::Float32
+    mid_tol::Float32
+    late_tol::Float32
+    breakpoint_1::Float32
+    breakpoint_2::Float32
+end
+```
+**Pros:** Very simple, interpretable
+**Cons:** Sharp transitions, may not fit all gradients
+
+---
+
+## Recommended Implementation Order
+
+1. **Phase 1: Data Collection** (minimal code change)
+   - Add FWHM binning to FirstPassSearch diagnostic output
+   - Log tolerance vs iRT relationship to verify assumption
+
+2. **Phase 2: Model Implementation**
+   - Add `IrtDependentTolerance` type
+   - Implement spline fitting in `get_irt_errs_dependent`
+   - Update storage type
+
+3. **Phase 3: Integration**
+   - Update all 11 usage locations
+   - Add backward compatibility layer
+   - Test with existing config files
+
+4. **Phase 4: Configuration**
+   - Add parameter to enable/disable RT-dependent tolerance
+   - Add `min_psms_for_dependent` threshold
+
+---
+
+## Verification Plan
+
+1. **Unit Tests:**
+   - Test `IrtDependentTolerance` evaluation
+   - Test fallback to constant tolerance
+   - Test spline fitting with synthetic data
+
+2. **Integration Tests:**
+   - Run SearchDIA with RT-dependent tolerance enabled
+   - Compare PSM counts vs constant tolerance
+   - Check that early/late RT regions have appropriate tolerances
+
+3. **Visual Verification:**
+   - Plot tolerance vs iRT curve for each file
+   - Compare to FWHM distribution across gradient
+
+---
+
+## Key Files to Modify
+
+| File | Changes |
+|------|---------|
+| `SearchTypes.jl` | Add `IrtDependentTolerance`, update storage type |
+| `FirstPassSearch/utils.jl` | Add `get_irt_errs_dependent()` |
+| `SecondPassSearch/utils.jl` | Update 2 locations to evaluate at iRT |
+| `HuberTuningSearch/utils.jl` | Update 1 location |
+| `IntegrateChromatogramsSearch/utils.jl` | Update 2 locations |
+| `LibrarySearch.jl` | Update 2 locations |
+| `ParameterTuningSearch.jl` | Update 2 locations |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -9,9 +9,40 @@ on:
         options:
           - all
           - fast
-          - test
           - fastest
-        default: test
+          - APMS_Astral
+          - EWZ_2P_MBR_Exploris
+          - KEAP1KO_Eclipse
+          - MTAC_3P_Alternating
+          - MTAC_3P_Standard
+          - MTAC_Yeast_Alternating_3min
+          - MTAC_Yeast_Alternating_5min
+          - MTAC_Yeast_Standard_3min
+          - MTAC_Yeast_Standard_5min
+          - Olsen_Astral_3P
+          - Olsen_Exploris_3P
+          - SCIEX_3P
+          - SCP_Astral_10ng_3ms
+          - SCP_Astral_10ng_6ms
+          - SCP_Astral_10ng_12ms
+          - SCP_Astral_10ng_24ms
+          - SCP_Astral_250pg_3ms
+          - SCP_Astral_250pg_6ms
+          - SCP_Astral_250pg_12ms
+          - SCP_Astral_250pg_24ms
+          - SCP_Astral_500pg_3ms
+          - SCP_Astral_500pg_6ms
+          - SCP_Astral_500pg_12ms
+          - SCP_Astral_500pg_24ms
+          - SCP_Astral_1000pg_3ms
+          - SCP_Astral_1000pg_6ms
+          - SCP_Astral_1000pg_12ms
+          - SCP_Astral_1000pg_24ms
+          - SCP_Astral_MBR
+          - Seer_Astral_45
+          - Seer_Astral_single
+          - YEAST_KO_Astral
+        default: all
 
 permissions:
   contents: write
@@ -26,7 +57,7 @@ jobs:
     strategy:
       matrix:
         version: ['1.11']
-        regression_set: ${{ github.event_name == 'release' && fromJSON('["all"]') || (github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["fastest","fast","all"]')) }}
+        regression_set: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["all"]') }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -62,6 +93,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
+          entrapment_ref="codex/add-max_points-and-bin_size-to-plotting-functions-srqvs5"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"
@@ -81,20 +113,23 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' ENTRAPMENT_REF='${entrapment_ref}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
 
+            regression_branch="codex/update-run_efdr_analysis-parameters-o07uog"
             if [ -d regression-configs/.git ]; then
               git -C regression-configs fetch --all
-              git -C regression-configs remote set-head origin -a
-              regression_branch="$(git -C regression-configs symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')"
-              git -C regression-configs checkout "$regression_branch"
-              git -C regression-configs reset --hard "origin/${regression_branch}"
             else
               git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
             fi
+            if [ ! -d regression-configs/.git ]; then
+              echo "Missing regression-configs repo after clone" >&2
+              exit 1
+            fi
+            git -C regression-configs checkout --force "$regression_branch"
+            git -C regression-configs reset --hard "origin/${regression_branch}"
 
             if [ -d "$PIONEER_DIR/.git" ]; then
               git -C "$PIONEER_DIR" fetch --all --tags
@@ -112,6 +147,14 @@ jobs:
               git -C "$ENTRAPMENT_DIR" fetch --all --tags
             else
               git clone "$ENTRAPMENT_REPO_URL" "$ENTRAPMENT_DIR"
+            fi
+            if [ -n "${ENTRAPMENT_REF:-}" ]; then
+              if git -C "$ENTRAPMENT_DIR" cat-file -e "${ENTRAPMENT_REF}^{commit}" 2>/dev/null; then
+                git -C "$ENTRAPMENT_DIR" checkout --force "$ENTRAPMENT_REF"
+              else
+                git -C "$ENTRAPMENT_DIR" fetch --depth=1 origin "$ENTRAPMENT_REF"
+                git -C "$ENTRAPMENT_DIR" checkout --force FETCH_HEAD
+              fi
             fi
 
             mkdir -p "$DEPOT_DIR"
@@ -181,22 +224,22 @@ jobs:
             fi
 
             dataset_filter=""
-            # dataset_tags.json schema: { "dataset-name": ["tag1", "tag2", ...], ... }
+            # dataset_tags.json schema: { "datasets": { "dataset-name": { "order": 1, "tags": ["tag1"] } } }
+            tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
+            if [ ! -f "$tags_path" ]; then
+              echo "Missing dataset tags file at $tags_path" >&2
+              exit 1
+            fi
+            python_cmd="python3"
+            if ! command -v python3 >/dev/null 2>&1; then
+              python_cmd="python"
+            fi
+            if ! command -v "$python_cmd" >/dev/null 2>&1; then
+              echo "Python not available on cluster; cannot parse dataset tags." >&2
+              exit 1
+            fi
             if [ "${REGRESSION_SET:-all}" != "all" ]; then
               dataset_tag="${REGRESSION_SET}"
-              tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
-              if [ ! -f "$tags_path" ]; then
-                echo "Missing dataset tags file at $tags_path" >&2
-                exit 1
-              fi
-              python_cmd="python3"
-              if ! command -v python3 >/dev/null 2>&1; then
-                python_cmd="python"
-              fi
-              if ! command -v "$python_cmd" >/dev/null 2>&1; then
-                echo "Python not available on cluster; cannot parse dataset tags." >&2
-                exit 1
-              fi
               dataset_filter=$(
                 "$python_cmd" -c 'import json,sys; data=json.load(open(sys.argv[1])); datasets=data.get("datasets", {}); tag=sys.argv[2]; print(",".join([n for n,v in datasets.items() if isinstance(v, dict) and tag in (v.get("tags") or [])]))' "$tags_path" "$dataset_tag"
               )
@@ -208,7 +251,9 @@ jobs:
             echo "Regression set: ${REGRESSION_SET:-all}"
             echo "Dataset filter: ${dataset_filter:-<all>}"
 
-            param_list=$(find "$PARAMS_DIR" -type f -name 'search*.json' -print)
+            param_list=$(
+              "$python_cmd" -c 'import glob,json,os,sys; params_dir=sys.argv[1]; tags_path=sys.argv[2]; allowed=sys.argv[3].split(",") if sys.argv[3] else None; data=json.load(open(tags_path)); datasets=data.get("datasets", {}); order_for=lambda name: datasets.get(name, {}).get("order", 10**9); items=[]; [items.extend((order_for(ds), ds, p) for p in sorted(glob.glob(os.path.join(params_dir, ds, "search*.json")))) for ds in os.listdir(params_dir) if os.path.isdir(os.path.join(params_dir, ds)) and (not allowed or ds in allowed)]; items.sort(key=lambda x: (x[0], x[1], x[2])); print("\n".join([p for _,_,p in items]))' "$PARAMS_DIR" "$tags_path" "${dataset_filter:-}"
+            )
 
             if [ -z "$param_list" ]; then
               echo "No parameter JSON files found in $PARAMS_DIR" >&2

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -284,9 +284,7 @@ jobs:
               rel_path="${param_file#${PARAMS_DIR}/}"
               dataset_dir_name="${rel_path%%/*}"
               search_name="$(basename "${rel_path%.*}")"
-              adjusted_path="$ADJUSTED_PARAMS_DIR/$rel_path"
               param_basename="$(basename "$param_file")"
-              mkdir -p "$(dirname "$adjusted_path")"
               if [ -n "${dataset_filter:-}" ]; then
                 dataset_allowed=0
                 IFS=',' read -r -a allowed_datasets <<< "$dataset_filter"
@@ -323,7 +321,7 @@ jobs:
                 )
               fi
 
-              sed "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file" > "$adjusted_path"
+              sed -i "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file"
 
               echo "${dataset_name}" >> "$manifest_file"
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -9,9 +9,47 @@ on:
         options:
           - all
           - fast
-          - test
           - fastest
-        default: test
+          - APMS_Astral
+          - EWZ_2P_MBR_Exploris
+          - KEAP1KO_Eclipse
+          - MTAC_3P_Alternating
+          - MTAC_3P_Standard
+          - MTAC_Yeast_Alternating_3min
+          - MTAC_Yeast_Alternating_5min
+          - MTAC_Yeast_Standard_3min
+          - MTAC_Yeast_Standard_5min
+          - Olsen_Astral_3P
+          - Olsen_Exploris_3P
+          - SCIEX_3P
+          - SCP_Astral_10ng_3ms
+          - SCP_Astral_10ng_6ms
+          - SCP_Astral_10ng_12ms
+          - SCP_Astral_10ng_24ms
+          - SCP_Astral_250pg_3ms
+          - SCP_Astral_250pg_6ms
+          - SCP_Astral_250pg_12ms
+          - SCP_Astral_250pg_24ms
+          - SCP_Astral_500pg_3ms
+          - SCP_Astral_500pg_6ms
+          - SCP_Astral_500pg_12ms
+          - SCP_Astral_500pg_24ms
+          - SCP_Astral_1000pg_3ms
+          - SCP_Astral_1000pg_6ms
+          - SCP_Astral_1000pg_12ms
+          - SCP_Astral_1000pg_24ms
+          - SCP_Astral_MBR
+          - Seer_Astral_45
+          - Seer_Astral_single
+          - YEAST_KO_Astral
+        default: all
+      delete_results:
+        description: Delete search results after metrics (set false to archive all results)
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "true"
 
 permissions:
   contents: write
@@ -26,7 +64,7 @@ jobs:
     strategy:
       matrix:
         version: ['1.11']
-        regression_set: ${{ github.event_name == 'release' && fromJSON('["all"]') || (github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["fastest","fast","all"]')) }}
+        regression_set: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["all"]') }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -62,6 +100,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
+          entrapment_ref="codex/add-max_points-and-bin_size-to-plotting-functions-srqvs5"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"
@@ -81,20 +120,23 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' ENTRAPMENT_REF='${entrapment_ref}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
 
+            regression_branch="codex/update-run_efdr_analysis-parameters-o07uog"
             if [ -d regression-configs/.git ]; then
               git -C regression-configs fetch --all
-              git -C regression-configs remote set-head origin -a
-              regression_branch="$(git -C regression-configs symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')"
-              git -C regression-configs checkout "$regression_branch"
-              git -C regression-configs reset --hard "origin/${regression_branch}"
             else
               git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
             fi
+            if [ ! -d regression-configs/.git ]; then
+              echo "Missing regression-configs repo after clone" >&2
+              exit 1
+            fi
+            git -C regression-configs checkout --force "$regression_branch"
+            git -C regression-configs reset --hard "origin/${regression_branch}"
 
             if [ -d "$PIONEER_DIR/.git" ]; then
               git -C "$PIONEER_DIR" fetch --all --tags
@@ -113,6 +155,14 @@ jobs:
             else
               git clone "$ENTRAPMENT_REPO_URL" "$ENTRAPMENT_DIR"
             fi
+            if [ -n "${ENTRAPMENT_REF:-}" ]; then
+              if git -C "$ENTRAPMENT_DIR" cat-file -e "${ENTRAPMENT_REF}^{commit}" 2>/dev/null; then
+                git -C "$ENTRAPMENT_DIR" checkout --force "$ENTRAPMENT_REF"
+              else
+                git -C "$ENTRAPMENT_DIR" fetch --depth=1 origin "$ENTRAPMENT_REF"
+                git -C "$ENTRAPMENT_DIR" checkout --force FETCH_HEAD
+              fi
+            fi
 
             mkdir -p "$DEPOT_DIR"
           EOF
@@ -127,6 +177,7 @@ jobs:
           SETUP_JOB_SCRIPT: ${{ vars.SETUP_JOB_SCRIPT }}
           METRICS_JOB_SCRIPT: ${{ vars.METRICS_JOB_SCRIPT }}
           REGRESSION_SET: ${{ github.event_name == 'workflow_dispatch' && inputs.regression_set || matrix.regression_set }}
+          PIONEER_DELETE_RESULTS: ${{ github.event_name == 'workflow_dispatch' && inputs.delete_results || 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -153,8 +204,9 @@ jobs:
           )
 
           timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-            "RUN_DIR='${remote_run_dir}' PARAMS_DIR='${params_dir}' REGRESSION_CONFIGS_DIR='${regression_configs_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' METRICS_SCRIPT='${metrics_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' REGRESSION_SET='${regression_set}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
+            "RUN_DIR='${remote_run_dir}' PARAMS_DIR='${params_dir}' REGRESSION_CONFIGS_DIR='${regression_configs_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' METRICS_SCRIPT='${metrics_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' REGRESSION_SET='${regression_set}' PIONEER_DELETE_RESULTS='${PIONEER_DELETE_RESULTS}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
+            PIONEER_DELETE_RESULTS="${PIONEER_DELETE_RESULTS:-true}"
 
             if [ ! -f "$SETUP_SCRIPT" ]; then
               echo "Missing setup job script: $SETUP_SCRIPT" >&2
@@ -181,22 +233,22 @@ jobs:
             fi
 
             dataset_filter=""
-            # dataset_tags.json schema: { "dataset-name": ["tag1", "tag2", ...], ... }
+            # dataset_tags.json schema: { "datasets": { "dataset-name": { "order": 1, "tags": ["tag1"] } } }
+            tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
+            if [ ! -f "$tags_path" ]; then
+              echo "Missing dataset tags file at $tags_path" >&2
+              exit 1
+            fi
+            python_cmd="python3"
+            if ! command -v python3 >/dev/null 2>&1; then
+              python_cmd="python"
+            fi
+            if ! command -v "$python_cmd" >/dev/null 2>&1; then
+              echo "Python not available on cluster; cannot parse dataset tags." >&2
+              exit 1
+            fi
             if [ "${REGRESSION_SET:-all}" != "all" ]; then
               dataset_tag="${REGRESSION_SET}"
-              tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
-              if [ ! -f "$tags_path" ]; then
-                echo "Missing dataset tags file at $tags_path" >&2
-                exit 1
-              fi
-              python_cmd="python3"
-              if ! command -v python3 >/dev/null 2>&1; then
-                python_cmd="python"
-              fi
-              if ! command -v "$python_cmd" >/dev/null 2>&1; then
-                echo "Python not available on cluster; cannot parse dataset tags." >&2
-                exit 1
-              fi
               dataset_filter=$(
                 "$python_cmd" -c 'import json,sys; data=json.load(open(sys.argv[1])); datasets=data.get("datasets", {}); tag=sys.argv[2]; print(",".join([n for n,v in datasets.items() if isinstance(v, dict) and tag in (v.get("tags") or [])]))' "$tags_path" "$dataset_tag"
               )
@@ -208,7 +260,9 @@ jobs:
             echo "Regression set: ${REGRESSION_SET:-all}"
             echo "Dataset filter: ${dataset_filter:-<all>}"
 
-            param_list=$(find "$PARAMS_DIR" -type f -name 'search*.json' -print)
+            param_list=$(
+              "$python_cmd" -c 'import glob,json,os,sys; params_dir=sys.argv[1]; tags_path=sys.argv[2]; allowed=sys.argv[3].split(",") if sys.argv[3] else None; data=json.load(open(tags_path)); datasets=data.get("datasets", {}); order_for=lambda name: datasets.get(name, {}).get("order", 10**9); items=[]; [items.extend((order_for(ds), ds, p) for p in sorted(glob.glob(os.path.join(params_dir, ds, "search*.json")))) for ds in os.listdir(params_dir) if os.path.isdir(os.path.join(params_dir, ds)) and (not allowed or ds in allowed)]; items.sort(key=lambda x: (x[0], x[1], x[2])); print("\n".join([p for _,_,p in items]))' "$PARAMS_DIR" "$tags_path" "${dataset_filter:-}"
+            )
 
             if [ -z "$param_list" ]; then
               echo "No parameter JSON files found in $PARAMS_DIR" >&2
@@ -353,6 +407,7 @@ jobs:
               metrics_submit=$(\
                 RUN_DIR="$RUN_DIR" \
                 PIONEER_DATASET_NAME="$dataset_name" \
+                PIONEER_DELETE_RESULTS="$PIONEER_DELETE_RESULTS" \
                 bsub -w "$dep_expr" < "$METRICS_SCRIPT")
 
               metrics_job_id=$(printf '%s\n' "$metrics_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -88,11 +88,11 @@ jobs:
           echo "$CLUSTER_RUN_ROOT"
 
           remote_run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
-          remote_run_root="${remote_run_root_raw%/}"
+          remote_run_root="${remote_run_root_raw%/}/runs"
           run_suffix="run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}"
           remote_run_dir="${remote_run_root}/${run_suffix}"
           mount_run_root_raw="/mnt/ris/Active/Automation/Pioneer"
-          mount_run_root="${mount_run_root_raw%/}"
+          mount_run_root="${mount_run_root_raw%/}/runs"
           mount_run_dir="${mount_run_root}/${run_suffix}"
           pioneer_dir="${remote_run_dir}/pioneer"
           entrapment_dir="${remote_run_dir}/PioneerEntrapment.jl"
@@ -183,8 +183,9 @@ jobs:
           set -euo pipefail
 
           remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
+          remote_run_root="${remote_run_root%/}/runs"
           remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}}"
-          mount_run_dir="${CLUSTER_RUN_DIR_MOUNT:-/mnt/ris/Active/Automation/Pioneer/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}}"
+          mount_run_dir="${CLUSTER_RUN_DIR_MOUNT:-/mnt/ris/Active/Automation/Pioneer/runs/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}}"
           params_dir="${remote_run_dir}/regression-configs/params"
           regression_configs_dir="${remote_run_dir}/regression-configs"
           job_script_path="${remote_run_dir}/${REGRESSION_JOB_SCRIPT:-regression-configs/job_scripts/search_dia.bsub}"
@@ -717,7 +718,7 @@ jobs:
 
           remote_run_dir="${CLUSTER_RUN_DIR:?CLUSTER_RUN_DIR not set}"
           run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
-          run_root="${run_root_raw%/}"
+          run_root="${run_root_raw%/}/runs"
           develop_dir="${run_root}/metrics/develop"
 
           ssh_options=(
@@ -774,7 +775,7 @@ jobs:
 
           remote_run_dir="${CLUSTER_RUN_DIR:?CLUSTER_RUN_DIR not set}"
           run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
-          run_root="${run_root_raw%/}"
+          run_root="${run_root_raw%/}/runs"
           release_tag="${RELEASE_TAG:?RELEASE_TAG not set}"
           release_dir="${run_root}/release/${release_tag}"
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -40,7 +40,6 @@ jobs:
           GITHUB_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           GITHUB_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           CLUSTER_ENTRAPMENT_REPO: ${{ secrets.CLUSTER_ENTRAPMENT_REPO }}
-          CLUSTER_ENTRAPMENT_REF: ${{ secrets.CLUSTER_ENTRAPMENT_REF }}
           REGRESSION_SET: ${{ github.event_name == 'workflow_dispatch' && inputs.regression_set || matrix.regression_set }}
         shell: bash
         run: |
@@ -63,7 +62,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
-          entrapment_ref="${CLUSTER_ENTRAPMENT_REF:-}"
+          entrapment_ref="codex/add-max_points-and-bin_size-to-plotting-functions-srqvs5"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -730,7 +730,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' DEVELOP_DIR='${develop_dir}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
             lock_dir="${DEVELOP_DIR}.lock"
@@ -788,7 +788,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' RELEASE_DIR='${release_dir}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
 
@@ -831,7 +831,7 @@ jobs:
             -o ConnectTimeout=30
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' REPORT_PATH='${report_path}' REPORT_SUBDIR='${report_subdir}' HISTORY_BRANCH='${history_branch}' GITHUB_REPOSITORY='${GITHUB_REPOSITORY}' GITHUB_TOKEN='${GITHUB_TOKEN}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -284,7 +284,9 @@ jobs:
               rel_path="${param_file#${PARAMS_DIR}/}"
               dataset_dir_name="${rel_path%%/*}"
               search_name="$(basename "${rel_path%.*}")"
+              adjusted_path="$ADJUSTED_PARAMS_DIR/$rel_path"
               param_basename="$(basename "$param_file")"
+              mkdir -p "$(dirname "$adjusted_path")"
               if [ -n "${dataset_filter:-}" ]; then
                 dataset_allowed=0
                 IFS=',' read -r -a allowed_datasets <<< "$dataset_filter"
@@ -321,7 +323,7 @@ jobs:
                 )
               fi
 
-              sed -i "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file"
+              sed "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file" > "$adjusted_path"
 
               echo "${dataset_name}" >> "$manifest_file"
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -301,17 +301,11 @@ jobs:
                 fi
               fi
 
-              results_path=$(sed -n 's/.*"results"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' "$param_file" | head -n 1)
-
-              if [ -z "$results_path" ]; then
-                echo "Failed to locate results path in $param_file" >&2
-                exit 1
-              fi
-
-              base_results=${results_path%/}
-              adjusted_results="${base_results}/${RUN_ID_SUFFIX}"
-              dataset_name="$(basename "$(dirname "$adjusted_results")")"
+              results_root="/scratch2/fs1/d.goldfarb/pioneer-regression/search"
+              adjusted_results="${results_root}/${dataset_dir_name}/${RUN_ID_SUFFIX}/${search_name}"
+              dataset_name="$dataset_dir_name"
               escaped_results=$(printf '%s\n' "$adjusted_results" | sed 's/[&/]/\\&/g')
+              mkdir -p "$adjusted_results"
               resource_basename="${param_basename/search/resources}"
               resource_file="$(dirname "$param_file")/${resource_basename}"
               cpus=8

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -58,7 +58,7 @@ permissions:
 jobs:
   regression:
     name: Julia ${{ matrix.version }} regression sweep (${{ matrix.regression_set }})
-    environment: regression-tests-${{ matrix.regression_set }}
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'regression-tests-manual' || format('regression-tests-{0}', matrix.regression_set) }}
     runs-on: [self-hosted, Linux, pioneer-regression]
     timeout-minutes: 7200
     strategy:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -301,8 +301,15 @@ jobs:
                 fi
               fi
 
-              results_root="/scratch2/fs1/d.goldfarb/pioneer-regression/search"
-              adjusted_results="${results_root}/${dataset_dir_name}/${RUN_ID_SUFFIX}/${search_name}"
+              results_path=$(sed -n 's/.*"results"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' "$param_file" | head -n 1)
+
+              if [ -z "$results_path" ]; then
+                echo "Failed to locate results path in $param_file" >&2
+                exit 1
+              fi
+
+              base_results=${results_path%/}
+              adjusted_results="${base_results}/${RUN_ID_SUFFIX}"
               dataset_name="$dataset_dir_name"
               escaped_results=$(printf '%s\n' "$adjusted_results" | sed 's/[&/]/\\&/g')
               mkdir -p "$adjusted_results"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -209,7 +209,7 @@ jobs:
             echo "Dataset filter: ${dataset_filter:-<all>}"
 
             param_list=$(
-              "$python_cmd" -c 'import glob,json,os,sys; params_dir=sys.argv[1]; tags_path=sys.argv[2]; allowed=sys.argv[3].split(",") if sys.argv[3] else None; data=json.load(open(tags_path)); datasets=data.get("datasets", {}); def order_for(name): v=datasets.get(name, {}); return v.get("order", 10**9); items=[]; [items.extend((order_for(ds), ds, p) for p in sorted(glob.glob(os.path.join(params_dir, ds, "search*.json")))) for ds in os.listdir(params_dir) if os.path.isdir(os.path.join(params_dir, ds)) and (not allowed or ds in allowed)]; items.sort(key=lambda x: (x[0], x[1], x[2])); print("\n".join([p for _,_,p in items]))' "$PARAMS_DIR" "$tags_path" "${dataset_filter:-}"
+              "$python_cmd" -c 'import glob,json,os,sys; params_dir=sys.argv[1]; tags_path=sys.argv[2]; allowed=sys.argv[3].split(",") if sys.argv[3] else None; data=json.load(open(tags_path)); datasets=data.get("datasets", {}); order_for=lambda name: datasets.get(name, {}).get("order", 10**9); items=[]; [items.extend((order_for(ds), ds, p) for p in sorted(glob.glob(os.path.join(params_dir, ds, "search*.json")))) for ds in os.listdir(params_dir) if os.path.isdir(os.path.join(params_dir, ds)) and (not allowed or ds in allowed)]; items.sort(key=lambda x: (x[0], x[1], x[2])); print("\n".join([p for _,_,p in items]))' "$PARAMS_DIR" "$tags_path" "${dataset_filter:-}"
             )
 
             if [ -z "$param_list" ]; then

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -100,7 +100,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
-          entrapment_ref="codex/add-max_points-and-bin_size-to-plotting-functions-srqvs5"
+          entrapment_ref="main"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"
@@ -125,7 +125,7 @@ jobs:
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
 
-            regression_branch="codex/update-run_efdr_analysis-parameters-o07uog"
+            regression_branch="main"
             if [ -d regression-configs/.git ]; then
               git -C regression-configs fetch --all
             else

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -181,22 +181,22 @@ jobs:
             fi
 
             dataset_filter=""
-            # dataset_tags.json schema: { "dataset-name": ["tag1", "tag2", ...], ... }
+            # dataset_tags.json schema: { "datasets": { "dataset-name": { "order": 1, "tags": ["tag1"] } } }
+            tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
+            if [ ! -f "$tags_path" ]; then
+              echo "Missing dataset tags file at $tags_path" >&2
+              exit 1
+            fi
+            python_cmd="python3"
+            if ! command -v python3 >/dev/null 2>&1; then
+              python_cmd="python"
+            fi
+            if ! command -v "$python_cmd" >/dev/null 2>&1; then
+              echo "Python not available on cluster; cannot parse dataset tags." >&2
+              exit 1
+            fi
             if [ "${REGRESSION_SET:-all}" != "all" ]; then
               dataset_tag="${REGRESSION_SET}"
-              tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
-              if [ ! -f "$tags_path" ]; then
-                echo "Missing dataset tags file at $tags_path" >&2
-                exit 1
-              fi
-              python_cmd="python3"
-              if ! command -v python3 >/dev/null 2>&1; then
-                python_cmd="python"
-              fi
-              if ! command -v "$python_cmd" >/dev/null 2>&1; then
-                echo "Python not available on cluster; cannot parse dataset tags." >&2
-                exit 1
-              fi
               dataset_filter=$(
                 "$python_cmd" -c 'import json,sys; data=json.load(open(sys.argv[1])); datasets=data.get("datasets", {}); tag=sys.argv[2]; print(",".join([n for n,v in datasets.items() if isinstance(v, dict) and tag in (v.get("tags") or [])]))' "$tags_path" "$dataset_tag"
               )
@@ -208,7 +208,9 @@ jobs:
             echo "Regression set: ${REGRESSION_SET:-all}"
             echo "Dataset filter: ${dataset_filter:-<all>}"
 
-            param_list=$(find "$PARAMS_DIR" -type f -name 'search*.json' -print)
+            param_list=$(
+              "$python_cmd" -c 'import glob,json,os,sys; params_dir=sys.argv[1]; tags_path=sys.argv[2]; allowed=sys.argv[3].split(",") if sys.argv[3] else None; data=json.load(open(tags_path)); datasets=data.get("datasets", {}); def order_for(name): v=datasets.get(name, {}); return v.get("order", 10**9); items=[]; [items.extend((order_for(ds), ds, p) for p in sorted(glob.glob(os.path.join(params_dir, ds, "search*.json")))) for ds in os.listdir(params_dir) if os.path.isdir(os.path.join(params_dir, ds)) and (not allowed or ds in allowed)]; items.sort(key=lambda x: (x[0], x[1], x[2])); print("\n".join([p for _,_,p in items]))' "$PARAMS_DIR" "$tags_path" "${dataset_filter:-}"
+            )
 
             if [ -z "$param_list" ]; then
               echo "No parameter JSON files found in $PARAMS_DIR" >&2

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -40,6 +40,7 @@ jobs:
           GITHUB_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           GITHUB_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           CLUSTER_ENTRAPMENT_REPO: ${{ secrets.CLUSTER_ENTRAPMENT_REPO }}
+          CLUSTER_ENTRAPMENT_REF: ${{ secrets.CLUSTER_ENTRAPMENT_REF }}
           REGRESSION_SET: ${{ github.event_name == 'workflow_dispatch' && inputs.regression_set || matrix.regression_set }}
         shell: bash
         run: |
@@ -62,6 +63,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
+          entrapment_ref="${CLUSTER_ENTRAPMENT_REF:-}"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"
@@ -81,7 +83,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' ENTRAPMENT_REF='${entrapment_ref}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
@@ -112,6 +114,14 @@ jobs:
               git -C "$ENTRAPMENT_DIR" fetch --all --tags
             else
               git clone "$ENTRAPMENT_REPO_URL" "$ENTRAPMENT_DIR"
+            fi
+            if [ -n "${ENTRAPMENT_REF:-}" ]; then
+              if git -C "$ENTRAPMENT_DIR" cat-file -e "${ENTRAPMENT_REF}^{commit}" 2>/dev/null; then
+                git -C "$ENTRAPMENT_DIR" checkout --force "$ENTRAPMENT_REF"
+              else
+                git -C "$ENTRAPMENT_DIR" fetch --depth=1 origin "$ENTRAPMENT_REF"
+                git -C "$ENTRAPMENT_DIR" checkout --force FETCH_HEAD
+              fi
             fi
 
             mkdir -p "$DEPOT_DIR"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -87,15 +87,18 @@ jobs:
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
 
+            regression_branch="codex/update-run_efdr_analysis-parameters-o07uog"
             if [ -d regression-configs/.git ]; then
               git -C regression-configs fetch --all
-              git -C regression-configs remote set-head origin -a
-              regression_branch="$(git -C regression-configs symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')"
-              git -C regression-configs checkout "$regression_branch"
-              git -C regression-configs reset --hard "origin/${regression_branch}"
             else
               git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
             fi
+            if [ ! -d regression-configs/.git ]; then
+              echo "Missing regression-configs repo after clone" >&2
+              exit 1
+            fi
+            git -C regression-configs checkout --force "$regression_branch"
+            git -C regression-configs reset --hard "origin/${regression_branch}"
 
             if [ -d "$PIONEER_DIR/.git" ]; then
               git -C "$PIONEER_DIR" fetch --all --tags

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -203,7 +203,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' PARAMS_DIR='${params_dir}' REGRESSION_CONFIGS_DIR='${regression_configs_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' METRICS_SCRIPT='${metrics_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' REGRESSION_SET='${regression_set}' PIONEER_DELETE_RESULTS='${PIONEER_DELETE_RESULTS}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
             PIONEER_DELETE_RESULTS="${PIONEER_DELETE_RESULTS:-true}"
@@ -847,7 +847,7 @@ jobs:
               fi
             else
               rm -rf "$repo_dir"
-              if git clone --branch "$HISTORY_BRANCH" "$repo_url" "$repo_dir"; then
+              if git clone --branch "$HISTORY_BRANCH" --depth 1 --filter=blob:none "$repo_url" "$repo_dir"; then
                 :
               else
                 git init "$repo_dir"

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -308,17 +308,11 @@ jobs:
                 fi
               fi
 
-              results_path=$(sed -n 's/.*"results"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' "$param_file" | head -n 1)
-
-              if [ -z "$results_path" ]; then
-                echo "Failed to locate results path in $param_file" >&2
-                exit 1
-              fi
-
-              base_results=${results_path%/}
-              adjusted_results="${base_results}/${RUN_ID_SUFFIX}"
-              dataset_name="$(basename "$(dirname "$adjusted_results")")"
+              results_root="/scratch2/fs1/d.goldfarb/pioneer-regression/search"
+              adjusted_results="${results_root}/${dataset_dir_name}/${RUN_ID_SUFFIX}/${search_name}"
+              dataset_name="$dataset_dir_name"
               escaped_results=$(printf '%s\n' "$adjusted_results" | sed 's/[&/]/\\&/g')
+              mkdir -p "$adjusted_results"
               resource_basename="${param_basename/search/resources}"
               resource_file="$(dirname "$param_file")/${resource_basename}"
               cpus=8

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -95,11 +95,11 @@ jobs:
           echo "$CLUSTER_RUN_ROOT"
 
           remote_run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
-          remote_run_root="${remote_run_root_raw%/}"
+          remote_run_root="${remote_run_root_raw%/}/runs"
           run_suffix="run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}"
           remote_run_dir="${remote_run_root}/${run_suffix}"
           mount_run_root_raw="/mnt/ris/Active/Automation/Pioneer"
-          mount_run_root="${mount_run_root_raw%/}"
+          mount_run_root="${mount_run_root_raw%/}/runs"
           mount_run_dir="${mount_run_root}/${run_suffix}"
           pioneer_dir="${remote_run_dir}/pioneer"
           entrapment_dir="${remote_run_dir}/PioneerEntrapment.jl"
@@ -190,8 +190,9 @@ jobs:
           set -euo pipefail
 
           remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
+          remote_run_root="${remote_run_root%/}/runs"
           remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}}"
-          mount_run_dir="${CLUSTER_RUN_DIR_MOUNT:-/mnt/ris/Active/Automation/Pioneer/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}}"
+          mount_run_dir="${CLUSTER_RUN_DIR_MOUNT:-/mnt/ris/Active/Automation/Pioneer/runs/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}}"
           params_dir="${remote_run_dir}/regression-configs/params"
           regression_configs_dir="${remote_run_dir}/regression-configs"
           job_script_path="${remote_run_dir}/${REGRESSION_JOB_SCRIPT:-regression-configs/job_scripts/slurm/search_dia.sbatch}"
@@ -723,7 +724,7 @@ jobs:
 
           remote_run_dir="${CLUSTER_RUN_DIR:?CLUSTER_RUN_DIR not set}"
           run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
-          run_root="${run_root_raw%/}"
+          run_root="${run_root_raw%/}/runs"
           develop_dir="${run_root}/metrics/develop"
 
           ssh_options=(
@@ -780,7 +781,7 @@ jobs:
 
           remote_run_dir="${CLUSTER_RUN_DIR:?CLUSTER_RUN_DIR not set}"
           run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
-          run_root="${run_root_raw%/}"
+          run_root="${run_root_raw%/}/runs"
           release_tag="${RELEASE_TAG:?RELEASE_TAG not set}"
           release_dir="${run_root}/release/${release_tag}"
 

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -291,9 +291,7 @@ jobs:
               rel_path="${param_file#${PARAMS_DIR}/}"
               dataset_dir_name="${rel_path%%/*}"
               search_name="$(basename "${rel_path%.*}")"
-              adjusted_path="$ADJUSTED_PARAMS_DIR/$rel_path"
               param_basename="$(basename "$param_file")"
-              mkdir -p "$(dirname "$adjusted_path")"
               if [ -n "${dataset_filter:-}" ]; then
                 dataset_allowed=0
                 IFS=',' read -r -a allowed_datasets <<< "$dataset_filter"
@@ -330,7 +328,7 @@ jobs:
                 )
               fi
 
-              sed "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file" > "$adjusted_path"
+              sed -i "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file"
 
               echo "${dataset_name}" >> "$manifest_file"
 

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -94,15 +94,18 @@ jobs:
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
 
+            regression_branch="codex/update-run_efdr_analysis-parameters-o07uog"
             if [ -d regression-configs/.git ]; then
               git -C regression-configs fetch --all
-              git -C regression-configs remote set-head origin -a
-              regression_branch="$(git -C regression-configs symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')"
-              git -C regression-configs checkout "$regression_branch"
-              git -C regression-configs reset --hard "origin/${regression_branch}"
             else
               git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
             fi
+            if [ ! -d regression-configs/.git ]; then
+              echo "Missing regression-configs repo after clone" >&2
+              exit 1
+            fi
+            git -C regression-configs checkout --force "$regression_branch"
+            git -C regression-configs reset --hard "origin/${regression_branch}"
 
             if [ -d "$PIONEER_DIR/.git" ]; then
               git -C "$PIONEER_DIR" fetch --all --tags

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -736,7 +736,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' DEVELOP_DIR='${develop_dir}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
             lock_dir="${DEVELOP_DIR}.lock"
@@ -794,7 +794,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' RELEASE_DIR='${release_dir}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
 
@@ -837,7 +837,7 @@ jobs:
             -o ConnectTimeout=30
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' REPORT_PATH='${report_path}' REPORT_SUBDIR='${report_subdir}' HISTORY_BRANCH='${history_branch}' GITHUB_REPOSITORY='${GITHUB_REPOSITORY}' GITHUB_TOKEN='${GITHUB_TOKEN}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
 

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -47,7 +47,6 @@ jobs:
           GITHUB_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           GITHUB_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           CLUSTER_ENTRAPMENT_REPO: ${{ secrets.CLUSTER_ENTRAPMENT_REPO }}
-          CLUSTER_ENTRAPMENT_REF: ${{ secrets.CLUSTER_ENTRAPMENT_REF }}
           REGRESSION_SET: ${{ github.event_name == 'workflow_dispatch' && inputs.regression_set || matrix.regression_set }}
         shell: bash
         run: |
@@ -70,7 +69,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
-          entrapment_ref="${CLUSTER_ENTRAPMENT_REF:-}"
+          entrapment_ref="codex/add-max_points-and-bin_size-to-plotting-functions-srqvs5"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -16,9 +16,47 @@ on:
         options:
           - all
           - fast
-          - test
           - fastest
-        default: test
+          - APMS_Astral
+          - EWZ_2P_MBR_Exploris
+          - KEAP1KO_Eclipse
+          - MTAC_3P_Alternating
+          - MTAC_3P_Standard
+          - MTAC_Yeast_Alternating_3min
+          - MTAC_Yeast_Alternating_5min
+          - MTAC_Yeast_Standard_3min
+          - MTAC_Yeast_Standard_5min
+          - Olsen_Astral_3P
+          - Olsen_Exploris_3P
+          - SCIEX_3P
+          - SCP_Astral_10ng_3ms
+          - SCP_Astral_10ng_6ms
+          - SCP_Astral_10ng_12ms
+          - SCP_Astral_10ng_24ms
+          - SCP_Astral_250pg_3ms
+          - SCP_Astral_250pg_6ms
+          - SCP_Astral_250pg_12ms
+          - SCP_Astral_250pg_24ms
+          - SCP_Astral_500pg_3ms
+          - SCP_Astral_500pg_6ms
+          - SCP_Astral_500pg_12ms
+          - SCP_Astral_500pg_24ms
+          - SCP_Astral_1000pg_3ms
+          - SCP_Astral_1000pg_6ms
+          - SCP_Astral_1000pg_12ms
+          - SCP_Astral_1000pg_24ms
+          - SCP_Astral_MBR
+          - Seer_Astral_45
+          - Seer_Astral_single
+          - YEAST_KO_Astral
+        default: all
+      delete_results:
+        description: Delete search results after metrics (set false to archive all results)
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "true"
 
 permissions:
   contents: write
@@ -33,7 +71,7 @@ jobs:
     strategy:
       matrix:
         version: ['1.11']
-        regression_set: ${{ github.event_name == 'release' && fromJSON('["all"]') || (github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["fastest","fast","all"]')) }}
+        regression_set: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["all"]') }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -69,6 +107,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
+          entrapment_ref="codex/add-max_points-and-bin_size-to-plotting-functions-srqvs5"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"
@@ -88,20 +127,23 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' ENTRAPMENT_REF='${entrapment_ref}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
 
+            regression_branch="codex/update-run_efdr_analysis-parameters-o07uog"
             if [ -d regression-configs/.git ]; then
               git -C regression-configs fetch --all
-              git -C regression-configs remote set-head origin -a
-              regression_branch="$(git -C regression-configs symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')"
-              git -C regression-configs checkout "$regression_branch"
-              git -C regression-configs reset --hard "origin/${regression_branch}"
             else
               git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
             fi
+            if [ ! -d regression-configs/.git ]; then
+              echo "Missing regression-configs repo after clone" >&2
+              exit 1
+            fi
+            git -C regression-configs checkout --force "$regression_branch"
+            git -C regression-configs reset --hard "origin/${regression_branch}"
 
             if [ -d "$PIONEER_DIR/.git" ]; then
               git -C "$PIONEER_DIR" fetch --all --tags
@@ -120,6 +162,14 @@ jobs:
             else
               git clone "$ENTRAPMENT_REPO_URL" "$ENTRAPMENT_DIR"
             fi
+            if [ -n "${ENTRAPMENT_REF:-}" ]; then
+              if git -C "$ENTRAPMENT_DIR" cat-file -e "${ENTRAPMENT_REF}^{commit}" 2>/dev/null; then
+                git -C "$ENTRAPMENT_DIR" checkout --force "$ENTRAPMENT_REF"
+              else
+                git -C "$ENTRAPMENT_DIR" fetch --depth=1 origin "$ENTRAPMENT_REF"
+                git -C "$ENTRAPMENT_DIR" checkout --force FETCH_HEAD
+              fi
+            fi
 
             mkdir -p "$DEPOT_DIR"
           EOF
@@ -134,6 +184,7 @@ jobs:
           SETUP_JOB_SCRIPT: ${{ vars.SETUP_JOB_SCRIPT }}
           METRICS_JOB_SCRIPT: ${{ vars.METRICS_JOB_SCRIPT }}
           REGRESSION_SET: ${{ github.event_name == 'workflow_dispatch' && inputs.regression_set || matrix.regression_set }}
+          PIONEER_DELETE_RESULTS: ${{ github.event_name == 'workflow_dispatch' && inputs.delete_results || 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -160,8 +211,9 @@ jobs:
           )
 
           timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-            "RUN_DIR='${remote_run_dir}' PARAMS_DIR='${params_dir}' REGRESSION_CONFIGS_DIR='${regression_configs_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' METRICS_SCRIPT='${metrics_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' REGRESSION_SET='${regression_set}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
+            "RUN_DIR='${remote_run_dir}' PARAMS_DIR='${params_dir}' REGRESSION_CONFIGS_DIR='${regression_configs_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' METRICS_SCRIPT='${metrics_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' REGRESSION_SET='${regression_set}' PIONEER_DELETE_RESULTS='${PIONEER_DELETE_RESULTS}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
+            PIONEER_DELETE_RESULTS="${PIONEER_DELETE_RESULTS:-true}"
 
             if [ ! -f "$SETUP_SCRIPT" ]; then
               echo "Missing setup job script: $SETUP_SCRIPT" >&2
@@ -188,22 +240,22 @@ jobs:
             fi
 
             dataset_filter=""
-            # dataset_tags.json schema: { "dataset-name": ["tag1", "tag2", ...], ... }
+            # dataset_tags.json schema: { "datasets": { "dataset-name": { "order": 1, "tags": ["tag1"] } } }
+            tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
+            if [ ! -f "$tags_path" ]; then
+              echo "Missing dataset tags file at $tags_path" >&2
+              exit 1
+            fi
+            python_cmd="python3"
+            if ! command -v python3 >/dev/null 2>&1; then
+              python_cmd="python"
+            fi
+            if ! command -v "$python_cmd" >/dev/null 2>&1; then
+              echo "Python not available on cluster; cannot parse dataset tags." >&2
+              exit 1
+            fi
             if [ "${REGRESSION_SET:-all}" != "all" ]; then
               dataset_tag="${REGRESSION_SET}"
-              tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
-              if [ ! -f "$tags_path" ]; then
-                echo "Missing dataset tags file at $tags_path" >&2
-                exit 1
-              fi
-              python_cmd="python3"
-              if ! command -v python3 >/dev/null 2>&1; then
-                python_cmd="python"
-              fi
-              if ! command -v "$python_cmd" >/dev/null 2>&1; then
-                echo "Python not available on cluster; cannot parse dataset tags." >&2
-                exit 1
-              fi
               dataset_filter=$(
                 "$python_cmd" -c 'import json,sys; data=json.load(open(sys.argv[1])); datasets=data.get("datasets", {}); tag=sys.argv[2]; print(",".join([n for n,v in datasets.items() if isinstance(v, dict) and tag in (v.get("tags") or [])]))' "$tags_path" "$dataset_tag"
               )
@@ -215,7 +267,9 @@ jobs:
             echo "Regression set: ${REGRESSION_SET:-all}"
             echo "Dataset filter: ${dataset_filter:-<all>}"
 
-            param_list=$(find "$PARAMS_DIR" -type f -name 'search*.json' -print)
+            param_list=$(
+              "$python_cmd" -c 'import glob,json,os,sys; params_dir=sys.argv[1]; tags_path=sys.argv[2]; allowed=sys.argv[3].split(",") if sys.argv[3] else None; data=json.load(open(tags_path)); datasets=data.get("datasets", {}); order_for=lambda name: datasets.get(name, {}).get("order", 10**9); items=[]; [items.extend((order_for(ds), ds, p) for p in sorted(glob.glob(os.path.join(params_dir, ds, "search*.json")))) for ds in os.listdir(params_dir) if os.path.isdir(os.path.join(params_dir, ds)) and (not allowed or ds in allowed)]; items.sort(key=lambda x: (x[0], x[1], x[2])); print("\n".join([p for _,_,p in items]))' "$PARAMS_DIR" "$tags_path" "${dataset_filter:-}"
+            )
 
             if [ -z "$param_list" ]; then
               echo "No parameter JSON files found in $PARAMS_DIR" >&2
@@ -358,6 +412,7 @@ jobs:
               metrics_submit=$(\
                 RUN_DIR="$RUN_DIR" \
                 PIONEER_DATASET_NAME="$dataset_name" \
+                PIONEER_DELETE_RESULTS="$PIONEER_DELETE_RESULTS" \
                 sbatch --dependency=afterany:"$dep_list" "$METRICS_SCRIPT")
 
               metrics_job_id=$(printf '%s\n' "$metrics_submit" | sed -n 's/Submitted batch job \([0-9]\+\).*/\1/p' | head -n 1)

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -216,7 +216,7 @@ jobs:
             echo "Dataset filter: ${dataset_filter:-<all>}"
 
             param_list=$(
-              "$python_cmd" -c 'import glob,json,os,sys; params_dir=sys.argv[1]; tags_path=sys.argv[2]; allowed=sys.argv[3].split(",") if sys.argv[3] else None; data=json.load(open(tags_path)); datasets=data.get("datasets", {}); def order_for(name): v=datasets.get(name, {}); return v.get("order", 10**9); items=[]; [items.extend((order_for(ds), ds, p) for p in sorted(glob.glob(os.path.join(params_dir, ds, "search*.json")))) for ds in os.listdir(params_dir) if os.path.isdir(os.path.join(params_dir, ds)) and (not allowed or ds in allowed)]; items.sort(key=lambda x: (x[0], x[1], x[2])); print("\n".join([p for _,_,p in items]))' "$PARAMS_DIR" "$tags_path" "${dataset_filter:-}"
+              "$python_cmd" -c 'import glob,json,os,sys; params_dir=sys.argv[1]; tags_path=sys.argv[2]; allowed=sys.argv[3].split(",") if sys.argv[3] else None; data=json.load(open(tags_path)); datasets=data.get("datasets", {}); order_for=lambda name: datasets.get(name, {}).get("order", 10**9); items=[]; [items.extend((order_for(ds), ds, p) for p in sorted(glob.glob(os.path.join(params_dir, ds, "search*.json")))) for ds in os.listdir(params_dir) if os.path.isdir(os.path.join(params_dir, ds)) and (not allowed or ds in allowed)]; items.sort(key=lambda x: (x[0], x[1], x[2])); print("\n".join([p for _,_,p in items]))' "$PARAMS_DIR" "$tags_path" "${dataset_filter:-}"
             )
 
             if [ -z "$param_list" ]; then

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -291,7 +291,9 @@ jobs:
               rel_path="${param_file#${PARAMS_DIR}/}"
               dataset_dir_name="${rel_path%%/*}"
               search_name="$(basename "${rel_path%.*}")"
+              adjusted_path="$ADJUSTED_PARAMS_DIR/$rel_path"
               param_basename="$(basename "$param_file")"
+              mkdir -p "$(dirname "$adjusted_path")"
               if [ -n "${dataset_filter:-}" ]; then
                 dataset_allowed=0
                 IFS=',' read -r -a allowed_datasets <<< "$dataset_filter"
@@ -328,7 +330,7 @@ jobs:
                 )
               fi
 
-              sed -i "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file"
+              sed "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file" > "$adjusted_path"
 
               echo "${dataset_name}" >> "$manifest_file"
 

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -107,7 +107,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
-          entrapment_ref="codex/add-max_points-and-bin_size-to-plotting-functions-srqvs5"
+          entrapment_ref="main"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"
@@ -132,7 +132,7 @@ jobs:
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
 
-            regression_branch="codex/update-run_efdr_analysis-parameters-o07uog"
+            regression_branch="main"
             if [ -d regression-configs/.git ]; then
               git -C regression-configs fetch --all
             else

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -16,9 +16,40 @@ on:
         options:
           - all
           - fast
-          - test
           - fastest
-        default: test
+          - APMS_Astral
+          - EWZ_2P_MBR_Exploris
+          - KEAP1KO_Eclipse
+          - MTAC_3P_Alternating
+          - MTAC_3P_Standard
+          - MTAC_Yeast_Alternating_3min
+          - MTAC_Yeast_Alternating_5min
+          - MTAC_Yeast_Standard_3min
+          - MTAC_Yeast_Standard_5min
+          - Olsen_Astral_3P
+          - Olsen_Exploris_3P
+          - SCIEX_3P
+          - SCP_Astral_10ng_3ms
+          - SCP_Astral_10ng_6ms
+          - SCP_Astral_10ng_12ms
+          - SCP_Astral_10ng_24ms
+          - SCP_Astral_250pg_3ms
+          - SCP_Astral_250pg_6ms
+          - SCP_Astral_250pg_12ms
+          - SCP_Astral_250pg_24ms
+          - SCP_Astral_500pg_3ms
+          - SCP_Astral_500pg_6ms
+          - SCP_Astral_500pg_12ms
+          - SCP_Astral_500pg_24ms
+          - SCP_Astral_1000pg_3ms
+          - SCP_Astral_1000pg_6ms
+          - SCP_Astral_1000pg_12ms
+          - SCP_Astral_1000pg_24ms
+          - SCP_Astral_MBR
+          - Seer_Astral_45
+          - Seer_Astral_single
+          - YEAST_KO_Astral
+        default: all
 
 permissions:
   contents: write
@@ -33,7 +64,7 @@ jobs:
     strategy:
       matrix:
         version: ['1.11']
-        regression_set: ${{ github.event_name == 'release' && fromJSON('["all"]') || (github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["fastest","fast","all"]')) }}
+        regression_set: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["all"]') }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -69,6 +100,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
+          entrapment_ref="codex/add-max_points-and-bin_size-to-plotting-functions-srqvs5"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"
@@ -88,20 +120,23 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' ENTRAPMENT_REF='${entrapment_ref}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
 
+            regression_branch="codex/update-run_efdr_analysis-parameters-o07uog"
             if [ -d regression-configs/.git ]; then
               git -C regression-configs fetch --all
-              git -C regression-configs remote set-head origin -a
-              regression_branch="$(git -C regression-configs symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')"
-              git -C regression-configs checkout "$regression_branch"
-              git -C regression-configs reset --hard "origin/${regression_branch}"
             else
               git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
             fi
+            if [ ! -d regression-configs/.git ]; then
+              echo "Missing regression-configs repo after clone" >&2
+              exit 1
+            fi
+            git -C regression-configs checkout --force "$regression_branch"
+            git -C regression-configs reset --hard "origin/${regression_branch}"
 
             if [ -d "$PIONEER_DIR/.git" ]; then
               git -C "$PIONEER_DIR" fetch --all --tags
@@ -119,6 +154,14 @@ jobs:
               git -C "$ENTRAPMENT_DIR" fetch --all --tags
             else
               git clone "$ENTRAPMENT_REPO_URL" "$ENTRAPMENT_DIR"
+            fi
+            if [ -n "${ENTRAPMENT_REF:-}" ]; then
+              if git -C "$ENTRAPMENT_DIR" cat-file -e "${ENTRAPMENT_REF}^{commit}" 2>/dev/null; then
+                git -C "$ENTRAPMENT_DIR" checkout --force "$ENTRAPMENT_REF"
+              else
+                git -C "$ENTRAPMENT_DIR" fetch --depth=1 origin "$ENTRAPMENT_REF"
+                git -C "$ENTRAPMENT_DIR" checkout --force FETCH_HEAD
+              fi
             fi
 
             mkdir -p "$DEPOT_DIR"
@@ -188,22 +231,22 @@ jobs:
             fi
 
             dataset_filter=""
-            # dataset_tags.json schema: { "dataset-name": ["tag1", "tag2", ...], ... }
+            # dataset_tags.json schema: { "datasets": { "dataset-name": { "order": 1, "tags": ["tag1"] } } }
+            tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
+            if [ ! -f "$tags_path" ]; then
+              echo "Missing dataset tags file at $tags_path" >&2
+              exit 1
+            fi
+            python_cmd="python3"
+            if ! command -v python3 >/dev/null 2>&1; then
+              python_cmd="python"
+            fi
+            if ! command -v "$python_cmd" >/dev/null 2>&1; then
+              echo "Python not available on cluster; cannot parse dataset tags." >&2
+              exit 1
+            fi
             if [ "${REGRESSION_SET:-all}" != "all" ]; then
               dataset_tag="${REGRESSION_SET}"
-              tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
-              if [ ! -f "$tags_path" ]; then
-                echo "Missing dataset tags file at $tags_path" >&2
-                exit 1
-              fi
-              python_cmd="python3"
-              if ! command -v python3 >/dev/null 2>&1; then
-                python_cmd="python"
-              fi
-              if ! command -v "$python_cmd" >/dev/null 2>&1; then
-                echo "Python not available on cluster; cannot parse dataset tags." >&2
-                exit 1
-              fi
               dataset_filter=$(
                 "$python_cmd" -c 'import json,sys; data=json.load(open(sys.argv[1])); datasets=data.get("datasets", {}); tag=sys.argv[2]; print(",".join([n for n,v in datasets.items() if isinstance(v, dict) and tag in (v.get("tags") or [])]))' "$tags_path" "$dataset_tag"
               )
@@ -215,7 +258,9 @@ jobs:
             echo "Regression set: ${REGRESSION_SET:-all}"
             echo "Dataset filter: ${dataset_filter:-<all>}"
 
-            param_list=$(find "$PARAMS_DIR" -type f -name 'search*.json' -print)
+            param_list=$(
+              "$python_cmd" -c 'import glob,json,os,sys; params_dir=sys.argv[1]; tags_path=sys.argv[2]; allowed=sys.argv[3].split(",") if sys.argv[3] else None; data=json.load(open(tags_path)); datasets=data.get("datasets", {}); order_for=lambda name: datasets.get(name, {}).get("order", 10**9); items=[]; [items.extend((order_for(ds), ds, p) for p in sorted(glob.glob(os.path.join(params_dir, ds, "search*.json")))) for ds in os.listdir(params_dir) if os.path.isdir(os.path.join(params_dir, ds)) and (not allowed or ds in allowed)]; items.sort(key=lambda x: (x[0], x[1], x[2])); print("\n".join([p for _,_,p in items]))' "$PARAMS_DIR" "$tags_path" "${dataset_filter:-}"
+            )
 
             if [ -z "$param_list" ]; then
               echo "No parameter JSON files found in $PARAMS_DIR" >&2

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -47,6 +47,7 @@ jobs:
           GITHUB_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           GITHUB_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           CLUSTER_ENTRAPMENT_REPO: ${{ secrets.CLUSTER_ENTRAPMENT_REPO }}
+          CLUSTER_ENTRAPMENT_REF: ${{ secrets.CLUSTER_ENTRAPMENT_REF }}
           REGRESSION_SET: ${{ github.event_name == 'workflow_dispatch' && inputs.regression_set || matrix.regression_set }}
         shell: bash
         run: |
@@ -69,6 +70,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
+          entrapment_ref="${CLUSTER_ENTRAPMENT_REF:-}"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"
@@ -88,7 +90,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' ENTRAPMENT_REF='${entrapment_ref}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
@@ -119,6 +121,14 @@ jobs:
               git -C "$ENTRAPMENT_DIR" fetch --all --tags
             else
               git clone "$ENTRAPMENT_REPO_URL" "$ENTRAPMENT_DIR"
+            fi
+            if [ -n "${ENTRAPMENT_REF:-}" ]; then
+              if git -C "$ENTRAPMENT_DIR" cat-file -e "${ENTRAPMENT_REF}^{commit}" 2>/dev/null; then
+                git -C "$ENTRAPMENT_DIR" checkout --force "$ENTRAPMENT_REF"
+              else
+                git -C "$ENTRAPMENT_DIR" fetch --depth=1 origin "$ENTRAPMENT_REF"
+                git -C "$ENTRAPMENT_DIR" checkout --force FETCH_HEAD
+              fi
             fi
 
             mkdir -p "$DEPOT_DIR"

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -65,7 +65,7 @@ permissions:
 jobs:
   regression:
     name: Julia ${{ matrix.version }} regression sweep (${{ matrix.regression_set }})
-    environment: regression-tests-${{ matrix.regression_set }}
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'regression-tests-manual' || format('regression-tests-{0}', matrix.regression_set) }}
     runs-on: [self-hosted, Linux, pioneer-regression]
     timeout-minutes: 7200
     strategy:

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -308,8 +308,15 @@ jobs:
                 fi
               fi
 
-              results_root="/scratch2/fs1/d.goldfarb/pioneer-regression/search"
-              adjusted_results="${results_root}/${dataset_dir_name}/${RUN_ID_SUFFIX}/${search_name}"
+              results_path=$(sed -n 's/.*"results"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' "$param_file" | head -n 1)
+
+              if [ -z "$results_path" ]; then
+                echo "Failed to locate results path in $param_file" >&2
+                exit 1
+              fi
+
+              base_results=${results_path%/}
+              adjusted_results="${base_results}/${RUN_ID_SUFFIX}"
               dataset_name="$dataset_dir_name"
               escaped_results=$(printf '%s\n' "$adjusted_results" | sed 's/[&/]/\\&/g')
               mkdir -p "$adjusted_results"

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -188,22 +188,22 @@ jobs:
             fi
 
             dataset_filter=""
-            # dataset_tags.json schema: { "dataset-name": ["tag1", "tag2", ...], ... }
+            # dataset_tags.json schema: { "datasets": { "dataset-name": { "order": 1, "tags": ["tag1"] } } }
+            tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
+            if [ ! -f "$tags_path" ]; then
+              echo "Missing dataset tags file at $tags_path" >&2
+              exit 1
+            fi
+            python_cmd="python3"
+            if ! command -v python3 >/dev/null 2>&1; then
+              python_cmd="python"
+            fi
+            if ! command -v "$python_cmd" >/dev/null 2>&1; then
+              echo "Python not available on cluster; cannot parse dataset tags." >&2
+              exit 1
+            fi
             if [ "${REGRESSION_SET:-all}" != "all" ]; then
               dataset_tag="${REGRESSION_SET}"
-              tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
-              if [ ! -f "$tags_path" ]; then
-                echo "Missing dataset tags file at $tags_path" >&2
-                exit 1
-              fi
-              python_cmd="python3"
-              if ! command -v python3 >/dev/null 2>&1; then
-                python_cmd="python"
-              fi
-              if ! command -v "$python_cmd" >/dev/null 2>&1; then
-                echo "Python not available on cluster; cannot parse dataset tags." >&2
-                exit 1
-              fi
               dataset_filter=$(
                 "$python_cmd" -c 'import json,sys; data=json.load(open(sys.argv[1])); datasets=data.get("datasets", {}); tag=sys.argv[2]; print(",".join([n for n,v in datasets.items() if isinstance(v, dict) and tag in (v.get("tags") or [])]))' "$tags_path" "$dataset_tag"
               )
@@ -215,7 +215,9 @@ jobs:
             echo "Regression set: ${REGRESSION_SET:-all}"
             echo "Dataset filter: ${dataset_filter:-<all>}"
 
-            param_list=$(find "$PARAMS_DIR" -type f -name 'search*.json' -print)
+            param_list=$(
+              "$python_cmd" -c 'import glob,json,os,sys; params_dir=sys.argv[1]; tags_path=sys.argv[2]; allowed=sys.argv[3].split(",") if sys.argv[3] else None; data=json.load(open(tags_path)); datasets=data.get("datasets", {}); def order_for(name): v=datasets.get(name, {}); return v.get("order", 10**9); items=[]; [items.extend((order_for(ds), ds, p) for p in sorted(glob.glob(os.path.join(params_dir, ds, "search*.json")))) for ds in os.listdir(params_dir) if os.path.isdir(os.path.join(params_dir, ds)) and (not allowed or ds in allowed)]; items.sort(key=lambda x: (x[0], x[1], x[2])); print("\n".join([p for _,_,p in items]))' "$PARAMS_DIR" "$tags_path" "${dataset_filter:-}"
+            )
 
             if [ -z "$param_list" ]; then
               echo "No parameter JSON files found in $PARAMS_DIR" >&2

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -210,7 +210,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' PARAMS_DIR='${params_dir}' REGRESSION_CONFIGS_DIR='${regression_configs_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' METRICS_SCRIPT='${metrics_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' REGRESSION_SET='${regression_set}' PIONEER_DELETE_RESULTS='${PIONEER_DELETE_RESULTS}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
             PIONEER_DELETE_RESULTS="${PIONEER_DELETE_RESULTS:-true}"
@@ -853,7 +853,7 @@ jobs:
               fi
             else
               rm -rf "$repo_dir"
-              if git clone --branch "$HISTORY_BRANCH" "$repo_url" "$repo_dir"; then
+              if git clone --branch "$HISTORY_BRANCH" --depth 1 --filter=blob:none "$repo_url" "$repo_dir"; then
                 :
               else
                 git init "$repo_dir"

--- a/assets/example_config/defaultSearchParams.json
+++ b/assets/example_config/defaultSearchParams.json
@@ -83,8 +83,7 @@
             "max_prob_to_impute_irt": 0.75,
             "fwhm_nstd": 4,
             "irt_nstd": 4,
-            "plot_rt_alignment": false,
-            "use_robust_fitting": true
+            "plot_rt_alignment": false
         }
     },
     "quant_search": {

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/FirstPassSearch.jl
@@ -118,7 +118,6 @@ struct FirstPassSearchParameters{P<:PrecEstimation} <: FragmentIndexSearchParame
     fwhm_nstd::Float32
     irt_nstd::Float32
     plot_rt_alignment::Bool
-    use_robust_fitting::Bool
     prec_estimation::P
 
     function FirstPassSearchParameters(params::PioneerParameters)
@@ -173,7 +172,6 @@ struct FirstPassSearchParameters{P<:PrecEstimation} <: FragmentIndexSearchParame
             Float32(irt_mapping_params.fwhm_nstd),   # Default fwhm_nstd
             Float32(irt_mapping_params.irt_nstd),   # Default irt_nstd
             Bool(hasproperty(irt_mapping_params, :plot_rt_alignment) ? irt_mapping_params.plot_rt_alignment : false),
-            Bool(hasproperty(irt_mapping_params, :use_robust_fitting) ? irt_mapping_params.use_robust_fitting : true),
             prec_estimation
         )
     end
@@ -558,7 +556,8 @@ function summarize_results!(
         )
     end
     # Map retention times
-    map_retention_times!(search_context, results, params)
+    all_psms_paths = getFirstPassPsms(getMSData(search_context))
+    map_retention_times!(search_context, params, all_psms_paths)
     # Process precursors
     precursor_dict = get_best_precursors_accross_runs!(search_context, results, params)
 

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -325,111 +325,137 @@ function get_best_psms!(psms::DataFrame,
 end
 
 """
-    map_retention_times!(search_context::SearchContext, results::FirstPassSearchResults, params::FirstPassSearchParameters)
+    map_retention_times!(search_context::SearchContext, params::FirstPassSearchParameters, all_psms_paths::Vector{String})
 
-Maps retention times between library and empirical scales for each MS file. For files with sufficient high-confidence PSMs 
-(probability > min_prob_for_irt_mapping), creates spline-based conversion models between retention time (RT) and indexed 
-retention time (iRT) scales.
+Maps retention times between library and empirical scales for each MS file. For files with sufficient high-confidence PSMs
+(probability > min_prob_for_irt_mapping), creates spline-based conversion models between retention time (RT) and indexed
+retention time (iRT) scales. Includes edge trimming to remove sparse data at RT boundaries.
 
 # Arguments
 - `search_context`: Contains MS data and mapping information
-- `results`: FirstPassSearch results container
 - `params`: Search parameters including minimum probability threshold
+- `all_psms_paths`: Paths to PSM Arrow files for each MS file
 
 Creates and stores:
 - RT to iRT mapping splines
 - iRT to RT mapping splines
 
-Throws an error if insufficient high-confidence PSMs are found for mapping.
+Uses identity model as fallback if insufficient PSMs or fitting fails.
 """
 function map_retention_times!(
     search_context::SearchContext,
-    results::FirstPassSearchResults,
-    params::FirstPassSearchParameters
+    params::FirstPassSearchParameters,
+    all_psms_paths::Vector{String}
 )
-
-    # Only process valid (non-failed) files
-    valid_files = get_valid_file_indices(search_context)
-    all_psms_paths = getFirstPassPsms(getMSData(search_context))
-
-    for ms_file_idx in valid_files
-        # Skip files that have been marked as failed
-        if is_file_failed(search_context, ms_file_idx)
-            continue
+    for ms_file_idx in eachindex(all_psms_paths)
+        file_name = try
+            getFileIdToName(getMSData(search_context), ms_file_idx)
+        catch
+            "file_$ms_file_idx"
         end
         psms_path = all_psms_paths[ms_file_idx]
         psms = Arrow.Table(psms_path)
-        best_hits = psms[:prob].>params.min_prob_for_irt_mapping#Map rts using only the best psms
-        try#if sum(best_hits) > 100
-            if params.use_robust_fitting
-                # Use robust fitting with RANSAC/penalty
-                best_psms_df = DataFrame(
-                    rt = psms[:rt][best_hits],
-                    irt_predicted = psms[:irt_predicted][best_hits]
-                )
+        best_hits = psms[:prob].>params.min_prob_for_irt_mapping
 
-                # Fit RT to iRT model using shared robust fitting
-                rt_model, valid_rt, valid_irt, irt_mad = Pioneer.fit_irt_model(
-                    best_psms_df;
-                    lambda_penalty = Float32(0.1),  # Default penalty
-                    ransac_threshold = 1000,        # Default RANSAC threshold
-                    min_psms = 10,                  # Default minimum PSMs
-                    spline_degree = 3,              # Default spline degree
-                    max_knots = 7,                  # Default max knots
-                    outlier_threshold = Float32(5.0)  # Default outlier threshold
-                )
+        try
+            # Check if we have enough PSMs for RT alignment
+            n_good_psms = sum(best_hits)
 
-                # Store RT to iRT model
-                setRtIrtMap!(search_context, rt_model, ms_file_idx)
+            if n_good_psms < 100
+                # Get file name for warning
+                file_name = try
+                    getFileIdToName(getMSData(search_context), ms_file_idx)
+                catch
+                    "file_$ms_file_idx"
+                end
 
-                # Fit inverse model (iRT to RT) - swap input/output
-                irt_to_rt_df = DataFrame(
-                    rt = valid_irt,           # Use iRT as input
-                    irt_predicted = valid_rt  # Use RT as output
-                )
-                irt_model, _, _, _ = Pioneer.fit_irt_model(
-                    irt_to_rt_df;
-                    lambda_penalty = Float32(0.1),
-                    ransac_threshold = 1000,
-                    min_psms = 10,
-                    spline_degree = 3,
-                    max_knots = 7,
-                    outlier_threshold = Float32(5.0)
-                )
-                setIrtRtMap!(search_context, irt_model, ms_file_idx)
+                @user_warn "Too few PSMs ($n_good_psms) for RT alignment in file: $file_name (need ≥100). Using identity RT model."
 
-                # Optionally generate plots
-                if params.plot_rt_alignment
-                    plot_rt_alignment_firstpass(
-                        valid_rt,
-                        valid_irt,
-                        rt_model,
-                        ms_file_idx,
-                        getDataOutDir(search_context)
-                    )
+                # Use identity mapping as fallback
+                identity_model = IdentityModel()
+                setRtIrtMap!(search_context, identity_model, ms_file_idx)
+                setIrtRtMap!(search_context, identity_model, ms_file_idx)
+                continue
+            end
+
+            # Extract best PSM data
+            best_rts = psms[:rt][best_hits]
+            best_irts = psms[:irt_predicted][best_hits]
+
+            # Calculate adaptive knots: 1 per 100 PSMs, min 5, max 100
+            n_knots = clamp(n_good_psms ÷ 100, 5, 100)
+
+            # Trim edges where data is sparse to avoid unstable fitting
+            min_psms_per_bin = 100  # Minimum PSMs required per bin
+
+            if n_good_psms >= 1000 && n_knots >= 10  # Only trim if enough data and knots
+                # Create uniform bin edges based on initial RT range
+                rt_min_initial, rt_max_initial = extrema(best_rts)
+                bin_edges = collect(LinRange(rt_min_initial, rt_max_initial, n_knots + 1))
+
+                # Count PSMs per bin using optimized histogram
+                hist = StatsBase.fit(Histogram, best_rts, bin_edges)
+                bin_counts = hist.weights
+
+                # Find first bin from left with sufficient data
+                left_bin_idx = findfirst(count -> count >= min_psms_per_bin, bin_counts)
+                # Find first bin from right with sufficient data
+                right_bin_idx = findlast(count -> count >= min_psms_per_bin, bin_counts)
+
+                if !isnothing(left_bin_idx) && !isnothing(right_bin_idx) && left_bin_idx <= right_bin_idx
+                    # Trim to dense region
+                    rt_min_trimmed = bin_edges[left_bin_idx]
+                    rt_max_trimmed = bin_edges[right_bin_idx + 1]
+
+                    # Apply trimming
+                    keep_mask = (best_rts .>= rt_min_trimmed) .& (best_rts .<= rt_max_trimmed)
+                    n_excluded = n_good_psms - sum(keep_mask)
+
+                    if n_excluded > 0
+                        best_rts = best_rts[keep_mask]
+                        best_irts = best_irts[keep_mask]
+
+                        pct_excluded = round(100 * n_excluded / n_good_psms, digits=1)
+                        @user_info "Trimmed $n_excluded PSMs ($pct_excluded%) from sparse edge bins (RT: $(round(rt_min_trimmed, digits=2))-$(round(rt_max_trimmed, digits=2)) min)"
+                    end
+                else
+                    @user_info "Edge trimming skipped: insufficient dense bins found"
                 end
             else
-                # Use simple UniformSpline (legacy behavior)
-                best_rts = psms[:rt][best_hits]
-                best_irts = psms[:irt_predicted][best_hits]
-
-                irt_to_rt_spline = UniformSpline(
-                    best_rts,
-                    best_irts,
-                    3,
-                    5
-                )
-                rt_to_irt_spline = UniformSpline(
-                    best_irts,
-                    best_rts,
-                    3,
-                    5
-                )
-
-                #Build rt=>irt and irt=> rt mappings for the file and add to the dictionaries
-                setRtIrtMap!(search_context, SplineRtConversionModel(rt_to_irt_spline), ms_file_idx)
-                setIrtRtMap!(search_context, SplineRtConversionModel(irt_to_rt_spline), ms_file_idx)
+                @user_info "Edge trimming skipped: n_good_psms=$n_good_psms, n_knots=$n_knots"
             end
+
+            # Fit adaptive UniformSpline for RT → iRT conversion
+            rt_to_irt_spline = UniformSpline(
+                best_irts,    # y values (iRT)
+                best_rts,     # x values (RT)
+                3,            # degree (cubic)
+                n_knots       # adaptive based on PSM count
+            )
+
+            # Fit adaptive UniformSpline for iRT → RT conversion (inverse)
+            irt_to_rt_spline = UniformSpline(
+                best_rts,     # y values (RT)
+                best_irts,    # x values (iRT)
+                3,            # degree (cubic)
+                n_knots       # adaptive based on PSM count
+            )
+
+            # Store models in SearchContext
+            setRtIrtMap!(search_context, SplineRtConversionModel(rt_to_irt_spline), ms_file_idx)
+            setIrtRtMap!(search_context, SplineRtConversionModel(irt_to_rt_spline), ms_file_idx)
+
+            # Optionally generate diagnostic plots
+            if params.plot_rt_alignment
+                plot_rt_alignment_firstpass(
+                    best_rts,
+                    best_irts,
+                    SplineRtConversionModel(rt_to_irt_spline),
+                    ms_file_idx,
+                    getDataOutDir(search_context)
+                )
+            end
+
         catch e
             # Get file name for debugging
             file_name = try
@@ -437,39 +463,22 @@ function map_retention_times!(
             catch
                 "file_$ms_file_idx"
             end
-            
+
             # Safely compute PSM count to avoid excessive output
             n_good_psms = try
                 sum(best_hits)
             catch
                 0  # Default to 0 if calculation fails
             end
-            
-            @user_warn "RT mapping failed for MS data file: $file_name ($n_good_psms good PSMs found, need >100 for spline). Using identity RT model."
-            
+
+            @user_warn "RT mapping failed for MS data file: $file_name ($n_good_psms PSMs). Error: $e. Using identity RT model."
+
             # Use identity mapping as fallback - no RT to iRT conversion
             identity_model = IdentityModel()
             setRtIrtMap!(search_context, identity_model, ms_file_idx)
             setIrtRtMap!(search_context, identity_model, ms_file_idx)
         end
     end
-    
-    # Set identity models for failed files
-    ms_data = getMassSpecData(search_context)
-    for failed_idx in 1:length(ms_data.file_paths)
-        if getFailedIndicator(ms_data, failed_idx)
-            file_name = try
-                getFileIdToName(getMSData(search_context), failed_idx)
-            catch
-                "file_$failed_idx"
-            end
-            @user_warn "Setting identity RT models for failed file: $file_name"
-            setRtIrtMap!(search_context, IdentityModel(), failed_idx)
-            setIrtRtMap!(search_context, IdentityModel(), failed_idx)
-        end
-    end
-    
-    return nothing
 end
 
 """
@@ -565,6 +574,20 @@ function create_rt_indices!(
 
 
     setIrtErrors!(search_context, irt_errs)
+
+    # Log RT tolerances for each file
+    @user_info "FirstPassSearch RT tolerances (per file):"
+    ms_data = getMSData(search_context)
+    for (file_idx, tol) in pairs(irt_errs)
+        file_name = getFileIdToName(ms_data, file_idx)
+        @user_info "  File $(file_idx) ($file_name): RT tol = $(round(tol, digits=3)) min"
+    end
+
+    # Log summary statistics
+    if !isempty(irt_errs)
+        tol_values = collect(values(irt_errs))
+        @user_info "  Summary: min=$(round(minimum(tol_values), digits=3)), max=$(round(maximum(tol_values), digits=3)), median=$(round(median(tol_values), digits=3)) min"
+    end
 
     # Create precursor to iRT mapping
     prec_to_irt = map(x -> (irt=x[:best_irt], mz=x[:mz]), 

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -428,7 +428,7 @@ function map_retention_times!(
                         best_irts = best_irts[keep_mask]
 
                         pct_excluded = round(100 * n_excluded / n_good_psms, digits=1)
-                        @user_info "Trimmed $n_excluded PSMs ($pct_excluded%) from sparse edge bins (RT: $(round(rt_min_trimmed, digits=2))-$(round(rt_max_trimmed, digits=2)) min)"
+                        #@user_info "Trimmed $n_excluded PSMs ($pct_excluded%) from sparse edge bins (RT: $(round(rt_min_trimmed, digits=2))-$(round(rt_max_trimmed, digits=2)) min)"
                     end
                 end
             end
@@ -584,17 +584,17 @@ function create_rt_indices!(
     setIrtErrors!(search_context, irt_errs)
 
     # Log RT tolerances for each file
-    @user_info "FirstPassSearch RT tolerances (per file):"
+   # @user_info "FirstPassSearch RT tolerances (per file):"
     ms_data = getMSData(search_context)
     for (file_idx, tol) in pairs(irt_errs)
         file_name = getFileIdToName(ms_data, file_idx)
-        @user_info "  File $(file_idx) ($file_name): RT tol = $(round(tol, digits=3)) min"
+        @debug_l1 "  File $(file_idx) ($file_name): RT tol = $(round(tol, digits=3)) min"
     end
 
     # Log summary statistics
     if !isempty(irt_errs)
         tol_values = collect(values(irt_errs))
-        @user_info "  Summary: min=$(round(minimum(tol_values), digits=3)), max=$(round(maximum(tol_values), digits=3)), median=$(round(median(tol_values), digits=3)) min"
+        @debug_l1 "  Summary: min=$(round(minimum(tol_values), digits=3)), max=$(round(maximum(tol_values), digits=3)), median=$(round(median(tol_values), digits=3)) min"
     end
 
     # Create precursor to iRT mapping

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -430,11 +430,7 @@ function map_retention_times!(
                         pct_excluded = round(100 * n_excluded / n_good_psms, digits=1)
                         @user_info "Trimmed $n_excluded PSMs ($pct_excluded%) from sparse edge bins (RT: $(round(rt_min_trimmed, digits=2))-$(round(rt_max_trimmed, digits=2)) min)"
                     end
-                else
-                    @user_info "Edge trimming skipped: insufficient dense bins found"
                 end
-            else
-                @user_info "Edge trimming skipped: n_good_psms=$n_good_psms, n_knots=$n_knots"
             end
 
             # Fit adaptive UniformSpline for RT → iRT conversion

--- a/src/Routines/SearchDIA/SearchMethods/HuberTuningSearch/HuberTuningSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/HuberTuningSearch/HuberTuningSearch.jl
@@ -89,6 +89,7 @@ struct HuberTuningSearchParameters{P<:PrecEstimation} <: FragmentIndexSearchPara
     delta_grid::Vector{Float32}
     min_pct_diff::Float32
     q_value_threshold::Float32
+    max_psms_for_huber::Int64
     prec_estimation::P
 
     # Override Parameters
@@ -121,6 +122,9 @@ struct HuberTuningSearchParameters{P<:PrecEstimation} <: FragmentIndexSearchPara
             @user_warn "Warning. Reg type `$reg_type` not recognized. Using NoNorm. Accepted types are `none`, `l1`, `l2`"
         end
 
+        # Get max PSMs for huber tuning (default 5000)
+        max_psms_huber = haskey(deconv_params, :max_psms_for_huber) ? Int64(deconv_params.max_psms_for_huber) : 5000
+
         new{typeof(prec_estimation)}(
             (UInt8(first(isotope_bounds)), UInt8(last(isotope_bounds))),
             Int64(frag_params.n_isotopes),  # Fixed n_frag_isotopes
@@ -139,6 +143,7 @@ struct HuberTuningSearchParameters{P<:PrecEstimation} <: FragmentIndexSearchPara
             huber_δs,
             10.0f0,  # Default min_pct_diff
             0.001f0, # Default q_value_threshold
+            max_psms_huber,
             prec_estimation,
 
             global_params.huber_override.override_huber_delta_fit,
@@ -185,8 +190,50 @@ function process_file!(
         # Get PSMs to tune on
         best_psms = get_best_psms(search_context, params.q_value_threshold)
         file_psms = filter(row -> row.ms_file_idx == ms_file_idx, best_psms)
+
+        # Get file name for logging
+        file_name = try
+            getFileIdToName(getMSData(search_context), ms_file_idx)
+        catch
+            "file_$ms_file_idx"
+        end
+
+        # Limit PSMs if needed - prioritize scans with most PSMs (densest scans)
+        n_original_psms = nrow(file_psms)
+        n_original_scans = length(unique(file_psms[!, :scan_idx]))
+
+        if n_original_psms > params.max_psms_for_huber
+            # Count PSMs per scan (sort=false for efficiency)
+            psm_counts = combine(
+                groupby(file_psms, :scan_idx, sort=false),
+                nrow => :n_psms
+            )
+
+            # Sort scans by PSM count (descending) - densest scans first
+            sort!(psm_counts, :n_psms, rev=true)
+
+            # Select scans until we reach max_psms_for_huber
+            scans_to_keep = Set{UInt32}()
+            total_psms = 0
+
+            for row in eachrow(psm_counts)
+                push!(scans_to_keep, row.scan_idx)
+                total_psms += row.n_psms
+                if total_psms >= params.max_psms_for_huber
+                    break
+                end
+            end
+
+            # Filter PSMs to selected scans
+            file_psms = filter(row -> row.scan_idx in scans_to_keep, file_psms)
+
+            @user_info "\nHuberTuning: File $ms_file_idx ($file_name) limited to $(nrow(file_psms)) PSMs from $(length(scans_to_keep)) scans (from $n_original_psms PSMs across $n_original_scans scans)"
+        else
+            @user_info "\nHuberTuning: File $ms_file_idx ($file_name) has $n_original_psms PSMs at q-value < $(params.q_value_threshold) ($n_original_scans unique scans)"
+        end
+
         isempty(file_psms) && return results
-        
+
         # Create scan/precursor set and scan indices
         prec_set = Set(zip(file_psms[!, :precursor_idx], file_psms[!, :scan_idx]))
         scan_idxs = Set(file_psms[!, :scan_idx])

--- a/src/Routines/SearchDIA/SearchMethods/HuberTuningSearch/HuberTuningSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/HuberTuningSearch/HuberTuningSearch.jl
@@ -191,16 +191,8 @@ function process_file!(
         best_psms = get_best_psms(search_context, params.q_value_threshold)
         file_psms = filter(row -> row.ms_file_idx == ms_file_idx, best_psms)
 
-        # Get file name for logging
-        file_name = try
-            getFileIdToName(getMSData(search_context), ms_file_idx)
-        catch
-            "file_$ms_file_idx"
-        end
-
         # Limit PSMs if needed - prioritize scans with most PSMs (densest scans)
         n_original_psms = nrow(file_psms)
-        n_original_scans = length(unique(file_psms[!, :scan_idx]))
 
         if n_original_psms > params.max_psms_for_huber
             # Count PSMs per scan (sort=false for efficiency)
@@ -226,10 +218,6 @@ function process_file!(
 
             # Filter PSMs to selected scans
             file_psms = filter(row -> row.scan_idx in scans_to_keep, file_psms)
-
-            @user_info "\nHuberTuning: File $ms_file_idx ($file_name) limited to $(nrow(file_psms)) PSMs from $(length(scans_to_keep)) scans (from $n_original_psms PSMs across $n_original_scans scans)"
-        else
-            @user_info "\nHuberTuning: File $ms_file_idx ($file_name) has $n_original_psms PSMs at q-value < $(params.q_value_threshold) ($n_original_scans unique scans)"
         end
 
         isempty(file_psms) && return results

--- a/src/Routines/SearchDIA/SearchMethods/HuberTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/HuberTuningSearch/utils.jl
@@ -198,11 +198,6 @@ function process_scans_for_huber!(
         :huber_δ => Float32[]
     )
 
-    # Log delta grid info
-    delta_grid = params.delta_grid
-    n_deltas = length(delta_grid)
-    @user_info "\nTesting $n_deltas delta values: [$(delta_grid[1]), ..., $(delta_grid[end])]"
-
     # Get working arrays
     Hs = getHs(search_data)
     weights = getTempWeights(search_data)

--- a/src/Routines/SearchDIA/SearchMethods/HuberTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/HuberTuningSearch/utils.jl
@@ -197,24 +197,49 @@ function process_scans_for_huber!(
         :weight => Float32[],
         :huber_δ => Float32[]
     )
-    
+
+    # Log delta grid info
+    delta_grid = params.delta_grid
+    n_deltas = length(delta_grid)
+    @user_info "\nTesting $n_deltas delta values: [$(delta_grid[1]), ..., $(delta_grid[end])]"
+
     # Get working arrays
     Hs = getHs(search_data)
     weights = getTempWeights(search_data)
     precursor_weights = getPrecursorWeights(search_data)
     residuals = getResiduals(search_data)
-    
+
+    # Timing accumulators for profiling
+    timing = Dict(
+        :transition_selection => 0.0,
+        :peak_matching => 0.0,
+        :design_matrix => 0.0,
+        :huber_solve => 0.0,
+        :other => 0.0
+    )
+
+    # Matrix statistics accumulators
+    matrix_stats = Dict(
+        :n_rows => 0,
+        :n_cols => 0,
+        :n_nonzero => 0,
+        :n_scans => 0,
+        :max_cols => 0
+    )
+
     # RT bin tracking state
     irt_start, irt_stop = 1, 1
     prec_mz_string = ""
     ion_idx = 0
-    
+
     # Get RT index
     rt_index = buildRtIndex(
         DataFrame(Arrow.Table(getRtIndex(getMSData(search_context), ms_file_idx))),
         bin_rt_size = 0.1)
-    
+
     irt_tol = getIrtErrors(search_context)[ms_file_idx]
+    n_scans_processed = 0
+    batch_time = @elapsed begin
     for scan_idx in scan_range
         scan_idx ∉ keys(scan_to_prec) && continue
         
@@ -235,26 +260,34 @@ function process_scans_for_huber!(
             irt_start = irt_start_new
             irt_stop = irt_stop_new
             prec_mz_string = prec_mz_string_new
-            
-            ion_idx, _ = select_transitions_for_huber!(
-                search_data, search_context, scan_idx, 
-                ms_file_idx, spectra, irt_start, irt_stop, rt_index, params
-            )
+
+            transition_time = @elapsed begin
+                ion_idx, _ = select_transitions_for_huber!(
+                    search_data, search_context, scan_idx,
+                    ms_file_idx, spectra, irt_start, irt_stop, rt_index, params
+                )
+            end
+            timing[:transition_selection] += transition_time
         end
         # Match peaks and process if enough matches found
-        nmatches, nmisses = match_peaks_for_huber!(
-            search_data,
-            ion_idx,
-            spectra,
-            scan_idx,
-            search_context,
-            ms_file_idx
-        )
-        
+        matching_time = @elapsed begin
+            nmatches, nmisses = match_peaks_for_huber!(
+                search_data,
+                ion_idx,
+                spectra,
+                scan_idx,
+                search_context,
+                ms_file_idx
+            )
+        end
+        timing[:peak_matching] += matching_time
+
         nmatches ≤ 2 && continue
-        
+
+        n_scans_processed += 1
+
         # Process delta values for this scan
-        process_delta_values!(
+        matrix_time, huber_time, scan_matrix_stats = process_delta_values!(
             params.delta_grid,
             Hs,
             weights,
@@ -268,8 +301,44 @@ function process_scans_for_huber!(
             scan_to_prec,
             tuning_results
         )
+        timing[:design_matrix] += matrix_time
+        timing[:huber_solve] += huber_time
+
+        # Accumulate matrix statistics
+        matrix_stats[:n_rows] += scan_matrix_stats[:n_rows]
+        matrix_stats[:n_cols] += scan_matrix_stats[:n_cols]
+        matrix_stats[:n_nonzero] += scan_matrix_stats[:n_nonzero]
+        matrix_stats[:n_scans] += 1
+        matrix_stats[:max_cols] = max(matrix_stats[:max_cols], scan_matrix_stats[:n_cols])
+
+        # Log slow scans for inspection
+        if huber_time > 1.0  # More than 1 second for 26 deltas
+            @user_info "\n  Slow scan $scan_idx: $(scan_matrix_stats[:n_rows])×$(scan_matrix_stats[:n_cols]) matrix, $(round(huber_time, digits=2))s for 26 deltas"
+        end
     end
-    
+    end  # end @elapsed
+
+    # Log batch completion summary with timing breakdown
+    total_time = sum(values(timing))
+    timing[:other] = batch_time - total_time  # Account for loop overhead
+
+    # Calculate matrix statistics
+    avg_rows = matrix_stats[:n_scans] > 0 ? matrix_stats[:n_rows] / matrix_stats[:n_scans] : 0
+    avg_cols = matrix_stats[:n_scans] > 0 ? matrix_stats[:n_cols] / matrix_stats[:n_scans] : 0
+    avg_nonzero = matrix_stats[:n_scans] > 0 ? matrix_stats[:n_nonzero] / matrix_stats[:n_scans] : 0
+    avg_density = (avg_rows * avg_cols > 0) ? 100 * avg_nonzero / (avg_rows * avg_cols) : 0
+
+    @user_info """\nBatch complete: processed $n_scans_processed scans in $(round(batch_time, digits=2))s ($(round(batch_time/max(n_scans_processed,1), digits=3))s per scan)
+  Timing breakdown:
+    Transition selection: $(round(timing[:transition_selection], digits=2))s ($(round(100*timing[:transition_selection]/batch_time, digits=1))%)
+    Peak matching: $(round(timing[:peak_matching], digits=2))s ($(round(100*timing[:peak_matching]/batch_time, digits=1))%)
+    Design matrix: $(round(timing[:design_matrix], digits=2))s ($(round(100*timing[:design_matrix]/batch_time, digits=1))%)
+    Huber solve (26 deltas): $(round(timing[:huber_solve], digits=2))s ($(round(100*timing[:huber_solve]/batch_time, digits=1))%)
+    Other: $(round(timing[:other], digits=2))s ($(round(100*timing[:other]/batch_time, digits=1))%)
+  Matrix statistics:
+    Avg dimensions: $(round(Int, avg_rows))×$(round(Int, avg_cols)) ($(round(Int, avg_nonzero)) non-zero, $(round(avg_density, digits=1))% dense)
+    Max columns: $(matrix_stats[:max_cols])"""
+
     return tuning_results
 end
 
@@ -370,6 +439,7 @@ end
                          search_data::SearchDataStructures, nmatches::Int, nmisses::Int,
                          params::HuberTuningSearchParameters, scan_idx::Int64,
                          scan_to_prec::Dict{UInt32, Vector{UInt32}}, tuning_results::Dict)
+                         -> (Float64, Float64, Dict{Symbol, Int})
 
 Process multiple delta values for a single scan.
 
@@ -379,6 +449,10 @@ Process multiple delta values for a single scan.
    - Initializes weights
    - Solves deconvolution problem
    - Records results for target PSMs
+
+# Returns
+- Tuple of (matrix_time, total_huber_time, matrix_stats) for profiling
+  - matrix_stats contains :n_rows, :n_cols, :n_nonzero
 """
 function process_delta_values!(
     delta_grid::Vector{Float32},
@@ -394,17 +468,31 @@ function process_delta_values!(
     scan_to_prec::Dict{UInt32, Vector{UInt32}},
     tuning_results::Dict
 )
-    # Build design matrix
-    buildDesignMatrix!(
-        Hs,
-        getIonMatches(search_data),
-        getIonMisses(search_data),
-        nmatches,
-        nmisses,
-        getIdToCol(search_data)
+    # Build design matrix (once per scan)
+    matrix_time = @elapsed begin
+        buildDesignMatrix!(
+            Hs,
+            getIonMatches(search_data),
+            getIonMisses(search_data),
+            nmatches,
+            nmisses,
+            getIdToCol(search_data)
+        )
+    end
+
+    # Collect matrix statistics
+    n_cols = getIdToCol(search_data).size  # Number of precursors
+    n_rows = length(Hs.colptr) - 1  # Number of unique peaks (rows in sparse matrix)
+    n_nonzero = length(Hs.nzval)  # Non-zero elements
+
+    matrix_stats = Dict(
+        :n_rows => n_rows,
+        :n_cols => n_cols,
+        :n_nonzero => n_nonzero
     )
-    
+
     # Process each delta value
+    total_huber_time = 0.0
     for δ in delta_grid
         # Resize arrays if needed
         if getIdToCol(search_data).size > length(weights)
@@ -413,38 +501,41 @@ function process_delta_values!(
             resize!(getSpectralScores(search_data), length(getSpectralScores(search_data)) + new_entries)
             append!(getUnscoredPsms(search_data), [eltype(getUnscoredPsms(search_data))() for _ in 1:new_entries])
         end
-        
+
         # Initialize weights
         for i in 1:getIdToCol(search_data).size
-            weights[getIdToCol(search_data)[getIdToCol(search_data).keys[i]]] = 
+            weights[getIdToCol(search_data)[getIdToCol(search_data).keys[i]]] =
                 precursor_weights[getIdToCol(search_data).keys[i]]
         end
-        
+
         # Solve deconvolution problem
-        initResiduals!(residuals, Hs, weights)
-        solveHuber!(
-            Hs,
-            residuals,
-            weights,
-            δ,
-            params.lambda,
-            params.max_iter_newton,
-            params.max_iter_bisection,
-            params.max_iter_outer,
-            params.accuracy_newton,
-            params.accuracy_bisection,
-            params.max_diff,
-            NoNorm()
-        )
-        
+        huber_time = @elapsed begin
+            initResiduals!(residuals, Hs, weights)
+            solveHuber!(
+                Hs,
+                residuals,
+                weights,
+                δ,
+                params.lambda,
+                params.max_iter_newton,
+                params.max_iter_bisection,
+                params.max_iter_outer,
+                params.accuracy_newton,
+                params.accuracy_bisection,
+                params.max_diff,
+                NoNorm()
+            )
+        end
+        total_huber_time += huber_time
+
         # Record results
         for i in 1:getIdToCol(search_data).size
             id = getIdToCol(search_data).keys[i]
             colid = getIdToCol(search_data)[id]
-            
+
             # Update precursor weights
             precursor_weights[id] = weights[colid]
-            
+
             # Record if this is a target PSM
             if id ∈ scan_to_prec[scan_idx]
                 push!(tuning_results[:precursor_idx], id)
@@ -454,9 +545,11 @@ function process_delta_values!(
             end
         end
     end
-    
+
     reset!(getIdToCol(search_data))
     reset!(Hs)
+
+    return (matrix_time, total_huber_time, matrix_stats)
 end
 
 #==========================================================

--- a/src/Routines/SearchDIA/SearchMethods/NceTuningSearch/ScanPriorityIndex.jl
+++ b/src/Routines/SearchDIA/SearchMethods/NceTuningSearch/ScanPriorityIndex.jl
@@ -301,17 +301,3 @@ function collect_nce_psms_for_scans(
 
     return psms
 end
-
-"""
-    log_memory_usage(checkpoint::String)
-
-Log current memory usage for monitoring.
-"""
-function log_memory_usage(checkpoint::String)
-    GC.gc()  # Force collection for accurate reading
-    gc_stats = Base.gc_num()
-    mem_used = Sys.total_memory() - Sys.free_memory()
-    println("Memory [$checkpoint]: $(round(mem_used / 1e9, digits=2)) GB")
-    println("  GC collections: $(gc_stats.collect)")
-    println("  GC time: $(round(gc_stats.total_time / 1e9, digits=3))s")
-end

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/types.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/types.jl
@@ -341,7 +341,7 @@ mutable struct ParameterTuningSearchParameters{P<:PrecEstimation} <: FragmentInd
             Set{Int64}([2]), # spec_order default
             Float32(frag_params.relative_improvement_threshold),
             3,  # spline_degree default
-            5,  # spline_n_knots default
+            100,  # spline_n_knots default - higher for fine-grained RT calibration
             5,  # spline_fit_outlier_sd default
             Int64(rt_params.sigma_tolerance),
             prec_estimation,

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -169,6 +169,14 @@ function process_scans!(
     irt_tol = getIrtErrors(search_context)[ms_file_idx]
     nce_model = getNceModel(search_context, ms_file_idx)
 
+    # Log RT tolerance being used for this file
+    file_name = try
+        getFileIdToName(getMSData(search_context), ms_file_idx)
+    catch
+        "file_$ms_file_idx"
+    end
+    @user_info "SecondPassSearch: Processing $file_name with RT tolerance = $(round(irt_tol, digits=3)) min"
+
     for scan_idx in scan_range
         ((scan_idx < 1) || scan_idx > length(spectra)) && continue
         msn = getMsOrder(spectra, scan_idx)
@@ -372,6 +380,14 @@ function process_scans!(
     last_val = 0
     # Note: prec_ids scratch array not required in MS1 path
     irt_tol = getIrtErrors(search_context)[ms_file_idx]
+
+    # Log RT tolerance being used for this file (MS1 processing)
+    file_name = try
+        getFileIdToName(getMSData(search_context), ms_file_idx)
+    catch
+        "file_$ms_file_idx"
+    end
+    @user_info "SecondPassSearch (MS1): Processing $file_name with RT tolerance = $(round(irt_tol, digits=3)) min"
 
     for scan_idx in scan_range
         empty!(pair_id_dict)

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -169,14 +169,6 @@ function process_scans!(
     irt_tol = getIrtErrors(search_context)[ms_file_idx]
     nce_model = getNceModel(search_context, ms_file_idx)
 
-    # Log RT tolerance being used for this file
-    file_name = try
-        getFileIdToName(getMSData(search_context), ms_file_idx)
-    catch
-        "file_$ms_file_idx"
-    end
-    @user_info "SecondPassSearch: Processing $file_name with RT tolerance = $(round(irt_tol, digits=3)) min"
-
     for scan_idx in scan_range
         ((scan_idx < 1) || scan_idx > length(spectra)) && continue
         msn = getMsOrder(spectra, scan_idx)
@@ -380,14 +372,6 @@ function process_scans!(
     last_val = 0
     # Note: prec_ids scratch array not required in MS1 path
     irt_tol = getIrtErrors(search_context)[ms_file_idx]
-
-    # Log RT tolerance being used for this file (MS1 processing)
-    file_name = try
-        getFileIdToName(getMSData(search_context), ms_file_idx)
-    catch
-        "file_$ms_file_idx"
-    end
-    @user_info "SecondPassSearch (MS1): Processing $file_name with RT tolerance = $(round(irt_tol, digits=3)) min"
 
     for scan_idx in scan_range
         empty!(pair_id_dict)

--- a/src/structs/RetentionTimeConversionModel.jl
+++ b/src/structs/RetentionTimeConversionModel.jl
@@ -34,6 +34,11 @@ struct SplineRtConversionModel <: RtConversionModel
 end
 (s::SplineRtConversionModel)(x::AbstractFloat) = s.model(x)
 
+struct InterpolationRtConversionModel <: RtConversionModel
+    model::Interpolations.Extrapolation
+end
+(s::InterpolationRtConversionModel)(x::AbstractFloat) = s.model(x)
+
 struct LinearRtConversionModel <: RtConversionModel
     slope::Float32
     intercept::Float32

--- a/src/utils/ML/uniformBasisCubicSpline.jl
+++ b/src/utils/ML/uniformBasisCubicSpline.jl
@@ -97,7 +97,23 @@ function build_temp_spline_from_coeffs(
     XPoly = buildPieceWise(knots, bin_width, spline_basis)
     piecewise_polynomials = XPoly * c
     n_total_coeffs = n_knots * (degree + 1)
-    coeffs = SVector{n_total_coeffs}(vcat([poly.coeffs for poly in piecewise_polynomials]...))
+
+    # Extract coefficients, padding to ensure exactly (degree+1) per polynomial
+    # The Polynomial type drops trailing zeros, so we must pad them back
+    expected_length = degree + 1
+    coeff_vecs = [
+        let c = poly.coeffs
+            if length(c) < expected_length
+                # Pad with zeros for missing trailing coefficients
+                vcat(c, zeros(T, expected_length - length(c)))
+            else
+                # Take exactly the expected number (shouldn't exceed, but be defensive)
+                c[1:expected_length]
+            end
+        end
+        for poly in piecewise_polynomials
+    ]
+    coeffs = SVector{n_total_coeffs}(vcat(coeff_vecs...))
 
     return UniformSpline{n_total_coeffs, T}(
         coeffs,
@@ -229,8 +245,23 @@ function UniformSpline(
     XPoly = buildPieceWise(knots, bin_width, spline_basis)
     piecewise_polynomials = XPoly*c
     n_coeffs = n_knots*(degree + 1)
-    coeffs = SVector{n_coeffs}(vcat([polynomial.coeffs for polynomial in piecewise_polynomials]...))
 
+    # Extract coefficients, padding to ensure exactly (degree+1) per polynomial
+    # The Polynomial type drops trailing zeros, so we must pad them back
+    expected_length = degree + 1
+    coeff_vecs = [
+        let c = polynomial.coeffs
+            if length(c) < expected_length
+                # Pad with zeros for missing trailing coefficients
+                vcat(c, zeros(T, expected_length - length(c)))
+            else
+                # Take exactly the expected number (shouldn't exceed, but be defensive)
+                c[1:expected_length]
+            end
+        end
+        for polynomial in piecewise_polynomials
+    ]
+    coeffs = SVector{n_coeffs}(vcat(coeff_vecs...))
 
     UniformSpline{n_coeffs, T}(
         coeffs,
@@ -666,7 +697,23 @@ function UniformSplinePenalized(
     XPoly = buildPieceWise(knots, bin_width, spline_basis)
     piecewise_polynomials = XPoly * c
     n_total_coeffs = n_knots * (degree + 1)
-    coeffs = SVector{n_total_coeffs}(vcat([poly.coeffs for poly in piecewise_polynomials]...))
+
+    # Extract coefficients, padding to ensure exactly (degree+1) per polynomial
+    # The Polynomial type drops trailing zeros, so we must pad them back
+    expected_length = degree + 1
+    coeff_vecs = [
+        let c = poly.coeffs
+            if length(c) < expected_length
+                # Pad with zeros for missing trailing coefficients
+                vcat(c, zeros(T, expected_length - length(c)))
+            else
+                # Take exactly the expected number (shouldn't exceed, but be defensive)
+                c[1:expected_length]
+            end
+        end
+        for poly in piecewise_polynomials
+    ]
+    coeffs = SVector{n_total_coeffs}(vcat(coeff_vecs...))
 
     return UniformSpline{n_total_coeffs, T}(
         coeffs,


### PR DESCRIPTION
### Motivation
- Ensure regression search job submissions follow an explicit ordering defined in `dataset_tags.json` so higher-priority datasets run first.
- Maintain the ability to select subsets via the existing `REGRESSION_SET` tag filter while honoring the new ordering metadata.

### Description
- Require and validate the presence of `params/dataset_tags.json` and update the documented schema to `{ "datasets": { "dataset-name": { "order": 1, "tags": ["tag"] } } }` in both ` .github/workflows/regression.yml` and ` .github/workflows/regression_slurm.yml`.
- Add Python detection (`python3`/`python`) and reuse it to parse dataset tags when `REGRESSION_SET` is provided.
- Replace the `find`-based `param_list` with a Python one-liner that collects all `search*.json` files under each dataset, looks up a dataset `order` (defaulting to a very large value when missing), and sorts the parameter files by `(order, dataset_name, param_path)` so ties are stable.
- Preserve tag-based filtering by only including datasets present in the tag-derived `dataset_filter` when `REGRESSION_SET` is set.

### Testing
- No automated tests were executed because this is a workflow-only change and requires running in CI/cluster context to validate; local commit applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967c2bece8883259fee3eccee59a196)