### PR TITLE
fix: pass delete-results flag to cluster metrics jobs

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -284,9 +284,7 @@ jobs:
               rel_path="${param_file#${PARAMS_DIR}/}"
               dataset_dir_name="${rel_path%%/*}"
               search_name="$(basename "${rel_path%.*}")"
-              adjusted_path="$ADJUSTED_PARAMS_DIR/$rel_path"
               param_basename="$(basename "$param_file")"
-              mkdir -p "$(dirname "$adjusted_path")"
               if [ -n "${dataset_filter:-}" ]; then
                 dataset_allowed=0
                 IFS=',' read -r -a allowed_datasets <<< "$dataset_filter"
@@ -323,7 +321,7 @@ jobs:
                 )
               fi
 
-              sed "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file" > "$adjusted_path"
+              sed -i "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file"
 
               echo "${dataset_name}" >> "$manifest_file"
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -9,9 +9,47 @@ on:
         options:
           - all
           - fast
-          - test
           - fastest
-        default: test
+          - APMS_Astral
+          - EWZ_2P_MBR_Exploris
+          - KEAP1KO_Eclipse
+          - MTAC_3P_Alternating
+          - MTAC_3P_Standard
+          - MTAC_Yeast_Alternating_3min
+          - MTAC_Yeast_Alternating_5min
+          - MTAC_Yeast_Standard_3min
+          - MTAC_Yeast_Standard_5min
+          - Olsen_Astral_3P
+          - Olsen_Exploris_3P
+          - SCIEX_3P
+          - SCP_Astral_10ng_3ms
+          - SCP_Astral_10ng_6ms
+          - SCP_Astral_10ng_12ms
+          - SCP_Astral_10ng_24ms
+          - SCP_Astral_250pg_3ms
+          - SCP_Astral_250pg_6ms
+          - SCP_Astral_250pg_12ms
+          - SCP_Astral_250pg_24ms
+          - SCP_Astral_500pg_3ms
+          - SCP_Astral_500pg_6ms
+          - SCP_Astral_500pg_12ms
+          - SCP_Astral_500pg_24ms
+          - SCP_Astral_1000pg_3ms
+          - SCP_Astral_1000pg_6ms
+          - SCP_Astral_1000pg_12ms
+          - SCP_Astral_1000pg_24ms
+          - SCP_Astral_MBR
+          - Seer_Astral_45
+          - Seer_Astral_single
+          - YEAST_KO_Astral
+        default: all
+      delete_results:
+        description: Delete search results after metrics (set false to archive all results)
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "true"
 
 permissions:
   contents: write
@@ -26,7 +64,7 @@ jobs:
     strategy:
       matrix:
         version: ['1.11']
