### PR TITLE
Runtime invalidation attempt 2

### DIFF
--- a/dev/Project.toml
+++ b/dev/Project.toml
@@ -19,3 +19,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
+
+[preferences.HostCPUFeatures]
+allow_runtime_invalidation = true


### PR DESCRIPTION
Previous attempt didn't put it into the dev .toml so it wasn't used during compilation. We need this to silently recompile julia code if the local CPU architecture doesn't support some commands. Otherwise we get warnings like this:

               ┌ Warning: Runtime invalidation was disabled, but the CPU info is out-of-date.
		│ Will continue with incorrect CPU name (from build time).
		└ @ HostCPUFeatures /Users/runner/.julia/packages/HostCPUFeatures/ZTXz4/src/cpu_info.jl:71
		┌ Warning: Runtime invalidation was disabled, but the CPU info is out-of-date.
		│ Will continue with incorrect CPU feature flag: +xsaves.
		└ @ HostCPUFeatures /Users/runner/.julia/packages/HostCPUFeatures/ZTXz4/src/cpu_info.jl:56
		┌ Warning: Runtime invalidation was disabled, but the CPU info is out-of-date.
		│ Will continue with incorrect CPU feature flag: +xsavec.
		└ @ HostCPUFeatures /Users/runner/.julia/packages/HostCPUFeatures/ZTXz4/src/cpu_info.jl:56
		┌ Warning: Runtime invalidation was disabled, but the CPU info is out-of-date.
		│ Will continue with incorrect CPU feature flag: -rtm.
		└ @ HostCPUFeatures /Users/runner/.julia/packages/HostCPUFeatures/ZTXz4/src/cpu_info.jl:56