### PR TITLE
fix: avoid develop metrics lock wait

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -733,20 +733,6 @@ jobs:
           timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' DEVELOP_DIR='${develop_dir}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
-            lock_dir="${DEVELOP_DIR}.lock"
-            lock_timeout=900
-            lock_interval=10
-            start_time=$(date +%s)
-
-            while ! mkdir "$lock_dir" 2>/dev/null; do
-              if [ $(( $(date +%s) - start_time )) -ge "$lock_timeout" ]; then
-                echo "Timeout waiting for develop metrics lock at $lock_dir" >&2
-                exit 1
-              fi
-              sleep "$lock_interval"
-            done
-            trap 'rmdir "$lock_dir"' EXIT
-
             if [ ! -d "$RUN_DIR/results" ]; then
               echo "Run results directory not found at $RUN_DIR/results" >&2
               exit 1

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -739,20 +739,6 @@ jobs:
           timeout 9000 ssh "${ssh_options[@]}" "${CLUSTER_USERNAME}@${CLUSTER_HOST}" \
             "RUN_DIR='${remote_run_dir}' DEVELOP_DIR='${develop_dir}' LMOD_QUIET=1 LMOD_SILENT=1 bash --noprofile --norc -s" <<'EOF'
             set -euo pipefail
-            lock_dir="${DEVELOP_DIR}.lock"
-            lock_timeout=900
-            lock_interval=10
-            start_time=$(date +%s)
-
-            while ! mkdir "$lock_dir" 2>/dev/null; do
-              if [ $(( $(date +%s) - start_time )) -ge "$lock_timeout" ]; then
-                echo "Timeout waiting for develop metrics lock at $lock_dir" >&2
-                exit 1
-              fi
-              sleep "$lock_interval"
-            done
-            trap 'rmdir "$lock_dir"' EXIT
-
             if [ ! -d "$RUN_DIR/results" ]; then
               echo "Run results directory not found at $RUN_DIR/results" >&2
               exit 1


### PR DESCRIPTION
### Motivation

- Prevent regression workflow runs from blocking while waiting for a develop metrics lock on shared storage.
- Remove the fragile `mkdir`-based lock and timeout (`DEVELOP_DIR.lock`, `mkdir` loop, and `trap 'rmdir'`) so the sync step does not block.
- Apply the same behavior to both `.github/workflows/regression.yml` and `.github/workflows/regression_slurm.yml`.

### Description

- Deleted the lock acquisition and wait loop (the `DEVELOP_DIR.lock` `mkdir` loop, timeout and `trap`) from the SSH-executed `Sync develop metrics to shared storage` step in `regression.yml`.
- Applied the identical removal to the `Sync develop metrics to shared storage` step in `regression_slurm.yml`.
- Kept the guard that checks `RUN_DIR/results`, the rotation of an existing `DEVELOP_DIR` with a timestamp, the `mkdir -p` for `DEVELOP_DIR`, and the `rsync -a` copy.

### Testing

- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970ead3f7388325aab290cf5606287a)