-        regression_set: ${{ github.event_name == 'release' && fromJSON('["all"]') || (github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["fastest","fast","all"]')) }}
+        regression_set: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["all"]') }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -62,6 +100,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
+          entrapment_ref="codex/add-max_points-and-bin_size-to-plotting-functions-srqvs5"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"
@@ -81,20 +120,23 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' ENTRAPMENT_REF='${entrapment_ref}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
 
+            regression_branch="codex/update-run_efdr_analysis-parameters-o07uog"
             if [ -d regression-configs/.git ]; then
               git -C regression-configs fetch --all
-              git -C regression-configs remote set-head origin -a
-              regression_branch="$(git -C regression-configs symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')"
-              git -C regression-configs checkout "$regression_branch"
-              git -C regression-configs reset --hard "origin/${regression_branch}"
             else
               git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
             fi
+            if [ ! -d regression-configs/.git ]; then
+              echo "Missing regression-configs repo after clone" >&2
+              exit 1
+            fi
+            git -C regression-configs checkout --force "$regression_branch"
+            git -C regression-configs reset --hard "origin/${regression_branch}"
 
             if [ -d "$PIONEER_DIR/.git" ]; then
               git -C "$PIONEER_DIR" fetch --all --tags
@@ -113,6 +155,14 @@ jobs:
             else
               git clone "$ENTRAPMENT_REPO_URL" "$ENTRAPMENT_DIR"
             fi
+            if [ -n "${ENTRAPMENT_REF:-}" ]; then
+              if git -C "$ENTRAPMENT_DIR" cat-file -e "${ENTRAPMENT_REF}^{commit}" 2>/dev/null; then
+                git -C "$ENTRAPMENT_DIR" checkout --force "$ENTRAPMENT_REF"
+              else
+                git -C "$ENTRAPMENT_DIR" fetch --depth=1 origin "$ENTRAPMENT_REF"
+                git -C "$ENTRAPMENT_DIR" checkout --force FETCH_HEAD
+              fi
+            fi
 
             mkdir -p "$DEPOT_DIR"
           EOF
@@ -127,6 +177,7 @@ jobs:
           SETUP_JOB_SCRIPT: ${{ vars.SETUP_JOB_SCRIPT }}
           METRICS_JOB_SCRIPT: ${{ vars.METRICS_JOB_SCRIPT }}
           REGRESSION_SET: ${{ github.event_name == 'workflow_dispatch' && inputs.regression_set || matrix.regression_set }}
+          PIONEER_DELETE_RESULTS: ${{ github.event_name == 'workflow_dispatch' && inputs.delete_results || 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -153,8 +204,9 @@ jobs:
           )
 
           timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-            "RUN_DIR='${remote_run_dir}' PARAMS_DIR='${params_dir}' REGRESSION_CONFIGS_DIR='${regression_configs_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' METRICS_SCRIPT='${metrics_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' REGRESSION_SET='${regression_set}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
+            "RUN_DIR='${remote_run_dir}' PARAMS_DIR='${params_dir}' REGRESSION_CONFIGS_DIR='${regression_configs_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' METRICS_SCRIPT='${metrics_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' REGRESSION_SET='${regression_set}' PIONEER_DELETE_RESULTS='${PIONEER_DELETE_RESULTS}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
+            PIONEER_DELETE_RESULTS="${PIONEER_DELETE_RESULTS:-true}"
 
             if [ ! -f "$SETUP_SCRIPT" ]; then
               echo "Missing setup job script: $SETUP_SCRIPT" >&2
@@ -181,22 +233,22 @@ jobs:
             fi
 
             dataset_filter=""
-            # dataset_tags.json schema: { "dataset-name": ["tag1", "tag2", ...], ... }
+            # dataset_tags.json schema: { "datasets": { "dataset-name": { "order": 1, "tags": ["tag1"] } } }
+            tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
+            if [ ! -f "$tags_path" ]; then
+              echo "Missing dataset tags file at $tags_path" >&2
+              exit 1
+            fi
+            python_cmd="python3"
+            if ! command -v python3 >/dev/null 2>&1; then
+              python_cmd="python"
+            fi
+            if ! command -v "$python_cmd" >/dev/null 2>&1; then
+              echo "Python not available on cluster; cannot parse dataset tags." >&2
+              exit 1
+            fi
             if [ "${REGRESSION_SET:-all}" != "all" ]; then
               dataset_tag="${REGRESSION_SET}"
-              tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
-              if [ ! -f "$tags_path" ]; then
-                echo "Missing dataset tags file at $tags_path" >&2
-                exit 1
-              fi
-              python_cmd="python3"
-              if ! command -v python3 >/dev/null 2>&1; then
-                python_cmd="python"
-              fi
-              if ! command -v "$python_cmd" >/dev/null 2>&1; then
-                echo "Python not available on cluster; cannot parse dataset tags." >&2
-                exit 1
-              fi
               dataset_filter=$(
                 "$python_cmd" -c 'import json,sys; data=json.load(open(sys.argv[1])); datasets=data.get("datasets", {}); tag=sys.argv[2]; print(",".join([n for n,v in datasets.items() if isinstance(v, dict) and tag in (v.get("tags") or [])]))' "$tags_path" "$dataset_tag"
               )
@@ -208,7 +260,9 @@ jobs:
             echo "Regression set: ${REGRESSION_SET:-all}"
             echo "Dataset filter: ${dataset_filter:-<all>}"
 
-            param_list=$(find "$PARAMS_DIR" -type f -name 'search*.json' -print)
+            param_list=$(
+              "$python_cmd" -c 'import glob,json,os,sys; params_dir=sys.argv[1]; tags_path=sys.argv[2]; allowed=sys.argv[3].split(",") if sys.argv[3] else None; data=json.load(open(tags_path)); datasets=data.get("datasets", {}); order_for=lambda name: datasets.get(name, {}).get("order", 10**9); items=[]; [items.extend((order_for(ds), ds, p) for p in sorted(glob.glob(os.path.join(params_dir, ds, "search*.json")))) for ds in os.listdir(params_dir) if os.path.isdir(os.path.join(params_dir, ds)) and (not allowed or ds in allowed)]; items.sort(key=lambda x: (x[0], x[1], x[2])); print("\n".join([p for _,_,p in items]))' "$PARAMS_DIR" "$tags_path" "${dataset_filter:-}"
+            )
 
             if [ -z "$param_list" ]; then
               echo "No parameter JSON files found in $PARAMS_DIR" >&2
@@ -353,6 +407,7 @@ jobs:
               metrics_submit=$(\
                 RUN_DIR="$RUN_DIR" \
                 PIONEER_DATASET_NAME="$dataset_name" \
+                PIONEER_DELETE_RESULTS="$PIONEER_DELETE_RESULTS" \
                 bsub -w "$dep_expr" < "$METRICS_SCRIPT")
 
               metrics_job_id=$(printf '%s\n' "$metrics_submit" | sed -n 's/Job <\([0-9]\+\)>.*$/\1/p' | head -n 1)

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -88,11 +88,11 @@ jobs:
           echo "$CLUSTER_RUN_ROOT"
 
           remote_run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
-          remote_run_root="${remote_run_root_raw%/}"
+          remote_run_root="${remote_run_root_raw%/}/runs"
           run_suffix="run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}"
           remote_run_dir="${remote_run_root}/${run_suffix}"
           mount_run_root_raw="/mnt/ris/Active/Automation/Pioneer"
-          mount_run_root="${mount_run_root_raw%/}"
+          mount_run_root="${mount_run_root_raw%/}/runs"
           mount_run_dir="${mount_run_root}/${run_suffix}"
           pioneer_dir="${remote_run_dir}/pioneer"
           entrapment_dir="${remote_run_dir}/PioneerEntrapment.jl"
@@ -183,8 +183,9 @@ jobs:
           set -euo pipefail
 
           remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
+          remote_run_root="${remote_run_root%/}/runs"
           remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}}"
-          mount_run_dir="${CLUSTER_RUN_DIR_MOUNT:-/mnt/ris/Active/Automation/Pioneer/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}}"
+          mount_run_dir="${CLUSTER_RUN_DIR_MOUNT:-/mnt/ris/Active/Automation/Pioneer/runs/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}}"
           params_dir="${remote_run_dir}/regression-configs/params"
           regression_configs_dir="${remote_run_dir}/regression-configs"
           job_script_path="${remote_run_dir}/${REGRESSION_JOB_SCRIPT:-regression-configs/job_scripts/search_dia.bsub}"
@@ -717,7 +718,7 @@ jobs:
 
           remote_run_dir="${CLUSTER_RUN_DIR:?CLUSTER_RUN_DIR not set}"
           run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
-          run_root="${run_root_raw%/}"
+          run_root="${run_root_raw%/}/runs"
           develop_dir="${run_root}/metrics/develop"
 
           ssh_options=(
@@ -774,7 +775,7 @@ jobs:
 
           remote_run_dir="${CLUSTER_RUN_DIR:?CLUSTER_RUN_DIR not set}"
           run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
-          run_root="${run_root_raw%/}"
+          run_root="${run_root_raw%/}/runs"
           release_tag="${RELEASE_TAG:?RELEASE_TAG not set}"
           release_dir="${run_root}/release/${release_tag}"
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -730,7 +730,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' DEVELOP_DIR='${develop_dir}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
             lock_dir="${DEVELOP_DIR}.lock"
@@ -788,7 +788,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' RELEASE_DIR='${release_dir}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
 
@@ -831,7 +831,7 @@ jobs:
             -o ConnectTimeout=30
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' REPORT_PATH='${report_path}' REPORT_SUBDIR='${report_subdir}' HISTORY_BRANCH='${history_branch}' GITHUB_REPOSITORY='${GITHUB_REPOSITORY}' GITHUB_TOKEN='${GITHUB_TOKEN}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -284,7 +284,9 @@ jobs:
               rel_path="${param_file#${PARAMS_DIR}/}"
               dataset_dir_name="${rel_path%%/*}"
               search_name="$(basename "${rel_path%.*}")"
+              adjusted_path="$ADJUSTED_PARAMS_DIR/$rel_path"
               param_basename="$(basename "$param_file")"
+              mkdir -p "$(dirname "$adjusted_path")"
               if [ -n "${dataset_filter:-}" ]; then
                 dataset_allowed=0
                 IFS=',' read -r -a allowed_datasets <<< "$dataset_filter"
@@ -321,7 +323,7 @@ jobs:
                 )
               fi
 
-              sed -i "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file"
+              sed "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file" > "$adjusted_path"
 
               echo "${dataset_name}" >> "$manifest_file"
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -301,17 +301,11 @@ jobs:
                 fi
               fi
 
-              results_path=$(sed -n 's/.*"results"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' "$param_file" | head -n 1)
-
-              if [ -z "$results_path" ]; then
-                echo "Failed to locate results path in $param_file" >&2
-                exit 1
-              fi
-
-              base_results=${results_path%/}
-              adjusted_results="${base_results}/${RUN_ID_SUFFIX}"
-              dataset_name="$(basename "$(dirname "$adjusted_results")")"
+              results_root="/scratch2/fs1/d.goldfarb/pioneer-regression/search"
+              adjusted_results="${results_root}/${dataset_dir_name}/${RUN_ID_SUFFIX}/${search_name}"
+              dataset_name="$dataset_dir_name"
               escaped_results=$(printf '%s\n' "$adjusted_results" | sed 's/[&/]/\\&/g')
+              mkdir -p "$adjusted_results"
               resource_basename="${param_basename/search/resources}"
               resource_file="$(dirname "$param_file")/${resource_basename}"
               cpus=8

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -58,7 +58,7 @@ permissions:
 jobs:
   regression:
     name: Julia ${{ matrix.version }} regression sweep (${{ matrix.regression_set }})
-    environment: regression-tests-${{ matrix.regression_set }}
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'regression-tests-manual' || format('regression-tests-{0}', matrix.regression_set) }}
     runs-on: [self-hosted, Linux, pioneer-regression]
     timeout-minutes: 7200
     strategy:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -301,8 +301,15 @@ jobs:
                 fi
               fi
 
