### PR TITLE
feat: add `specificity` option and track `num_enzymatic_termini` through library & scoring

### DIFF
--- a/assets/example_config/defaultBuildLibParams.json
+++ b/assets/example_config/defaultBuildLibParams.json
@@ -25,6 +25,7 @@
         "min_charge": 2,
         "max_charge": 4,
         "cleavage_regex": "[KR][^_|$]",
+        "specificity": "full",
         "missed_cleavages": 1,
         "max_var_mods": 1,
         "add_decoys": true,

--- a/assets/example_config/defaultBuildLibParamsSimplified.json
+++ b/assets/example_config/defaultBuildLibParamsSimplified.json
@@ -35,6 +35,7 @@
         "min_charge": 2,
         "max_charge": 3,
         "cleavage_regex": "[KR][^_|$]",
+        "specificity": "full",
         "missed_cleavages": 1,
         "max_var_mods": 1
     },

--- a/docs/src/user_guide/parameters.md
+++ b/docs/src/user_guide/parameters.md
@@ -221,6 +221,7 @@ The regex patterns for parsing FASTA headers can be configured in three ways:
 | `min_charge` | Int | Minimum charge state (default: 2) |
 | `max_charge` | Int | Maximum charge state (default: 4) |
 | `cleavage_regex` | String | Regular expression for cleavage sites (default: "[KR][^_\|$]", to exclude cleavage after proline: "[KR][^P|$]") |
+| `specificity` | String | Digestion specificity ("full", "semi-n", "semi-c", or "semi"; default: "full") |
 | `missed_cleavages` | Int | Maximum allowed missed cleavages (default: 1) |
 | `max_var_mods` | Int | Maximum variable modifications per peptide (default: 1) |
 | `add_decoys` | Boolean | Generate decoy sequences (default: true) |

--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -313,6 +313,9 @@ function BuildSpecLib(params_path::String)
                 precursors_table[!, :mz] = Float32.(precursors_table[!, :mz])
                 precursors_table[!, :irt] = Float32.(precursors_table[!, :irt])
                 precursors_table[!, :start_idx] = UInt32.(precursors_table[!, :start_idx])
+                if hasproperty(precursors_table, :num_enzymatic_termini)
+                    precursors_table[!, :num_enzymatic_termini] = UInt8.(precursors_table[!, :num_enzymatic_termini])
+                end
 
                 # Save processed precursor table
                 println("   Before add_pair_indices!: $(nrow(precursors_table)) precursors")

--- a/src/Routines/BuildSpecLib/chronologer/chronologer_prep.jl
+++ b/src/Routines/BuildSpecLib/chronologer/chronologer_prep.jl
@@ -162,7 +162,8 @@ function prepare_chronologer_input(
                 regex = Regex(_params.fasta_digest_params["cleavage_regex"]),
                 max_length = _params.fasta_digest_params["max_length"],
                 min_length = _params.fasta_digest_params["min_length"],
-                missed_cleavages = _params.fasta_digest_params["missed_cleavages"]
+                missed_cleavages = _params.fasta_digest_params["missed_cleavages"],
+                specificity = _params.fasta_digest_params["specificity"]
             )
         )
     end
@@ -348,6 +349,7 @@ function add_mods(
                     get_base_target_id(fasta_peptide), # preserve base_target_id
                     get_base_pep_id(fasta_peptide),  # Preserve original base_pep_id
                     get_entrapment_pair_id(fasta_peptide),
+                    get_num_enzymatic_termini(fasta_peptide),
                     is_decoy(fasta_peptide),
                 ))
         end
@@ -401,6 +403,7 @@ function add_charge(
                     get_base_target_id(fasta_peptide), # preserve base_target_id
                     get_base_pep_id(fasta_peptide),   # preserve base_pep_id
                     get_entrapment_pair_id(fasta_peptide),
+                    get_num_enzymatic_termini(fasta_peptide),
                     is_decoy(fasta_peptide)
                 ))
         end
