### PR TITLE
fix(workflows): correct develop/release metrics paths in regression workflows

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -719,7 +719,7 @@ jobs:
           remote_run_dir="${CLUSTER_RUN_DIR:?CLUSTER_RUN_DIR not set}"
           run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
           run_root="${run_root_raw%/}/runs"
-          develop_dir="${run_root}/metrics/develop"
+          develop_dir="${run_root_raw%/}/metrics/develop"
 
           ssh_options=(
             -o BatchMode=yes
@@ -763,7 +763,7 @@ jobs:
           run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
           run_root="${run_root_raw%/}/runs"
           release_tag="${RELEASE_TAG:?RELEASE_TAG not set}"
-          release_dir="${run_root}/release/${release_tag}"
+          release_dir="${run_root_raw%/}/release/${release_tag}"
 
           ssh_options=(
             -o BatchMode=yes

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -725,7 +725,7 @@ jobs:
           remote_run_dir="${CLUSTER_RUN_DIR:?CLUSTER_RUN_DIR not set}"
           run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
           run_root="${run_root_raw%/}/runs"
-          develop_dir="${run_root}/metrics/develop"
+          develop_dir="${run_root_raw%/}/metrics/develop"
 
           ssh_options=(
             -o BatchMode=yes
@@ -769,7 +769,7 @@ jobs:
           run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
           run_root="${run_root_raw%/}/runs"
           release_tag="${RELEASE_TAG:?RELEASE_TAG not set}"
-          release_dir="${run_root}/release/${release_tag}"
+          release_dir="${run_root_raw%/}/release/${release_tag}"
 
           ssh_options=(
             -o BatchMode=yes


### PR DESCRIPTION
### Motivation

- The regression workflows were syncing develop and release metrics into the `runs` subdirectory, but the metrics live under the raw run root after the runs were moved into a `runs/` subdirectory. 
- This change ensures metrics are written to the actual storage locations so historical develop and release metrics remain reachable and consistent with existing layout.

### Description

- Updated `.github/workflows/regression.yml` to set `develop_dir` to `${run_root_raw%/}/metrics/develop` instead of `${run_root}/metrics/develop` so metrics target the raw run root. 
- Updated `.github/workflows/regression.yml` to set `release_dir` to `${run_root_raw%/}/release/${release_tag}` instead of `${run_root}/release/${release_tag}` so release metrics target the raw run root. 
- Applied the same two fixes to `.github/workflows/regression_slurm.yml` and kept `run_root` (the `runs` path) available for other uses in the workflow.

### Testing

- No automated tests were run because this is a workflow-only change; CI will validate on next workflow execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970efc62d948325afb1a7999bbcc132)