-              results_root="/scratch2/fs1/d.goldfarb/pioneer-regression/search"
-              adjusted_results="${results_root}/${dataset_dir_name}/${RUN_ID_SUFFIX}/${search_name}"
+              results_path=$(sed -n 's/.*"results"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' "$param_file" | head -n 1)
+
+              if [ -z "$results_path" ]; then
+                echo "Failed to locate results path in $param_file" >&2
+                exit 1
+              fi
+
+              base_results=${results_path%/}
+              adjusted_results="${base_results}/${RUN_ID_SUFFIX}"
               dataset_name="$dataset_dir_name"
               escaped_results=$(printf '%s\n' "$adjusted_results" | sed 's/[&/]/\\&/g')
               mkdir -p "$adjusted_results"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -100,7 +100,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
-          entrapment_ref="codex/add-max_points-and-bin_size-to-plotting-functions-srqvs5"
+          entrapment_ref="main"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"
@@ -125,7 +125,7 @@ jobs:
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
 
-            regression_branch="codex/update-run_efdr_analysis-parameters-o07uog"
+            regression_branch="main"
             if [ -d regression-configs/.git ]; then
               git -C regression-configs fetch --all
             else

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -203,7 +203,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' PARAMS_DIR='${params_dir}' REGRESSION_CONFIGS_DIR='${regression_configs_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' METRICS_SCRIPT='${metrics_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' REGRESSION_SET='${regression_set}' PIONEER_DELETE_RESULTS='${PIONEER_DELETE_RESULTS}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
             PIONEER_DELETE_RESULTS="${PIONEER_DELETE_RESULTS:-true}"
@@ -847,7 +847,7 @@ jobs:
               fi
             else
               rm -rf "$repo_dir"
-              if git clone --branch "$HISTORY_BRANCH" "$repo_url" "$repo_dir"; then
+              if git clone --branch "$HISTORY_BRANCH" --depth 1 --filter=blob:none "$repo_url" "$repo_dir"; then
                 :
               else
                 git init "$repo_dir"

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -308,17 +308,11 @@ jobs:
                 fi
               fi
 
-              results_path=$(sed -n 's/.*"results"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' "$param_file" | head -n 1)
-
-              if [ -z "$results_path" ]; then
-                echo "Failed to locate results path in $param_file" >&2
-                exit 1
-              fi
-
-              base_results=${results_path%/}
-              adjusted_results="${base_results}/${RUN_ID_SUFFIX}"
-              dataset_name="$(basename "$(dirname "$adjusted_results")")"
+              results_root="/scratch2/fs1/d.goldfarb/pioneer-regression/search"
+              adjusted_results="${results_root}/${dataset_dir_name}/${RUN_ID_SUFFIX}/${search_name}"
+              dataset_name="$dataset_dir_name"
               escaped_results=$(printf '%s\n' "$adjusted_results" | sed 's/[&/]/\\&/g')
+              mkdir -p "$adjusted_results"
               resource_basename="${param_basename/search/resources}"
               resource_file="$(dirname "$param_file")/${resource_basename}"
               cpus=8

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -95,11 +95,11 @@ jobs:
           echo "$CLUSTER_RUN_ROOT"
 
           remote_run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
-          remote_run_root="${remote_run_root_raw%/}"
+          remote_run_root="${remote_run_root_raw%/}/runs"
           run_suffix="run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}"
           remote_run_dir="${remote_run_root}/${run_suffix}"
           mount_run_root_raw="/mnt/ris/Active/Automation/Pioneer"
-          mount_run_root="${mount_run_root_raw%/}"
+          mount_run_root="${mount_run_root_raw%/}/runs"
           mount_run_dir="${mount_run_root}/${run_suffix}"
           pioneer_dir="${remote_run_dir}/pioneer"
           entrapment_dir="${remote_run_dir}/PioneerEntrapment.jl"
@@ -190,8 +190,9 @@ jobs:
           set -euo pipefail
 
           remote_run_root="${CLUSTER_RUN_ROOT:-\$HOME/pioneer-regressions}"
+          remote_run_root="${remote_run_root%/}/runs"
           remote_run_dir="${CLUSTER_RUN_DIR:-${remote_run_root}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}}"
-          mount_run_dir="${CLUSTER_RUN_DIR_MOUNT:-/mnt/ris/Active/Automation/Pioneer/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}}"
+          mount_run_dir="${CLUSTER_RUN_DIR_MOUNT:-/mnt/ris/Active/Automation/Pioneer/runs/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${REGRESSION_SET}}"
           params_dir="${remote_run_dir}/regression-configs/params"
           regression_configs_dir="${remote_run_dir}/regression-configs"
           job_script_path="${remote_run_dir}/${REGRESSION_JOB_SCRIPT:-regression-configs/job_scripts/slurm/search_dia.sbatch}"
@@ -723,7 +724,7 @@ jobs:
 
           remote_run_dir="${CLUSTER_RUN_DIR:?CLUSTER_RUN_DIR not set}"
           run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
-          run_root="${run_root_raw%/}"
+          run_root="${run_root_raw%/}/runs"
           develop_dir="${run_root}/metrics/develop"
 
           ssh_options=(
@@ -780,7 +781,7 @@ jobs:
 
           remote_run_dir="${CLUSTER_RUN_DIR:?CLUSTER_RUN_DIR not set}"
           run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
-          run_root="${run_root_raw%/}"
+          run_root="${run_root_raw%/}/runs"
           release_tag="${RELEASE_TAG:?RELEASE_TAG not set}"
           release_dir="${run_root}/release/${release_tag}"
 

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -291,9 +291,7 @@ jobs:
               rel_path="${param_file#${PARAMS_DIR}/}"
               dataset_dir_name="${rel_path%%/*}"
               search_name="$(basename "${rel_path%.*}")"
-              adjusted_path="$ADJUSTED_PARAMS_DIR/$rel_path"
               param_basename="$(basename "$param_file")"
-              mkdir -p "$(dirname "$adjusted_path")"
               if [ -n "${dataset_filter:-}" ]; then
                 dataset_allowed=0
                 IFS=',' read -r -a allowed_datasets <<< "$dataset_filter"
@@ -330,7 +328,7 @@ jobs:
                 )
               fi
 
-              sed "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file" > "$adjusted_path"
+              sed -i "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file"
 
               echo "${dataset_name}" >> "$manifest_file"
 

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -736,7 +736,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' DEVELOP_DIR='${develop_dir}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
             lock_dir="${DEVELOP_DIR}.lock"
@@ -794,7 +794,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' RELEASE_DIR='${release_dir}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
 
@@ -837,7 +837,7 @@ jobs:
             -o ConnectTimeout=30
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' REPORT_PATH='${report_path}' REPORT_SUBDIR='${report_subdir}' HISTORY_BRANCH='${history_branch}' GITHUB_REPOSITORY='${GITHUB_REPOSITORY}' GITHUB_TOKEN='${GITHUB_TOKEN}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
 

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -16,9 +16,47 @@ on:
         options:
           - all
           - fast
-          - test
           - fastest
-        default: test
+          - APMS_Astral
+          - EWZ_2P_MBR_Exploris
+          - KEAP1KO_Eclipse
+          - MTAC_3P_Alternating
+          - MTAC_3P_Standard
+          - MTAC_Yeast_Alternating_3min
+          - MTAC_Yeast_Alternating_5min
+          - MTAC_Yeast_Standard_3min
+          - MTAC_Yeast_Standard_5min
+          - Olsen_Astral_3P
+          - Olsen_Exploris_3P
+          - SCIEX_3P
+          - SCP_Astral_10ng_3ms
+          - SCP_Astral_10ng_6ms
+          - SCP_Astral_10ng_12ms
+          - SCP_Astral_10ng_24ms
+          - SCP_Astral_250pg_3ms
+          - SCP_Astral_250pg_6ms
+          - SCP_Astral_250pg_12ms
+          - SCP_Astral_250pg_24ms
+          - SCP_Astral_500pg_3ms
+          - SCP_Astral_500pg_6ms
+          - SCP_Astral_500pg_12ms
+          - SCP_Astral_500pg_24ms
+          - SCP_Astral_1000pg_3ms
+          - SCP_Astral_1000pg_6ms
+          - SCP_Astral_1000pg_12ms
+          - SCP_Astral_1000pg_24ms
+          - SCP_Astral_MBR
+          - Seer_Astral_45
+          - Seer_Astral_single
+          - YEAST_KO_Astral
+        default: all
+      delete_results:
+        description: Delete search results after metrics (set false to archive all results)
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "true"
 
 permissions:
   contents: write
@@ -33,7 +71,7 @@ jobs:
     strategy:
       matrix:
         version: ['1.11']
-        regression_set: ${{ github.event_name == 'release' && fromJSON('["all"]') || (github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["fastest","fast","all"]')) }}
+        regression_set: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["all"]') }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -69,6 +107,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
+          entrapment_ref="codex/add-max_points-and-bin_size-to-plotting-functions-srqvs5"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"
@@ -88,20 +127,23 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
+          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" "RUN_ROOT='${remote_run_root}' RUN_DIR='${remote_run_dir}' PIONEER_DIR='${pioneer_dir}' DEPOT_DIR='${depot_dir}' PIONEER_REPO='${pioneer_repo}' TARGET_SHA='${GITHUB_SHA}' ENTRAPMENT_DIR='${entrapment_dir}' ENTRAPMENT_REPO_URL='${entrapment_repo_url}' ENTRAPMENT_REF='${entrapment_ref}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
 
+            regression_branch="codex/update-run_efdr_analysis-parameters-o07uog"
             if [ -d regression-configs/.git ]; then
               git -C regression-configs fetch --all
-              git -C regression-configs remote set-head origin -a
-              regression_branch="$(git -C regression-configs symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')"
-              git -C regression-configs checkout "$regression_branch"
-              git -C regression-configs reset --hard "origin/${regression_branch}"
             else
               git clone https://github.com/GoldfarbLab/pioneer-regression-configs regression-configs
             fi
+            if [ ! -d regression-configs/.git ]; then
+              echo "Missing regression-configs repo after clone" >&2
+              exit 1
+            fi
+            git -C regression-configs checkout --force "$regression_branch"
+            git -C regression-configs reset --hard "origin/${regression_branch}"
 
             if [ -d "$PIONEER_DIR/.git" ]; then
               git -C "$PIONEER_DIR" fetch --all --tags
@@ -120,6 +162,14 @@ jobs:
             else
               git clone "$ENTRAPMENT_REPO_URL" "$ENTRAPMENT_DIR"
             fi
+            if [ -n "${ENTRAPMENT_REF:-}" ]; then
+              if git -C "$ENTRAPMENT_DIR" cat-file -e "${ENTRAPMENT_REF}^{commit}" 2>/dev/null; then
+                git -C "$ENTRAPMENT_DIR" checkout --force "$ENTRAPMENT_REF"
+              else
+                git -C "$ENTRAPMENT_DIR" fetch --depth=1 origin "$ENTRAPMENT_REF"
+                git -C "$ENTRAPMENT_DIR" checkout --force FETCH_HEAD
+              fi
+            fi
 
             mkdir -p "$DEPOT_DIR"
           EOF
@@ -134,6 +184,7 @@ jobs:
           SETUP_JOB_SCRIPT: ${{ vars.SETUP_JOB_SCRIPT }}
           METRICS_JOB_SCRIPT: ${{ vars.METRICS_JOB_SCRIPT }}
           REGRESSION_SET: ${{ github.event_name == 'workflow_dispatch' && inputs.regression_set || matrix.regression_set }}
+          PIONEER_DELETE_RESULTS: ${{ github.event_name == 'workflow_dispatch' && inputs.delete_results || 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -160,8 +211,9 @@ jobs:
           )
 
           timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
-            "RUN_DIR='${remote_run_dir}' PARAMS_DIR='${params_dir}' REGRESSION_CONFIGS_DIR='${regression_configs_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' METRICS_SCRIPT='${metrics_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' REGRESSION_SET='${regression_set}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
+            "RUN_DIR='${remote_run_dir}' PARAMS_DIR='${params_dir}' REGRESSION_CONFIGS_DIR='${regression_configs_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' METRICS_SCRIPT='${metrics_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' REGRESSION_SET='${regression_set}' PIONEER_DELETE_RESULTS='${PIONEER_DELETE_RESULTS}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
+            PIONEER_DELETE_RESULTS="${PIONEER_DELETE_RESULTS:-true}"
 
             if [ ! -f "$SETUP_SCRIPT" ]; then
               echo "Missing setup job script: $SETUP_SCRIPT" >&2
@@ -188,22 +240,22 @@ jobs:
             fi
 
             dataset_filter=""
-            # dataset_tags.json schema: { "dataset-name": ["tag1", "tag2", ...], ... }
+            # dataset_tags.json schema: { "datasets": { "dataset-name": { "order": 1, "tags": ["tag1"] } } }
+            tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
+            if [ ! -f "$tags_path" ]; then
+              echo "Missing dataset tags file at $tags_path" >&2
+              exit 1
+            fi
+            python_cmd="python3"
+            if ! command -v python3 >/dev/null 2>&1; then
+              python_cmd="python"
+            fi
+            if ! command -v "$python_cmd" >/dev/null 2>&1; then
+              echo "Python not available on cluster; cannot parse dataset tags." >&2
+              exit 1
+            fi
             if [ "${REGRESSION_SET:-all}" != "all" ]; then
               dataset_tag="${REGRESSION_SET}"
-              tags_path="${REGRESSION_CONFIGS_DIR}/params/dataset_tags.json"
-              if [ ! -f "$tags_path" ]; then
-                echo "Missing dataset tags file at $tags_path" >&2
-                exit 1
-              fi
-              python_cmd="python3"
-              if ! command -v python3 >/dev/null 2>&1; then
-                python_cmd="python"
-              fi
-              if ! command -v "$python_cmd" >/dev/null 2>&1; then
-                echo "Python not available on cluster; cannot parse dataset tags." >&2
-                exit 1
-              fi
               dataset_filter=$(
                 "$python_cmd" -c 'import json,sys; data=json.load(open(sys.argv[1])); datasets=data.get("datasets", {}); tag=sys.argv[2]; print(",".join([n for n,v in datasets.items() if isinstance(v, dict) and tag in (v.get("tags") or [])]))' "$tags_path" "$dataset_tag"
               )
@@ -215,7 +267,9 @@ jobs:
             echo "Regression set: ${REGRESSION_SET:-all}"
             echo "Dataset filter: ${dataset_filter:-<all>}"
 
-            param_list=$(find "$PARAMS_DIR" -type f -name 'search*.json' -print)
+            param_list=$(
+              "$python_cmd" -c 'import glob,json,os,sys; params_dir=sys.argv[1]; tags_path=sys.argv[2]; allowed=sys.argv[3].split(",") if sys.argv[3] else None; data=json.load(open(tags_path)); datasets=data.get("datasets", {}); order_for=lambda name: datasets.get(name, {}).get("order", 10**9); items=[]; [items.extend((order_for(ds), ds, p) for p in sorted(glob.glob(os.path.join(params_dir, ds, "search*.json")))) for ds in os.listdir(params_dir) if os.path.isdir(os.path.join(params_dir, ds)) and (not allowed or ds in allowed)]; items.sort(key=lambda x: (x[0], x[1], x[2])); print("\n".join([p for _,_,p in items]))' "$PARAMS_DIR" "$tags_path" "${dataset_filter:-}"
+            )
 
             if [ -z "$param_list" ]; then
               echo "No parameter JSON files found in $PARAMS_DIR" >&2
@@ -358,6 +412,7 @@ jobs:
               metrics_submit=$(\
                 RUN_DIR="$RUN_DIR" \
                 PIONEER_DATASET_NAME="$dataset_name" \
+                PIONEER_DELETE_RESULTS="$PIONEER_DELETE_RESULTS" \
                 sbatch --dependency=afterany:"$dep_list" "$METRICS_SCRIPT")
 
               metrics_job_id=$(printf '%s\n' "$metrics_submit" | sed -n 's/Submitted batch job \([0-9]\+\).*/\1/p' | head -n 1)

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -291,7 +291,9 @@ jobs:
               rel_path="${param_file#${PARAMS_DIR}/}"
               dataset_dir_name="${rel_path%%/*}"
               search_name="$(basename "${rel_path%.*}")"
+              adjusted_path="$ADJUSTED_PARAMS_DIR/$rel_path"
               param_basename="$(basename "$param_file")"
+              mkdir -p "$(dirname "$adjusted_path")"
               if [ -n "${dataset_filter:-}" ]; then
                 dataset_allowed=0
                 IFS=',' read -r -a allowed_datasets <<< "$dataset_filter"
@@ -328,7 +330,7 @@ jobs:
                 )
               fi
 
-              sed -i "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file"
+              sed "s|\"results\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"results\": \"${escaped_results}\"|" "$param_file" > "$adjusted_path"
 
               echo "${dataset_name}" >> "$manifest_file"
 

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -107,7 +107,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
-          entrapment_ref="codex/add-max_points-and-bin_size-to-plotting-functions-srqvs5"
+          entrapment_ref="main"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"
@@ -132,7 +132,7 @@ jobs:
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
 
-            regression_branch="codex/update-run_efdr_analysis-parameters-o07uog"
+            regression_branch="main"
             if [ -d regression-configs/.git ]; then
               git -C regression-configs fetch --all
             else

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -65,7 +65,7 @@ permissions:
 jobs:
   regression:
     name: Julia ${{ matrix.version }} regression sweep (${{ matrix.regression_set }})
-    environment: regression-tests-${{ matrix.regression_set }}
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'regression-tests-manual' || format('regression-tests-{0}', matrix.regression_set) }}
     runs-on: [self-hosted, Linux, pioneer-regression]
     timeout-minutes: 7200
     strategy:

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -308,8 +308,15 @@ jobs:
                 fi
               fi
 
-              results_root="/scratch2/fs1/d.goldfarb/pioneer-regression/search"
-              adjusted_results="${results_root}/${dataset_dir_name}/${RUN_ID_SUFFIX}/${search_name}"
+              results_path=$(sed -n 's/.*"results"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' "$param_file" | head -n 1)
+
+              if [ -z "$results_path" ]; then
+                echo "Failed to locate results path in $param_file" >&2
+                exit 1
+              fi
+
+              base_results=${results_path%/}
+              adjusted_results="${base_results}/${RUN_ID_SUFFIX}"
               dataset_name="$dataset_dir_name"
               escaped_results=$(printf '%s\n' "$adjusted_results" | sed 's/[&/]/\\&/g')
               mkdir -p "$adjusted_results"

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -210,7 +210,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' PARAMS_DIR='${params_dir}' REGRESSION_CONFIGS_DIR='${regression_configs_dir}' JOB_SCRIPT='${job_script_path}' SETUP_SCRIPT='${setup_script_path}' METRICS_SCRIPT='${metrics_script_path}' ADJUSTED_PARAMS_DIR='${adjusted_params_dir}' RUN_ID_SUFFIX='${run_suffix}' REGRESSION_SET='${regression_set}' PIONEER_DELETE_RESULTS='${PIONEER_DELETE_RESULTS}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -eu
             PIONEER_DELETE_RESULTS="${PIONEER_DELETE_RESULTS:-true}"
@@ -853,7 +853,7 @@ jobs:
               fi
             else
               rm -rf "$repo_dir"
-              if git clone --branch "$HISTORY_BRANCH" "$repo_url" "$repo_dir"; then
+              if git clone --branch "$HISTORY_BRANCH" --depth 1 --filter=blob:none "$repo_url" "$repo_dir"; then
                 :
               else
                 git init "$repo_dir"


### PR DESCRIPTION
### Motivation
- Allow workflow_dispatch to control whether search results are deleted after metrics so consumers can choose to archive full results by setting the flag to false. 
- Preserve current behavior by defaulting deletion to true and ensure the deletion flag is available on the cluster when metrics jobs run.

### Description
- Added a new `workflow_dispatch` input `delete_results` (options `"true"`/`"false"`, default `"true"`) to both `.github/workflows/regression.yml` and `.github/workflows/regression_slurm.yml`.
- Propagate `PIONEER_DELETE_RESULTS` into the job environment (`env:`) and include it in the SSH command that launches the remote cluster script, and set a default inside the remote shell.
- Pass `PIONEER_DELETE_RESULTS` through into the metrics job submission environment for both LSF (`bsub`) and Slurm (`sbatch`) so the metrics job can decide to delete or copy/archive the results.

### Testing
- No automated tests were run because this is a GitHub Actions workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967c2bece8883259fee3eccee59a196)