### PR TITLE
fix: detect tag dispatches in regression workflows

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -69,8 +69,8 @@ jobs:
         version: ['1.11']
         regression_set: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["all"]') }}
     env:
-      GITHUB_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || (github.ref_type == 'tag' && github.ref_name || github.sha) }}
-      GITHUB_REF_NAME: ${{ github.ref_type == 'tag' && github.ref_name || github.ref_name }}
+      GITHUB_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || (startsWith(github.ref, 'refs/tags/') && github.ref_name || github.sha) }}
+      GITHUB_REF_NAME: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || github.ref_name }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -753,7 +753,7 @@ jobs:
           EOF
 
       - name: Sync release metrics to shared storage
-        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag')) && matrix.regression_set == 'all'
+        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/'))) && matrix.regression_set == 'all'
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
@@ -1020,7 +1020,7 @@ jobs:
             });
 
       - name: Update release notes with regression report
-        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag')) && env.REPORT_PAGES_SUBDIR != ''
+        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/'))) && env.REPORT_PAGES_SUBDIR != ''
         uses: actions/github-script@v7
         env:
           REPORT_PAGES_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -75,8 +75,8 @@ jobs:
         version: ['1.11']
         regression_set: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["all"]') }}
     env:
-      GITHUB_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || (github.ref_type == 'tag' && github.ref_name || github.sha) }}
-      GITHUB_REF_NAME: ${{ github.ref_type == 'tag' && github.ref_name || github.ref_name }}
+      GITHUB_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || (startsWith(github.ref, 'refs/tags/') && github.ref_name || github.sha) }}
+      GITHUB_REF_NAME: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || github.ref_name }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -758,7 +758,7 @@ jobs:
           EOF
 
       - name: Sync release metrics to shared storage
-        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag')) && matrix.regression_set == 'all'
+        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/'))) && matrix.regression_set == 'all'
         env:
           CLUSTER_HOST: ${{ secrets.CLUSTER2_HOST }}
           CLUSTER_USERNAME: ${{ secrets.CLUSTER_USERNAME }}
@@ -1025,7 +1025,7 @@ jobs:
             });
 
       - name: Update release notes with regression report
-        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag')) && env.REPORT_PAGES_SUBDIR != ''
+        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/'))) && env.REPORT_PAGES_SUBDIR != ''
         uses: actions/github-script@v7
         env:
           REPORT_PAGES_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}


### PR DESCRIPTION
### Motivation
- Manual `workflow_dispatch` runs on tags were not reliably detected because `github.ref_type` is not set for manual dispatches, so checks should examine `github.ref` instead.

### Description
- Replace occurrences of `github.ref_type == 'tag'` with `startsWith(github.ref, 'refs/tags/')` and update related expressions for `GITHUB_SHA` and `GITHUB_REF_NAME` in `.github/workflows/regression.yml` and `.github/workflows/regression_slurm.yml`.
- Update release-only step conditions (including the release notes update step and the sync-to-shared-storage step) to use the `startsWith(github.ref, 'refs/tags/')` check.

### Testing
- No automated tests were run because this is a CI workflow change only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697297674be8832585ce02c12d9f4f8f)