@@ -489,6 +492,7 @@ Create a DataFrame containing peptide information from FASTA entries.
 - `DataFrame`: DataFrame containing peptide information including:
   - Precursor identification info (upid, accession_number)
   - Sequence information (sequence, mods, isotopic_mods)
+  - Digestion information (num_enzymatic_termini)
   - Charge and energy (precursor_charge, collision_energy)
   - Group information (decoy, entrapment_group_id, base_pep_id, pair_id)
   - Koina-compatible sequence representation
@@ -549,6 +553,7 @@ function build_fasta_df(fasta_peptides::Vector{FastaEntry};
     _structural_mods = Vector{Union{String, Missing}}(undef, prec_alloc_size)
     _isotopic_mods = Vector{Union{String, Missing}}(undef, prec_alloc_size)
     _start_idx = Vector{UInt32}(undef, prec_alloc_size)
+    _num_enzymatic_termini = Vector{UInt8}(undef, prec_alloc_size)
     _precursor_charge = Vector{UInt8}(undef, prec_alloc_size)
     _collision_energy = Vector{Float32}(undef, prec_alloc_size )
     _decoy = Vector{Bool}(undef, prec_alloc_size)  
@@ -570,6 +575,7 @@ function build_fasta_df(fasta_peptides::Vector{FastaEntry};
         _accession_number[n] = accession_id
         _sequence[n] = sequence
         _start_idx[n] = get_start_idx(peptide)
+        _num_enzymatic_termini[n] = get_num_enzymatic_termini(peptide)
         _structural_mods[n] = getModString(get_structural_mods(peptide))
         _isotopic_mods[n] = getModString(get_isotopic_mods(peptide))
         _precursor_charge[n] = get_charge(peptide)
@@ -587,6 +593,7 @@ function build_fasta_df(fasta_peptides::Vector{FastaEntry};
          accession_number = _accession_number[1:n],
          sequence = _sequence[1:n],
          start_idx = _start_idx[1:n],
+         num_enzymatic_termini = _num_enzymatic_termini[1:n],
          mods = _structural_mods[1:n],
          isotopic_mods = _isotopic_mods[1:n],
          precursor_charge = _precursor_charge[1:n],

--- a/src/Routines/BuildSpecLib/fasta/fasta_utils.jl
+++ b/src/Routines/BuildSpecLib/fasta/fasta_utils.jl
@@ -223,6 +223,7 @@ function add_entrapment_sequences(
                         get_base_target_id(target_entry), # inherit base_target_id for tracking
                         get_base_pep_id(target_entry),
                         entrapment_group_id,
+                        get_num_enzymatic_termini(target_entry),
                         false
                     )
                     n += 1
@@ -400,6 +401,7 @@ function add_entrapment_sequences_grouped(
                     get_base_target_id(target_entry),
                     get_base_pep_id(target_entry),
                     UInt8(i),
+                    get_num_enzymatic_termini(target_entry),
                     false
                 ))
             end
@@ -805,6 +807,7 @@ function add_decoy_sequences(
                 get_base_target_id(target_entry), # inherit base_target_id for tracking
                 get_base_pep_id(target_entry),  # inherit base_pep_id for pairing
                 get_entrapment_pair_id(target_entry),
+                get_num_enzymatic_termini(target_entry),
                 true  # This is a decoy sequence
             )
             
@@ -963,6 +966,7 @@ function add_decoy_sequences_grouped(
                 get_base_target_id(target_entry),
                 get_base_pep_id(target_entry),
                 get_entrapment_pair_id(target_entry),
+                get_num_enzymatic_termini(target_entry),
                 true
             ))
         end
@@ -1056,7 +1060,8 @@ function combine_shared_peptides(peptides::Vector{FastaEntry})
                                                         get_charge(fasta_entry),
                                                         get_base_target_id(fasta_entry), # preserve base_target_id
                                                         base_pep_id,
-                                                        get_entrapment_pair_id(fasta_entry), 
+                                                        get_entrapment_pair_id(fasta_entry),
+                                                        get_num_enzymatic_termini(fasta_entry),
                                                         is_decoy(fasta_entry)
                                                         )
             base_pep_id += one(UInt32)
