### PR TITLE
chore: run regression workflows on tag pushes and honor tag refs

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,6 +1,9 @@
 name: Regression Tests (LSF)
 
 on:
+  push:
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       regression_set:
@@ -65,6 +68,9 @@ jobs:
       matrix:
         version: ['1.11']
         regression_set: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["all"]') }}
+    env:
+      GITHUB_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || (github.ref_type == 'tag' && github.ref_name || github.sha) }}
+      GITHUB_REF_NAME: ${{ github.ref_type == 'tag' && github.ref_name || github.ref_name }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -75,7 +81,6 @@ jobs:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
-          GITHUB_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           GITHUB_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           CLUSTER_ENTRAPMENT_REPO: ${{ secrets.CLUSTER_ENTRAPMENT_REPO }}
           REGRESSION_SET: ${{ github.event_name == 'workflow_dispatch' && inputs.regression_set || matrix.regression_set }}
@@ -796,8 +801,8 @@ jobs:
           REPORT_HTML_PATH: ${{ env.REPORT_HTML_PATH }}
           REPORT_PAGES_SUBDIR: ${{ env.REPORT_PAGES_SUBDIR }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_REF_NAME: ${{ github.ref_name }}
-          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_REF_NAME: ${{ env.GITHUB_REF_NAME }}
+          GITHUB_SHA: ${{ env.GITHUB_SHA }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - develop
+    tags:
+      - 'v*.*.*'
   release:
     types: [published]
   pull_request:
@@ -72,6 +74,9 @@ jobs:
       matrix:
         version: ['1.11']
         regression_set: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["all"]') }}
+    env:
+      GITHUB_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || (github.ref_type == 'tag' && github.ref_name || github.sha) }}
+      GITHUB_REF_NAME: ${{ github.ref_type == 'tag' && github.ref_name || github.ref_name }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -82,7 +87,6 @@ jobs:
           CLUSTER_HOST: ${{ secrets.CLUSTER2_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
-          GITHUB_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           GITHUB_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           CLUSTER_ENTRAPMENT_REPO: ${{ secrets.CLUSTER_ENTRAPMENT_REPO }}
           REGRESSION_SET: ${{ github.event_name == 'workflow_dispatch' && inputs.regression_set || matrix.regression_set }}
@@ -802,8 +806,8 @@ jobs:
           REPORT_HTML_PATH: ${{ env.REPORT_HTML_PATH }}
           REPORT_PAGES_SUBDIR: ${{ env.REPORT_PAGES_SUBDIR }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_REF_NAME: ${{ github.ref_name }}
-          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_REF_NAME: ${{ env.GITHUB_REF_NAME }}
+          GITHUB_SHA: ${{ env.GITHUB_SHA }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
- Allow regression workflows to run for released versions by triggering on tag pushes matching `v*.*.*` while preserving the existing `develop` branch push behavior. 
- Ensure cluster runs and generated report paths use the release tag ref so `GITHUB_SHA` and `GITHUB_REF_NAME` reflect the tag commit/ref instead of the workflow runner commit. 

### Description
- Added `push: tags: - 'v*.*.*'` to `.github/workflows/regression.yml` and `.github/workflows/regression_slurm.yml` to trigger on release tags. 
- Introduced job-level `env` entries `GITHUB_SHA` and `GITHUB_REF_NAME` that prefer PR head SHAs or tag refs (`github.ref_type == 'tag'`) and fall back to `github.sha`/`github.ref_name`. 
- Replaced inline uses of `github.sha`/`github.ref_name` in downstream step environments with the new `env.GITHUB_SHA` and `env.GITHUB_REF_NAME` so cluster checkouts, report directories, and pages updates use the tag-based values. 

### Testing
- No automated tests were run because this is a workflow-only change and CI execution was not invoked during the update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724adbdf1883259a473b9feb43cd7f)