### PR TITLE
determinisitic params for lightGBM

### DIFF
--- a/src/utils/ML/lightgbm_utils.jl
+++ b/src/utils/ML/lightgbm_utils.jl
@@ -84,9 +84,9 @@ function build_lightgbm_classifier(; num_iterations::Integer = 100,
         num_class = 1,
         verbosity = Int(verbosity),
         is_unbalance = is_unbalance,
-        #seed = 1776, # potentialy needed for stable results
-        #deterministic = true, # potentialy needed for stable results
-        #force_row_wise = true # potentialy needed for stable results
+        seed = 1776, # potentialy needed for stable results
+        deterministic = true, # potentialy needed for stable results
+        force_row_wise = true # potentialy needed for stable results
     )
 end
 


### PR DESCRIPTION
LightGBM models use deterministic mode which should make them more consistent with different numbers of threads.