@@ -1104,6 +1109,7 @@ function assign_base_pep_ids!(fasta_entries::Vector{FastaEntry})
             get_base_target_id(entry), # preserve base_target_id
             UInt32(i),               # base_pep_id - sequential assignment
             get_entrapment_pair_id(entry),
+            get_num_enzymatic_termini(entry),
             is_decoy(entry)
         )
     end
@@ -1131,6 +1137,7 @@ function assign_base_target_ids!(fasta_entries::Vector{FastaEntry})
             UInt32(i),   # assign grouped base_target_id
             get_base_pep_id(entry),    # preserve existing base_pep_id
             get_entrapment_pair_id(entry),
+            get_num_enzymatic_termini(entry),
             is_decoy(entry)
         )
     end

--- a/src/Routines/BuildSpecLib/utils/check_params.jl
+++ b/src/Routines/BuildSpecLib/utils/check_params.jl
@@ -78,6 +78,23 @@ function check_params_bsp(json_string::String)
     check_param(fasta_digest_params, "max_var_mods", Integer)
     check_param(fasta_digest_params, "add_decoys", Bool)
     check_param(fasta_digest_params, "entrapment_r", Real)
+
+    if haskey(fasta_digest_params, "specificity")
+        check_param(fasta_digest_params, "specificity", String)
+    end
+    if !haskey(fasta_digest_params, "specificity") && haskey(fasta_digest_params, "enzymaticity")
+        fasta_digest_params["specificity"] = fasta_digest_params["enzymaticity"]
+    end
+
+    if !haskey(fasta_digest_params, "specificity")
+        fasta_digest_params["specificity"] = "full"
+    else
+        specificity = lowercase(fasta_digest_params["specificity"])
+        if !(specificity in ["full", "semi-n", "semi-c", "semi"])
+            error("specificity must be one of \"full\", \"semi-n\", \"semi-c\", or \"semi\"; got: $(fasta_digest_params["specificity"])")
+        end
+        fasta_digest_params["specificity"] = specificity
+    end
     
     # Check decoy_method with default value
     if !haskey(fasta_digest_params, "decoy_method")

