### PR TITLE
fix: support tag-dispatch release updates in regression workflows

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -753,13 +753,13 @@ jobs:
           EOF
 
       - name: Sync release metrics to shared storage
-        if: github.event_name == 'release' && matrix.regression_set == 'all'
+        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag')) && matrix.regression_set == 'all'
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
           CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1020,19 +1020,34 @@ jobs:
             });
 
       - name: Update release notes with regression report
-        if: github.event_name == 'release' && env.REPORT_PAGES_SUBDIR != ''
+        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag')) && env.REPORT_PAGES_SUBDIR != ''
         uses: actions/github-script@v7
         env:
           REPORT_PAGES_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
           REPORT_PAGES_SUBDIR: ${{ env.REPORT_PAGES_SUBDIR }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
         with:
           script: |
             const pagesUrl = process.env.REPORT_PAGES_URL;
             const reportSubdir = process.env.REPORT_PAGES_SUBDIR;
-            const release = context.payload.release;
-            if (!pagesUrl || !reportSubdir || !release) {
-              core.info('Missing Pages URL, report subdir, or release payload; skipping release notes update.');
+            if (!pagesUrl || !reportSubdir) {
+              core.info('Missing Pages URL or report subdir; skipping release notes update.');
               return;
+            }
+            const { owner, repo } = context.repo;
+            let release = context.payload.release;
+            if (!release) {
+              const releaseTag = process.env.RELEASE_TAG;
+              if (!releaseTag) {
+                core.info('Missing release payload and tag; skipping release notes update.');
+                return;
+              }
+              const response = await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
+                tag: releaseTag,
+              });
+              release = response.data;
             }
             const normalizedBase = pagesUrl.endsWith('/') ? pagesUrl.slice(0, -1) : pagesUrl;
             const reportUrl = `${normalizedBase}/${reportSubdir}/`;

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -758,13 +758,13 @@ jobs:
           EOF
 
       - name: Sync release metrics to shared storage
-        if: github.event_name == 'release' && matrix.regression_set == 'all'
+        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag')) && matrix.regression_set == 'all'
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER2_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
           CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
           CLUSTER_RUN_ROOT: ${{ secrets.CLUSTER_RUN_ROOT }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1025,19 +1025,34 @@ jobs:
             });
 
       - name: Update release notes with regression report
-        if: github.event_name == 'release' && env.REPORT_PAGES_SUBDIR != ''
+        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag')) && env.REPORT_PAGES_SUBDIR != ''
         uses: actions/github-script@v7
         env:
           REPORT_PAGES_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
           REPORT_PAGES_SUBDIR: ${{ env.REPORT_PAGES_SUBDIR }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
         with:
           script: |
             const pagesUrl = process.env.REPORT_PAGES_URL;
             const reportSubdir = process.env.REPORT_PAGES_SUBDIR;
-            const release = context.payload.release;
-            if (!pagesUrl || !reportSubdir || !release) {
-              core.info('Missing Pages URL, report subdir, or release payload; skipping release notes update.');
+            if (!pagesUrl || !reportSubdir) {
+              core.info('Missing Pages URL or report subdir; skipping release notes update.');
               return;
+            }
+            const { owner, repo } = context.repo;
+            let release = context.payload.release;
+            if (!release) {
+              const releaseTag = process.env.RELEASE_TAG;
+              if (!releaseTag) {
+                core.info('Missing release payload and tag; skipping release notes update.');
+                return;
+              }
+              const response = await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
+                tag: releaseTag,
+              });
+              release = response.data;
             }
             const normalizedBase = pagesUrl.endsWith('/') ? pagesUrl.slice(0, -1) : pagesUrl;
             const reportUrl = `${normalizedBase}/${reportSubdir}/`;


### PR DESCRIPTION
### Motivation
- Release-only steps in regression workflows should run for tag-based manual `workflow_dispatch` runs and must resolve the release tag when the `release` event payload is absent.

### Description
- Broadened release-only `if:` guards in `.github/workflows/regression.yml` to also allow `(github.event_name == 'workflow_dispatch' && github.ref_type == 'tag')` and mirrored the same change in `.github/workflows/regression_slurm.yml`.
- Added a fallback for the release tag value using `github.ref_name` when `github.event.release.tag_name` is unavailable and exported it as `RELEASE_TAG` in both workflows.
- Updated the `actions/github-script` release notes step to fetch the release via the GitHub API using `repos.getReleaseByTag({ owner, repo, tag })` when `context.payload.release` is missing, then update the release body with the regression report link.

### Testing
- No automated tests were run because these are GitHub Actions workflow changes only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724c47c5b483259708e47ee4b3a979)