### PR TITLE
fix: extend gh-pages update timeout

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -730,7 +730,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' DEVELOP_DIR='${develop_dir}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
             lock_dir="${DEVELOP_DIR}.lock"
@@ -788,7 +788,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' RELEASE_DIR='${release_dir}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
 
@@ -831,7 +831,7 @@ jobs:
             -o ConnectTimeout=30
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' REPORT_PATH='${report_path}' REPORT_SUBDIR='${report_subdir}' HISTORY_BRANCH='${history_branch}' GITHUB_REPOSITORY='${GITHUB_REPOSITORY}' GITHUB_TOKEN='${GITHUB_TOKEN}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
 

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -736,7 +736,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' DEVELOP_DIR='${develop_dir}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
             lock_dir="${DEVELOP_DIR}.lock"
@@ -794,7 +794,7 @@ jobs:
             -q
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' RELEASE_DIR='${release_dir}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
 
@@ -837,7 +837,7 @@ jobs:
             -o ConnectTimeout=30
           )
 
-          timeout 300 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
+          timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' REPORT_PATH='${report_path}' REPORT_SUBDIR='${report_subdir}' HISTORY_BRANCH='${history_branch}' GITHUB_REPOSITORY='${GITHUB_REPOSITORY}' GITHUB_TOKEN='${GITHUB_TOKEN}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
 


### PR DESCRIPTION
### Motivation
- Prevent premature SSH timeouts when updating the gh-pages site and syncing results to the cluster by allowing longer-running remote operations.

### Description
- Increase the `timeout` value from `300` to `9000` seconds for SSH invocations in `.github/workflows/regression.yml` to cover the develop metrics sync, release sync, and gh-pages update steps.
- Mirror the same `timeout` increase in `.github/workflows/regression_slurm.yml` for the corresponding steps on the slurm-target cluster.
- Change is limited to GitHub Actions workflow YAML files and only affects the remote SSH command timeouts.

### Testing
- No automated tests were run because this is a CI workflow configuration change only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970070724c083258917f3abfe167edd)