### PR TITLE
fix: relax approval for manual regression runs

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -58,7 +58,7 @@ permissions:
 jobs:
   regression:
     name: Julia ${{ matrix.version }} regression sweep (${{ matrix.regression_set }})
-    environment: regression-tests-${{ matrix.regression_set }}
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'regression-tests-manual' || format('regression-tests-{0}', matrix.regression_set) }}
     runs-on: [self-hosted, Linux, pioneer-regression]
     timeout-minutes: 7200
     strategy:

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -65,7 +65,7 @@ permissions:
 jobs:
   regression:
     name: Julia ${{ matrix.version }} regression sweep (${{ matrix.regression_set }})
-    environment: regression-tests-${{ matrix.regression_set }}
+    environment: ${{ github.event_name == 'workflow_dispatch' && 'regression-tests-manual' || format('regression-tests-{0}', matrix.regression_set) }}
     runs-on: [self-hosted, Linux, pioneer-regression]
     timeout-minutes: 7200
     strategy:


### PR DESCRIPTION
### Motivation
- Make manually-triggered regression workflows bypass the gated environment that requires reviewer approval while keeping automatically-triggered runs on the gated environments.
- Ensure consistent behavior between the LSF and SLURM regression workflows.

### Description
- Change the `environment` selection in `.github/workflows/regression.yml` to use the conditional `github.event_name == 'workflow_dispatch'` to pick `'regression-tests-manual'` for manual runs and `format('regression-tests-{0}', matrix.regression_set)` for automatic runs.
- Apply the same `environment` conditional update to `.github/workflows/regression_slurm.yml` for parity between SLURM and LSF regression pipelines.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69700b34bcec8325a99767d2552653e6)