### PR TITLE
fix: default regression configs and entrapment to main branch

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -100,7 +100,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
-          entrapment_ref="codex/add-max_points-and-bin_size-to-plotting-functions-srqvs5"
+          entrapment_ref="main"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"
@@ -125,7 +125,7 @@ jobs:
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
 
-            regression_branch="codex/update-run_efdr_analysis-parameters-o07uog"
+            regression_branch="main"
             if [ -d regression-configs/.git ]; then
               git -C regression-configs fetch --all
             else

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -107,7 +107,7 @@ jobs:
           pioneer_repo="https://github.com/${GITHUB_REPOSITORY}"
           entrapment_repo="${CLUSTER_ENTRAPMENT_REPO:-nwamsley1/PioneerEntrapment.jl}"
           entrapment_repo_url="$entrapment_repo"
-          entrapment_ref="codex/add-max_points-and-bin_size-to-plotting-functions-srqvs5"
+          entrapment_ref="main"
 
           if [[ "$entrapment_repo" != http* ]]; then
             entrapment_repo_url="https://github.com/${entrapment_repo}"
@@ -132,7 +132,7 @@ jobs:
             mkdir -p "$RUN_DIR"
             cd "$RUN_DIR"
 
-            regression_branch="codex/update-run_efdr_analysis-parameters-o07uog"
+            regression_branch="main"
             if [ -d regression-configs/.git ]; then
               git -C regression-configs fetch --all
             else


### PR DESCRIPTION
### Motivation
- Ensure regression workflows default to checking out the `main` branch for the external `pioneer-regression-configs` and `PioneerEntrapment.jl` repos and keep the standard and Slurm regression workflows consistent.

### Description
- Updated `.github/workflows/regression.yml` and `.github/workflows/regression_slurm.yml` to set `entrapment_ref="main"` and `regression_branch="main"` in place of previously hard-coded feature branches.

### Testing
- No automated tests were run because this change only modifies CI workflow defaults (workflow-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fec389a548325baa4ac1c99192bee)