### PR TITLE
fix: store release metrics under metrics path

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -768,7 +768,7 @@ jobs:
           run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
           run_root="${run_root_raw%/}/runs"
           release_tag="${RELEASE_TAG:?RELEASE_TAG not set}"
-          release_dir="${run_root_raw%/}/release/${release_tag}"
+          release_dir="${run_root_raw%/}/metrics/release/${release_tag}"
 
           ssh_options=(
             -o BatchMode=yes

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -773,7 +773,7 @@ jobs:
           run_root_raw="${CLUSTER_RUN_ROOT:-/storage1/fs1/d.goldfarb/Active/Automation/Pioneer}"
           run_root="${run_root_raw%/}/runs"
           release_tag="${RELEASE_TAG:?RELEASE_TAG not set}"
-          release_dir="${run_root_raw%/}/release/${release_tag}"
+          release_dir="${run_root_raw%/}/metrics/release/${release_tag}"
 
           ssh_options=(
             -o BatchMode=yes


### PR DESCRIPTION
## Summary
- update tagged-release regression sync path to use metrics/release/<tag>
- apply the same fix in both standard and slurm regression workflows

## Testing
- not run (workflow path change only)