--- a/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/FirstPassSearch/utils.jl
@@ -51,6 +51,7 @@ function add_main_search_columns!(psms::DataFrame,
                                 rt_irt::T,
                                 structural_mods::AbstractVector{Union{Missing, String}},
                                 prec_missed_cleavages::Arrow.Primitive{UInt8, Vector{UInt8}},
+                                prec_num_enzymatic_termini::AbstractVector{UInt8},
                                 prec_is_decoy::Arrow.BoolVector{Bool},
                                 prec_irt::Arrow.Primitive{U, Vector{U}},
                                 prec_charge::Arrow.Primitive{UInt8, Vector{UInt8}},
@@ -63,6 +64,7 @@ function add_main_search_columns!(psms::DataFrame,
     #Allocate new columns
     N = size(psms, 1)
     missed_cleavage = zeros(UInt8, N);
+    num_enzymatic_termini = zeros(UInt8, N);
     Mox = zeros(UInt8, N);
     irt_pred = zeros(Float32, N);
     rt = zeros(Float32, N);
@@ -92,6 +94,7 @@ function add_main_search_columns!(psms::DataFrame,
 
                 targets[i] = prec_is_decoy[prec_idx] == false;
                 missed_cleavage[i] = prec_missed_cleavages[prec_idx]
+                num_enzymatic_termini[i] = prec_num_enzymatic_termini[prec_idx]
                 Mox[i] = countMOX(coalesce(structural_mods[prec_idx], ""))::UInt8 #UInt8(length(collect(eachmatch(r"ox",  precursors[precursor_idx[i]].sequence))))
                 irt_pred[i] = Float32(prec_irt[prec_idx]);
                 rt[i] = Float32(scan_retention_time[scan_idx[i]]);
@@ -112,6 +115,7 @@ function add_main_search_columns!(psms::DataFrame,
     psms[!,:err_norm] = err_norm
     psms[!,:target] = targets
     psms[!,:missed_cleavage] = missed_cleavage
+    psms[!,:num_enzymatic_termini] = num_enzymatic_termini
     psms[!,:Mox] = Mox
     psms[!,:charge] = charge
     psms[!,:spectrum_peak_count] = spectrum_peak_count
@@ -766,6 +770,5 @@ function mass_err_ms1(ppm_errs::Vector{Float32},
         (Float32(abs(l_bound)), Float32(abs(r_bound)))
     ), pmp_errs_corrected
 end
-
 
 

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
@@ -43,6 +43,7 @@ end
 # Note: :target is excluded as it's the label, not a feature
 const ADVANCED_FEATURE_SET = [
     :missed_cleavage,
+    :num_enzymatic_termini,
     :Mox,
     :prec_mz_qbin,     # Quantile-binned version of :prec_mz
     #:prec_mz,
@@ -106,7 +107,7 @@ const ADVANCED_FEATURE_SET = [
 
 const REDUCED_FEATURE_SET = [
     # Core peptide properties
-    :missed_cleavage, :Mox, :prec_mz_qbin, :sequence_length, :charge,
+    :missed_cleavage, :num_enzymatic_termini, :Mox, :prec_mz_qbin, :sequence_length, :charge,
     # RT features
     :irt_pred_qbin, :irt_error, :irt_diff,
     :ms1_ms2_rt_diff,  # MS1-MS2 RT difference in iRT space

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
@@ -357,6 +357,7 @@ function train_lightgbm_model_in_memory(
             :MBR_is_missing
         ])
     end
+    remove_zero_variance_columns!(features, best_psms)
 
     # Diagnostic: Report which quantile-binned features are being used
     qbin_features = filter(f -> endswith(string(f), "_qbin"), features)

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
@@ -519,6 +519,7 @@ function get_quant_necessary_columns(match_between_runs::Bool)
         qval_cols.global_qval,  # Conditional: :MBR_boosted_global_qval or :global_qval
         :run_specific_qval,
         :prec_mz,
+        :start_idx,
         qval_cols.pep,  # Always :pep but included for consistency
         :weight,
         :target,

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/scoring_interface.jl
@@ -525,6 +525,7 @@ function get_quant_necessary_columns(match_between_runs::Bool)
         :rt,
         :irt_obs,
         :missed_cleavage,
+        :num_enzymatic_termini,
         :Mox,
         :isotopes_captured,
         :scan_idx,

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -842,6 +842,11 @@ function add_features!(psms::DataFrame,
     prec_charge = getCharge(getPrecursors(getSpecLib(search_context)))#[:prec_charge],
     entrap_group_ids = getEntrapmentGroupId(getPrecursors(getSpecLib(search_context)))
     precursor_missed_cleavage = getMissedCleavages(getPrecursors(getSpecLib(search_context)))#[:missed_cleavages],
+    precursor_num_enzymatic_termini = if hasproperty(getPrecursors(getSpecLib(search_context)).data, :num_enzymatic_termini)
+        getNumEnzymaticTermini(getPrecursors(getSpecLib(search_context)))
+    else
+        fill(UInt8(0), length(getPrecursors(getSpecLib(search_context))))
+    end
     precursor_pair_idxs = getPairIdx(getPrecursors(getSpecLib(search_context)))
     #filter!(x -> x.best_scan, psms);
     filter!(x->x.weight>0, psms);
@@ -859,6 +864,7 @@ function add_features!(psms::DataFrame,
     #psms[!,:missed_cleavage] .= zero(UInt8);
     #psms[!,:sequence] .= "";
     missed_cleavage = zeros(UInt8, N);
+    num_enzymatic_termini = zeros(UInt8, N);
     #sequence = Vector{String}(undef, N);
     #stripped_sequence = Vector{String}(undef, N);
     adjusted_intensity_explained = zeros(Float16, N);
@@ -913,6 +919,7 @@ function add_features!(psms::DataFrame,
                 irt_error[i] = abs(irt_obs[i] - irt_pred[i])
 
                 missed_cleavage[i] = precursor_missed_cleavage[prec_idx]
+                num_enzymatic_termini[i] = precursor_num_enzymatic_termini[prec_idx]
                 #sequence[i] = precursor_sequence[prec_idx]
                 sequence_length[i] = length(replace(precursor_sequence[prec_idx], r"\(.*?\)" => ""))#replace.(sequence[i], "M(ox)" => "M");
                 Mox[i] = countMOX(structural_mods[prec_idx])::UInt8
@@ -935,6 +942,7 @@ function add_features!(psms::DataFrame,
     psms[!,:irt_error] = irt_error
     psms[!,:ms1_irt_diff] = ms1_irt_diff
     psms[!,:missed_cleavage] = missed_cleavage
+    psms[!,:num_enzymatic_termini] = num_enzymatic_termini
     #psms[!,:sequence] = sequence
     #psms[!,:stripped_sequence] = stripped_sequence
     psms[!,:Mox] = Mox

--- a/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/SecondPassSearch/utils.jl
@@ -840,6 +840,7 @@ function add_features!(psms::DataFrame,
     prec_mz = getMz(getPrecursors(getSpecLib(search_context)))#[:mz],
     prec_irt = getIrt(getPrecursors(getSpecLib(search_context)))#[:irt],
     prec_charge = getCharge(getPrecursors(getSpecLib(search_context)))#[:prec_charge],
+    prec_start_idx = getStartIdx(getPrecursors(getSpecLib(search_context)))
     entrap_group_ids = getEntrapmentGroupId(getPrecursors(getSpecLib(search_context)))
     precursor_missed_cleavage = getMissedCleavages(getPrecursors(getSpecLib(search_context)))#[:missed_cleavages],
     precursor_num_enzymatic_termini = if hasproperty(getPrecursors(getSpecLib(search_context)).data, :num_enzymatic_termini)
@@ -865,6 +866,7 @@ function add_features!(psms::DataFrame,
     #psms[!,:sequence] .= "";
     missed_cleavage = zeros(UInt8, N);
     num_enzymatic_termini = zeros(UInt8, N);
+    start_idx = zeros(UInt32, N);
     #sequence = Vector{String}(undef, N);
     #stripped_sequence = Vector{String}(undef, N);
     adjusted_intensity_explained = zeros(Float16, N);
@@ -920,6 +922,7 @@ function add_features!(psms::DataFrame,
 
                 missed_cleavage[i] = precursor_missed_cleavage[prec_idx]
                 num_enzymatic_termini[i] = precursor_num_enzymatic_termini[prec_idx]
+                start_idx[i] = prec_start_idx[prec_idx]
                 #sequence[i] = precursor_sequence[prec_idx]
                 sequence_length[i] = length(replace(precursor_sequence[prec_idx], r"\(.*?\)" => ""))#replace.(sequence[i], "M(ox)" => "M");
                 Mox[i] = countMOX(structural_mods[prec_idx])::UInt8
@@ -943,6 +946,7 @@ function add_features!(psms::DataFrame,
     psms[!,:ms1_irt_diff] = ms1_irt_diff
     psms[!,:missed_cleavage] = missed_cleavage
     psms[!,:num_enzymatic_termini] = num_enzymatic_termini
+    psms[!,:start_idx] = start_idx
     #psms[!,:sequence] = sequence
     #psms[!,:stripped_sequence] = stripped_sequence
     psms[!,:Mox] = Mox

--- a/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
+++ b/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
@@ -247,6 +247,7 @@ function writePrecursorCSV(
         :isotopic_mods,
         :prec_mz,
         :missed_cleavage,
+        :num_enzymatic_termini,
         :global_score,
         :score,
         global_qval_col,  # Conditional: MBR_boosted_global_qval or global_qval

--- a/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
+++ b/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
@@ -203,6 +203,7 @@ function writePrecursorCSV(
     "isotopic_mods"
     "prec_mz"
     "start_idx"
+    "num_enzymatic_termini"
     "global_score"
     String(global_qval_col)  # Conditional: MBR_boosted_global_qval or global_qval
     "use_for_protein_quant"

--- a/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
+++ b/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
@@ -202,6 +202,7 @@ function writePrecursorCSV(
     "structural_mods"
     "isotopic_mods"
     "prec_mz"
+    "start_idx"
     "global_score"
     String(global_qval_col)  # Conditional: MBR_boosted_global_qval or global_qval
     "use_for_protein_quant"
@@ -246,6 +247,7 @@ function writePrecursorCSV(
         :structural_mods,
         :isotopic_mods,
         :prec_mz,
+        :start_idx,
         :missed_cleavage,
         :num_enzymatic_termini,
         :global_score,

--- a/src/structs/KoinaStructs/FastaTypes.jl
+++ b/src/structs/KoinaStructs/FastaTypes.jl
@@ -33,6 +33,7 @@ struct FastaEntry
     base_target_id::UInt32
     base_pep_id::UInt32
     entrapment_pair_id::UInt32
+    num_enzymatic_termini::UInt8
     is_decoy::Bool
 end
 
@@ -48,6 +49,7 @@ get_start_idx(entry::FastaEntry) = entry.start_idx
 get_base_target_id(entry::FastaEntry) = entry.base_target_id
 get_base_pep_id(entry::FastaEntry) = entry.base_pep_id
 get_entrapment_pair_id(entry::FastaEntry) = entry.entrapment_pair_id
+get_num_enzymatic_termini(entry::FastaEntry) = entry.num_enzymatic_termini
 is_decoy(entry::FastaEntry) = entry.is_decoy
 get_isotopic_mods(entry::FastaEntry) = entry.isotopic_mods
 get_structural_mods(entry::FastaEntry) = entry.structural_mods
@@ -86,7 +88,41 @@ function FastaEntry(
     return FastaEntry(
         String(accession), String(description), String(gene), String(protein), String(organism), String(proteome), String(sequence),
         start_idx, struct_mods, iso_mods, charge,
-        base_target_id, base_pep_id, UInt32(entrapment_pair_id), is_decoy,
+        base_target_id, base_pep_id, UInt32(entrapment_pair_id), UInt8(0), is_decoy,
+    )
+end
+
+"""
+    FastaEntry(acc, desc, gene, protein, organism, proteome, sequence,
+               start_idx::UInt32, struct_mods, iso_mods,
+               charge::UInt8, base_target_id::UInt32, base_pep_id::UInt32,
+               entrapment_pair_id::Union{UInt8,UInt32}, num_enzymatic_termini::UInt8,
+               is_decoy::Bool)
+
+Constructor including `num_enzymatic_termini` (0-2).
+"""
+function FastaEntry(
+    accession::AbstractString,
+    description::AbstractString,
+    gene::AbstractString,
+    protein::AbstractString,
+    organism::AbstractString,
+    proteome::AbstractString,
+    sequence::AbstractString,
+    start_idx::UInt32,
+    struct_mods::Union{Missing,Vector{PeptideMod}},
+    iso_mods::Union{Missing,Vector{PeptideMod}},
+    charge::UInt8,
+    base_target_id::UInt32,
+    base_pep_id::UInt32,
+    entrapment_pair_id::Integer,
+    num_enzymatic_termini::UInt8,
+    is_decoy::Bool,
+)
+    return FastaEntry(
+        String(accession), String(description), String(gene), String(protein), String(organism), String(proteome), String(sequence),
+        start_idx, struct_mods, iso_mods, charge,
+        base_target_id, base_pep_id, UInt32(entrapment_pair_id), num_enzymatic_termini, is_decoy,
     )
 end
 
@@ -120,6 +156,41 @@ function FastaEntry(
     return FastaEntry(
         String(accession), String(description), String(gene), String(protein), String(organism), String(proteome), String(sequence),
         start_idx, struct_mods, iso_mods, charge,
-        base_target_id, base_pep_id, UInt32(entrapment_pair_id), is_decoy,
+        base_target_id, base_pep_id, UInt32(entrapment_pair_id), UInt8(0), is_decoy,
+    )
+end
+
+"""
+    FastaEntry(acc, desc, gene, protein, organism, proteome, sequence,
+               start_idx::UInt32, struct_mods, iso_mods,
+               charge::UInt8, base_target_id::UInt32, base_pep_id::UInt32,
+               base_prec_id::UInt32, entrapment_pair_id::Union{UInt8,UInt32},
+               num_enzymatic_termini::UInt8, is_decoy::Bool)
+
+Compatibility constructor with `base_prec_id` and `num_enzymatic_termini`.
+"""
+function FastaEntry(
+    accession::AbstractString,
+    description::AbstractString,
+    gene::AbstractString,
+    protein::AbstractString,
+    organism::AbstractString,
+    proteome::AbstractString,
+    sequence::AbstractString,
+    start_idx::UInt32,
+    struct_mods::Union{Missing,Vector{PeptideMod}},
+    iso_mods::Union{Missing,Vector{PeptideMod}},
+    charge::UInt8,
+    base_target_id::UInt32,
+    base_pep_id::UInt32,
+    base_prec_id::UInt32,
+    entrapment_pair_id::Integer,
+    num_enzymatic_termini::UInt8,
+    is_decoy::Bool,
+)
+    return FastaEntry(
+        String(accession), String(description), String(gene), String(protein), String(organism), String(proteome), String(sequence),
+        start_idx, struct_mods, iso_mods, charge,
+        base_target_id, base_pep_id, UInt32(entrapment_pair_id), num_enzymatic_termini, is_decoy,
     )
 end

--- a/src/structs/LibraryIon.jl
+++ b/src/structs/LibraryIon.jl
@@ -756,6 +756,7 @@ getBasePepId(lp::LibraryPrecursors)::Arrow.Primitive{UInt32, Vector{UInt32}} = l
 getMz(lp::LibraryPrecursors)::Arrow.Primitive{Float32, Vector{Float32}}  = lp.data[:mz]
 getLength(lp::LibraryPrecursors)::Arrow.Primitive{UInt8, Vector{UInt8}}  = lp.data[:length]
 getMissedCleavages(lp::LibraryPrecursors)::Arrow.Primitive{UInt8, Vector{UInt8}} = lp.data[:missed_cleavages]
+getNumEnzymaticTermini(lp::LibraryPrecursors)::Arrow.Primitive{UInt8, Vector{UInt8}} = lp.data[:num_enzymatic_termini]
 getIrt(lp::LibraryPrecursors)::Arrow.Primitive{Float32, Vector{Float32}} = lp.data[:irt]
 getSulfurCount(lp::LibraryPrecursors)::Arrow.Primitive{UInt8, Vector{UInt8}} = lp.data[:sulfur_count]
 getIsotopicMods(lp::LibraryPrecursors)::Arrow.List{Union{Missing, String}, Int32, Vector{UInt8}} = lp.data[:isotopic_mods]
@@ -783,5 +784,4 @@ function extract_pair_idx(pair_idx_column, idx)
 end
 getPairIdx(lp::LibraryPrecursors) = lp.data[:pair_id]
 #getPlex(lp::PlexedLibraryPrecursors)::Arrow.Primitive{I, Vector{I}} where {I<:Integer} = lp.data[:plex]
-
 

--- a/test/UnitTests/FastaEntryConstructorsTests.jl
+++ b/test/UnitTests/FastaEntryConstructorsTests.jl
@@ -33,6 +33,7 @@ using Test
     @test get_entrapment_pair_id(e1) == 0
     @test get_base_pep_id(e1) == 0
     @test get_charge(e1) == 0
+    @test get_num_enzymatic_termini(e1) == 0
 
     # 16-arg compatibility constructor (base_prec_id ignored)
     e2 = FastaEntry(acc, desc, gene, prot, org, protm, seq,
@@ -40,5 +41,5 @@ using Test
                     UInt32(1), UInt32(2), UInt32(999), 1, false)
     @test get_base_pep_id(e2) == 2
     @test get_entrapment_pair_id(e2) == 1
+    @test get_num_enzymatic_termini(e2) == 0
 end
-


### PR DESCRIPTION
### Motivation
- Replace the old `enzymaticity` parameter with a clearer `specificity` option and add per-precursor information about how many enzymatic termini a peptide has so downstream scoring can use this as a feature.
- Propagate the value from digestion through library-building so the precursor table and later searches can access it for ML/rescoring models.
- Include the new feature in first-pass probit scoring and LightGBM/percolator-style workflows while avoiding singular matrices when the feature has no variance.

### Description
- Renamed/validated the digest parameter to `specificity` (keeps backward compatibility with `enzymaticity`) and updated example configs and docs (`src/Routines/BuildSpecLib/utils/check_params.jl`, `assets/...`, `docs/...`).
- Extended `digest_sequence` to return a per-peptide `num_enzymatic_termini` (0–2) and updated `digest_fasta` to attach that value to `FastaEntry` instances (`src/Routines/BuildSpecLib/fasta/fasta_digest.jl`).
- Added `num_enzymatic_termini` to the `FastaEntry` struct and provided constructors/accessor (`src/structs/KoinaStructs/FastaTypes.jl`) and threaded the field through modification, entrapment, charge, and decoy generation paths (`src/Routines/BuildSpecLib/fasta/fasta_utils.jl`, `chronologer_prep.jl`).
- Persisted `num_enzymatic_termini` into the precursors DataFrame/Arrow output and exposed an accessor on `LibraryPrecursors` (`src/Routines/BuildSpecLib.jl`, `src/structs/LibraryIon.jl`, `src/Routines/BuildSpecLib/chronologer/chronologer_prep.jl`).
- Added `num_enzymatic_termini` to PSM feature generation in both first-pass and second-pass flows and to the model feature sets, and guarded ML training by removing zero-variance features (FirstPass/SecondPass/ScoringSearch changes in `src/Routines/SearchDIA/...`).
- Updated unit tests to exercise the new return shape and specificity behavior and added compatibility checks in constructor tests (`test/UnitTests/FastaDigestTests.jl`, `test/UnitTests/FastaEntryConstructorsTests.jl`).

### Testing
- Unit tests were updated to assert `digest_sequence` returns enzymatic-termini counts and to validate `specificity` modes, but no automated test suite was executed as part of this change (no CI run requested).
- Files changed include test updates under `test/UnitTests/*` to reflect the new API and defaults; these tests should be run locally or in CI via `julia --project -e 'using Pkg; Pkg.test()'` to confirm behavior.
- Runtime guards were added to scoring routines to remove `:num_enzymatic_termini` when it has no variance, preventing singular matrices during probit/ML training (no runtime regression observed in static review).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a8d72c51083259206ecf87185241a)