### PR TITLE
Disable match-between-runs defaults

### DIFF
--- a/assets/example_config/defaultSearchParams.json
+++ b/assets/example_config/defaultSearchParams.json
@@ -23,8 +23,7 @@
             "huber_delta": 1055
         }, 
         "ms1_scoring": true,
-        "ms1_quant": false,
-		"match_between_runs": true
+        "ms1_quant": false
     },
     "parameter_tuning": {
         "fragment_settings": {

--- a/assets/example_config/defaultSearchParamsSimplified.json
+++ b/assets/example_config/defaultSearchParamsSimplified.json
@@ -18,7 +18,6 @@
         "scoring": {
             "q_value_threshold": 0.01
         },
-        "match_between_runs": true,
         "ms1_quant": false
     },
     "first_search": {

--- a/data/ecoli_test/ecoli_test_params.json
+++ b/data/ecoli_test/ecoli_test_params.json
@@ -22,8 +22,7 @@
             "huber_delta": 1055
         }, 
         "ms1_scoring": true,
-        "ms1_quant": false,
-		"match_between_runs": true
+        "ms1_quant": false
     },
     "parameter_tuning": {
         "fragment_settings": {

--- a/data/example_config/LibrarySearch.json
+++ b/data/example_config/LibrarySearch.json
@@ -12,8 +12,7 @@
         "normalization": {
             "n_rt_bins": 100,
             "spline_n_knots": 7
-        }, 
-		"match_between_runs": true
+        }
     },
     "parameter_tuning": {
         "fragment_settings": {

--- a/data/param_test/search.json
+++ b/data/param_test/search.json
@@ -23,8 +23,7 @@
         "huber_override": {
             "override_huber_delta_fit": false,
             "huber_delta": 1500.0
-        },
-        "match_between_runs": true
+        }
     },
     "parameter_tuning": {
         "fragment_settings": {

--- a/data/precompile/search_ecoli_prosit.json
+++ b/data/precompile/search_ecoli_prosit.json
@@ -11,8 +11,7 @@
         "normalization": {"n_rt_bins": 100, "spline_n_knots": 7},
         "huber_override": {"override_huber_delta_fit": false, "huber_delta": 1500.0},
         "ms1_scoring": true,
-        "ms1_quant": false,
-        "match_between_runs": false
+        "ms1_quant": false
     },
     "parameter_tuning": {
         "fragment_settings": {

--- a/data/precompile/search_yeast_altimeter.json
+++ b/data/precompile/search_yeast_altimeter.json
@@ -11,8 +11,7 @@
         "normalization": {"n_rt_bins": 100, "spline_n_knots": 7},
         "huber_override": {"override_huber_delta_fit": false, "huber_delta": 1500.0},
         "ms1_scoring": true,
-        "ms1_quant": false,
-        "match_between_runs": true
+        "ms1_quant": false
     },
     "parameter_tuning": {
         "fragment_settings": {

--- a/data/precompile/search_yeast_altimeter_OOM.json
+++ b/data/precompile/search_yeast_altimeter_OOM.json
@@ -11,8 +11,7 @@
         "normalization": {"n_rt_bins": 100, "spline_n_knots": 7},
         "huber_override": {"override_huber_delta_fit": false, "huber_delta": 1500.0},
         "ms1_scoring": true,
-        "ms1_quant": false,
-        "match_between_runs": true
+        "ms1_quant": false
     },
     "parameter_tuning": {
         "fragment_settings": {

--- a/docs/src/supplemental_methods/CLAUDE.md
+++ b/docs/src/supplemental_methods/CLAUDE.md
@@ -105,13 +105,13 @@ Multi-layered approach:
 - PSM-level (Percolator-style iterative training)
 - Precursor-level (two-stage global + experiment-wide)
 - Protein-level (target-decoy competition)
-- Transfer-level (FTR for match-between-runs)
+- Transfer-level (FTR for cross-run transfer candidates)
 
 ### Novel Contributions
 1. **Intensity-aware fragment indexing** - accounts for predicted intensities in scoring
 2. **NCE alignment** - maps vendor collision energies to PROCAL Lumos scale
 3. **Conditional fragment isotopes** - models isotopes based on quadrupole transmission
-4. **FTR filtering** - controls false transfers in match-between-runs
+4. **FTR filtering** - controls false transfers in cross-run transfer candidates
 5. **Integrated workflow** - spectral prediction (Altimeter) → search → quantification (Pioneer)
 
 ## Technical Details

--- a/docs/src/supplemental_methods/all_methods.tex
+++ b/docs/src/supplemental_methods/all_methods.tex
@@ -602,7 +602,7 @@ Pioneer solves each of these single variable problems by the Newton-Raphson meth
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Target-Decoy Model, Match-Between-Runs, and False-Discovery Rate Estimation}\label{subsec:target-decoy-mbr-fdr}
 
-Pioneer trains LightGBM target-decoy discrimination models using cross-validation to score each precursor isotope trace \cite{LightGBM paper...}. The approach implements iterative training with negative mining and, when match-between-runs (MBR) is enabled, incorporates cross-run comparison features followed by false transfer rate (FTR) filtering.
+Pioneer trains LightGBM target-decoy discrimination models using cross-validation to score each precursor isotope trace \cite{LightGBM paper...}. The approach implements iterative training with negative mining. Cross-run transfer comparison features and false transfer rate (FTR) filtering are currently disabled in production runs.
 
 \subsubsection{Data Structure and Cross-Validation Setup}\label{subsubsec:data-structure-cv-setup}
 
@@ -612,7 +612,7 @@ During spectral library construction, Pioneer randomly assigns each protein grou
 
 \subsubsection{Target-Decoy Pairing for Match-Between-Runs}\label{subsubsec:target-decoy-pairing}
 
-When MBR is enabled, Pioneer establishes 1:1 target-decoy pairs to enable chromatographic comparison features. Pairing is performed within retention time bins to ensure comparable elution profiles.
+Pioneer establishes 1:1 target-decoy pairs to enable chromatographic comparison features. Pairing is performed within retention time bins to ensure comparable elution profiles.
 
 \paragraph{iRT Binning}\label{para:irt-binning} Precursors are sorted by predicted indexed retention time (iRT) and partitioned into bins of size $B = 1000$. For precursors with predicted iRTs $\{\text{iRT}_1, \ldots, \text{iRT}_{|\mathcal{P}|}\}$ sorted in ascending order, bin assignments $b_p$ are:
 \begin{equation}
@@ -632,7 +632,7 @@ where $\text{next\_id}()$ generates a unique pair identifier and unpaired precur
 
 \subsubsection{Match-Between-Runs Features}\label{sec:mbr_features}
 
-When MBR is enabled, Pioneer augments the feature vector $\mathbf{X}_{p,i,r}$ with seven additional features computed by comparing chromatographic profiles across runs. These features are added starting from iteration 2, using in-fold probabilities from the previous iteration.
+In the cross-run transfer pathway, Pioneer augments the feature vector $\mathbf{X}_{p,i,r}$ with seven additional features computed by comparing chromatographic profiles across runs. These features are added starting from iteration 2, using in-fold probabilities from the previous iteration.
 
 \paragraph{Paired Precursor Identification}\label{para:paired-precursor-identification} For each isotope trace $(p,i,r)$, identify the best-scoring paired precursor from a \emph{different} run. Let $\mathcal{P}_{\text{pair}}(p, r)$ denote all paired traces across other runs:
 \begin{equation}
@@ -1041,7 +1041,7 @@ After protein inference and filtering, Pioneer scores protein groups in three st
 \begin{equation}
 \text{score}(q) = -\sum_{p \in \mathcal{N}(q)} \log(1 - \text{prob}_p)
 \end{equation}
-where $\text{prob}_p$ is the maximum precursor probability for peptide, $p$, within that run. When match-between-runs (MBR) is enabled, protein scoring uses MBR-boosted precursor probabilities; otherwise standard precursor probabilities from the machine learning PSM scoring model are used.
+where $\text{prob}_p$ is the maximum precursor probability for peptide, $p$, within that run, using precursor probabilities from the machine learning PSM scoring model.
 
 \paragraph{Stage 2: Probit Regression Refinement}\label{para:stage2-probit-regression-refinement} Pioneer applies probit regression to refine the per-run protein group scores using the following features:
 \begin{itemize}

--- a/docs/src/supplemental_methods/new_all_methods.tex
+++ b/docs/src/supplemental_methods/new_all_methods.tex
@@ -602,7 +602,7 @@ Pioneer solves each of these single variable problems by the Newton-Raphson meth
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Target-Decoy Model, Match-Between-Runs, and False-Discovery Rate Estimation}\label{subsec2}
 
-Pioneer trains LightGBM target-decoy discrimination models using cross-validation to score each precursor isotope trace \cite{LightGBM paper...}. The approach implements iterative training with negative mining and, when match-between-runs (MBR) is enabled, incorporates cross-run comparison features followed by false transfer rate (FTR) filtering.
+Pioneer trains LightGBM target-decoy discrimination models using cross-validation to score each precursor isotope trace \cite{LightGBM paper...}. The approach implements iterative training with negative mining. Cross-run transfer comparison features and false transfer rate (FTR) filtering are currently disabled in production runs.
 
 \subsubsection{Data Structure and Cross-Validation Setup}
 
@@ -612,7 +612,7 @@ During spectral library construction, Pioneer randomly assigns each protein grou
 
 \subsubsection{Target-Decoy Pairing for Match-Between-Runs}
 
-When MBR is enabled, Pioneer establishes 1:1 target-decoy pairs to enable chromatographic comparison features. Pairing is performed within retention time bins to ensure comparable elution profiles.
+Pioneer establishes 1:1 target-decoy pairs to enable chromatographic comparison features. Pairing is performed within retention time bins to ensure comparable elution profiles.
 
 \paragraph{iRT Binning} Precursors are sorted by predicted indexed retention time (iRT) and partitioned into bins of size $B = 1000$. For precursors with predicted iRTs $\{\text{iRT}_1, \ldots, \text{iRT}_{|\mathcal{P}|}\}$ sorted in ascending order, bin assignments $b_p$ are:
 \begin{equation}
@@ -632,7 +632,7 @@ where $\text{next\_id}()$ generates a unique pair identifier and unpaired precur
 
 \subsubsection{Match-Between-Runs Features}\label{sec:mbr_features}
 
-When MBR is enabled, Pioneer augments the feature vector $\mathbf{X}_{p,i,r}$ with seven additional features computed by comparing chromatographic profiles across runs. These features are added starting from iteration 2, using in-fold probabilities from the previous iteration.
+In the cross-run transfer pathway, Pioneer augments the feature vector $\mathbf{X}_{p,i,r}$ with seven additional features computed by comparing chromatographic profiles across runs. These features are added starting from iteration 2, using in-fold probabilities from the previous iteration.
 
 \paragraph{Paired Precursor Identification} For each isotope trace $(p,i,r)$, identify the best-scoring paired precursor from a \emph{different} run. Let $\mathcal{P}_{\text{pair}}(p, r)$ denote all paired traces across other runs:
 \begin{equation}

--- a/docs/src/supplemental_methods/protein_inference.tex
+++ b/docs/src/supplemental_methods/protein_inference.tex
@@ -145,7 +145,7 @@ After protein inference and filtering, each protein group is scored based on its
 \begin{equation}
 \text{score}(q) = -\sum_{p \in \mathcal{N}(q)} \log(1 - \text{prob}_p)
 \end{equation}
-where $\text{prob}_p$ is the maximum precursor probability for peptide, $p$, within that run. When match-between-runs (MBR) is enabled, protein scoring uses MBR-boosted precursor probabilities; otherwise standard precursor probabilities from the machine learning PSM scoring model are used.
+where $\text{prob}_p$ is the maximum precursor probability for peptide, $p$, within that run, using precursor probabilities from the machine learning PSM scoring model.
 
 \paragraph{Stage 2: Probit Regression Refinement} Pioneer applies probit regression to refine the per-run protein group scores. The probit model uses the log-sum score as the primary feature, along with additional features including:
 \begin{itemize}

--- a/docs/src/user_guide/parameters.md
+++ b/docs/src/user_guide/parameters.md
@@ -34,14 +34,13 @@ Most parameters should not be changed, but the following may need adjustment.
 | `isotope_settings.combine_traces` | Boolean | Whether to combine precursor isotope traces in quantification (default: true) |
 | `isotope_settings.partial_capture` | Boolean | Whether to estimate the conditional fragment isotope distribution (true) or assume complete transmission of the entire precursor isotopic envelope (default: true) |
 | `isotope_settings.min_fraction_transmitted` | Float | Minimum fraction of the precursor isotope distribution that must be isolated for scoring and quantitation (default: 0.25) |
-| `scoring.q_value_threshold` | Float | Global q-value threshold for filtering results. Also controls false transfer rate of MBR (default: 0.01) |
+| `scoring.q_value_threshold` | Float | Global q-value threshold for filtering results (default: 0.01) |
 | `normalization.n_rt_bins` | Int | Number of retention time bins for quant normalization (default: 100) |
 | `normalization.spline_n_knots` | Int | Number of knots in quant normalization spline (default: 7) |
 | `huber_override.override_huber_delta_fit` | Boolean | Whether to override the automatic Huber delta fitting with a manual value (default: false) |
 | `huber_override.huber_delta` | Float | Huber delta value when override is enabled (default: 1055) |
 | `ms1_scoring` | Boolean | Enable MS1-level scoring features (default: true) |
 | `ms1_quant` | Boolean | Enable MS1-level quantification (default: false) |
-| `match_between_runs` | Boolean | Whether to attempt to transfer peptide identifications across runs. Turning this on will add additional features to the LightGBM model (default: true) |
 
 ### Parameter Tuning Settings
 
@@ -175,9 +174,7 @@ The deconvolution parameters are split into `ms1` and `ms2` sub-objects for sepa
 |-----------|------|-------------|
 | `machine_learning.max_psm_memory_mb` | Real | Memory budget in MB for PSMs held in memory during LightGBM training. Row count is dynamically estimated from Arrow column sizes (default: 2000) |
 | `machine_learning.force_oom` | Boolean | Force out-of-memory processing regardless of dataset size (default: false) |
-| `machine_learning.max_mbr_training_candidates` | Int | Maximum number of candidates for MBR training (default: 1000000) |
 | `machine_learning.min_trace_prob` | Float | Minimum trace probability threshold (default: 0.75) |
-| `machine_learning.max_q_value_mbr_itr` | Float | q-value threshold for match-between-runs candidates kept during the iterative training (ITR) stage of LightGBM rescoring (default: 0.20) |
 | `machine_learning.min_PEP_neg_threshold_itr` | Float | Minimum posterior error probability threshold for reclassifying weak target PSMs as negatives during the ITR stage of LightGBM rescoring (default: 0.90) |
 | `machine_learning.spline_points` | Int | Number of points for probability spline (default: 500) |
 | `machine_learning.interpolation_points` | Int | Number of interpolation points (default: 10) |

--- a/src/Routines/SearchDIA.jl
+++ b/src/Routines/SearchDIA.jl
@@ -127,7 +127,6 @@ function SearchDIA(params_path::String)
    
     # === Initialize logging ===
     checkParams(params_path)
-    params_string = read(params_path, String)
 
     params = parse_pioneer_parameters(params_path)
     mkpath(params.paths[:results])  # Ensure directory exists
@@ -271,31 +270,6 @@ function SearchDIA(params_path::String)
                 return
             end
 
-            # Disable match-between-runs if only a single run is provided
-            if length(MS_TABLE_PATHS) == 1 && params.global_settings.match_between_runs
-                @user_warn "Only one run detected; disabling match_between_runs (MBR)."
-
-                params_dict = JSON.parse(params_string)
-                params_dict["global"]["match_between_runs"] = false
-                params_string = JSON.json(params_dict, 4)
-
-                updated_global = (; params.global_settings..., match_between_runs=false)
-                params = PioneerParameters(
-                    updated_global,
-                    params.parameter_tuning,
-                    params.first_search,
-                    params.quant_search,
-                    params.acquisition,
-                    params.rt_alignment,
-                    params.optimization,
-                    params.protein_inference,
-                    params.maxLFQ,
-                    params.output,
-                    params.logging,
-                    params.paths,
-                )
-            end
-            
             nothing
         end
         timings["Parameter Loading"] = params_timing

--- a/src/Routines/SearchDIA/ParseInputs/paramsChecks.jl
+++ b/src/Routines/SearchDIA/ParseInputs/paramsChecks.jl
@@ -65,7 +65,6 @@ function checkParams(json_path::String)
     check_param(global_params["huber_override"], "huber_delta", Real)
     check_param(global_params, "ms1_scoring", Bool)
     check_param(global_params, "ms1_quant", Bool)
-    check_param(global_params, "match_between_runs", Bool)
 
     # Validate parameter tuning parameters
     tuning_params = params["parameter_tuning"]

--- a/src/Routines/SearchDIA/ParseInputs/parseParams.jl
+++ b/src/Routines/SearchDIA/ParseInputs/parseParams.jl
@@ -46,6 +46,10 @@ function params_to_dict(params::PioneerParameters)
     function namedtuple_to_dict(nt::NamedTuple)
         result = Dict{String, Any}()
         for (k, v) in pairs(nt)
+            if k == :match_between_runs
+                # Keep runtime behavior deterministic while omitting deprecated config keys.
+                continue
+            end
             key_str = string(k)
             result[key_str] = if v isa NamedTuple
                 namedtuple_to_dict(v)
@@ -130,7 +134,7 @@ function parse_pioneer_parameters(json_path::String; apply_defaults::Bool = true
     end
 
     # Parse each section
-    global_settings = dict_to_namedtuple(params["global"])
+    global_settings = (; dict_to_namedtuple(params["global"])..., match_between_runs=false)
     parameter_tuning = dict_to_namedtuple(params["parameter_tuning"])
     first_search = dict_to_namedtuple(params["first_search"])
     quant_search = dict_to_namedtuple(params["quant_search"])

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/CLAUDE.md
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/CLAUDE.md
@@ -102,7 +102,7 @@ ScoringSearch implements a comprehensive 23-step pipeline:
 - **ADVANCED_FEATURE_SET**: 50 features including all spectral, RT, MS1, and quality metrics
 - **REDUCED_FEATURE_SET**: 40+ core features for balanced performance
 - **MINIMAL_FEATURE_SET**: 5 essential spectral matching features
-- **MBR Features**: Automatically appended when match_between_runs=true
+- **Cross-run transfer features**: Currently disabled in production runs
 
 **Clean Output Design**:
 - Progress bars suppressed during comparison using `show_progress=false` parameter
@@ -187,8 +187,7 @@ ScoringSearch implements a comprehensive 23-step pipeline:
 "global_settings": {
     "scoring": {
         "q_value_threshold": 0.01  // Used for model comparison target counting
-    },
-    "match_between_runs": true
+    }
 }
 ```
 

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/README.md
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/README.md
@@ -93,7 +93,7 @@ PSM Count Decision Tree:
 - **ADVANCED_FEATURE_SET**: 50+ features including all spectral, RT, MS1, and quality metrics
 - **REDUCED_FEATURE_SET**: 40+ core features for balanced performance  
 - **MINIMAL_FEATURE_SET**: 5 essential features (spectral contrast, residuals, error norms, intensity explained)
-- **MBR Features**: Automatically appended when match_between_runs=true
+- **Cross-run transfer features**: Currently disabled in production runs
 
 ## Function Call Flow
 
@@ -104,7 +104,6 @@ score_precursor_isotope_traces(
     second_pass_folder,
     file_paths,
     precursors,
-    match_between_runs,
     max_q_value_lightgbm_rescore,
     max_q_value_mbr_itr,
     min_PEP_neg_threshold_itr,
@@ -168,9 +167,9 @@ sort_of_percolator_in_memory!()
 │   │   │   └── LightGBMModel(hyperparams...)
 │   │   ├── Predict on train/test sets
 │   │   ├── Calculate q-values
-│   │   └── update_mbr_features!() [if match_between_runs]
+│   │   └── update_mbr_features!() [transfer path only]
 │   └── Store fold predictions
-├── Handle MBR transfer candidates [if match_between_runs]
+├── Handle MBR transfer candidates [transfer path only]
 └── Return trained models (Dict{UInt8, LightGBMModelVector})
 ```
 
@@ -179,7 +178,7 @@ sort_of_percolator_in_memory!()
 1. **Cross-Validation**: Uses CV folds from spectral library (typically 2 folds with values 0,1)
 2. **Iterative Training**: 3-stage scheme [100, 200, 200] rounds with progressive filtering
 3. **Negative Mining**: Converts low-scoring targets to negatives in later iterations
-4. **MBR Integration**: Optional match-between-runs features added in final iteration
+4. **Transfer Integration**: Cross-run transfer features exist in code but are disabled in production runs
 5. **Dynamic Training Data**: Training set filtered by q-value thresholds between iterations
 
 ## Probit Regression Pipeline
@@ -200,7 +199,7 @@ probit_regression_scoring_cv!()
 │   │   └── Predict probabilities on test set
 │   └── Store fold predictions
 ├── Assign final probabilities to DataFrame
-├── Create MBR columns for compatibility [if match_between_runs]
+├── Create MBR columns for compatibility [transfer path only]
 ├── Validate and clamp probability values
 └── Clean up temporary columns
 ```
@@ -258,8 +257,7 @@ The trained models integrate into the broader ScoringSearch pipeline:
     "global_settings": {
         "scoring": {
             "q_value_threshold": 0.01
-        },
-        "match_between_runs": true
+        }
     }
 }
 ```
@@ -271,7 +269,6 @@ The trained models integrate into the broader ScoringSearch pipeline:
 - **max_q_value_mbr_itr**: Caps MBR transfers admitted to the iterative training (ITR) stage
 - **min_PEP_neg_threshold_itr**: Sets the PEP cutoff for relabeling weak targets as negatives during ITR
 - **q_value_threshold**: Used for model performance evaluation during comparison
-- **match_between_runs**: Enables MBR features and processing
 
 ## Performance Characteristics
 

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/README.md
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/README.md
@@ -157,7 +157,7 @@ sort_of_percolator_in_memory!()
 ├── Initialize probability arrays and CV fold mappings
 ├── For each CV fold:
 │   ├── Split train/test data
-│   ├── For each iteration in iter_scheme [100, 200, 200]:
+│   ├── For each iteration in iter_scheme [100, 200, 200, 200]:
 │   │   ├── get_training_data_for_iteration!()
 │   │   │   ├── First iteration: Use all training PSMs
 │   │   │   └── Later iterations: 
@@ -176,7 +176,7 @@ sort_of_percolator_in_memory!()
 ### Key Training Features
 
 1. **Cross-Validation**: Uses CV folds from spectral library (typically 2 folds with values 0,1)
-2. **Iterative Training**: 3-stage scheme [100, 200, 200] rounds with progressive filtering
+2. **Iterative Training**: 4-stage scheme [100, 200, 200, 200] rounds with progressive filtering
 3. **Negative Mining**: Converts low-scoring targets to negatives in later iterations
 4. **Transfer Integration**: Cross-run transfer features exist in code but are disabled in production runs
 5. **Dynamic Training Data**: Training set filtered by q-value thresholds between iterations

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/model_config.jl
@@ -196,7 +196,7 @@ function create_model_configurations(ms1_scoring::Bool = true)
                 :max_depth => 4,
                 :num_leaves => 15,
                 :learning_rate => 0.1,
-                :iter_scheme => [150, 300, 300]
+                :iter_scheme => [150, 300, 300, 300]
             )
         ),
         
@@ -213,7 +213,7 @@ function create_model_configurations(ms1_scoring::Bool = true)
                 :max_depth => -1,
                 :num_leaves => 63,
                 :learning_rate => 0.05,
-                :iter_scheme => [100, 200, 200]
+                :iter_scheme => [100, 200, 200, 200]
             )
         ),
         
@@ -259,7 +259,7 @@ function create_model_configurations(ms1_scoring::Bool = true)
                 :max_depth => 4,
                 :num_leaves => 15,
                 :learning_rate => 0.1,
-                :iter_scheme => [150, 300, 300]
+                :iter_scheme => [150, 300, 300, 300]
             )
         )
     ]
@@ -479,7 +479,7 @@ function build_scoring_config(
     ] : Symbol[]
 
     # Get iteration scheme
-    iter_scheme = get(model_config.hyperparams, :iter_scheme, [100, 200, 200])
+    iter_scheme = get(model_config.hyperparams, :iter_scheme, [100, 200, 200, 200])
 
     return ScoringConfig(
         model,

--- a/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ScoringSearch/score_psms.jl
@@ -270,7 +270,7 @@ function create_default_advanced_lightgbm_config(ms1_scoring::Bool = true)
             :max_depth => 10,
             :num_leaves => 63,
             :learning_rate => 0.05,
-            :iter_scheme => [100, 200, 200]
+            :iter_scheme => [100, 200, 200, 200]
         )
     )
 end

--- a/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
+++ b/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
@@ -127,6 +127,27 @@ function getModifiedSequence(
     mods = [("("*getModName(mod.match)*")", getModIndex(mod.match)) for mod in parseMods(mods)]
     return "_"*insert_at_indices(sequence, mods)*"_."*string(charge)
 end
+
+"""
+    _ensure_typed_missing_file_columns!(df, file_names, T)
+
+Ensure each file column in `file_names` exists in `df` and has element type
+`Union{Missing,T}` when the column is fully missing for a batch.
+"""
+function _ensure_typed_missing_file_columns!(
+    df::DataFrame,
+    file_names::AbstractVector{<:AbstractString},
+    ::Type{T}) where {T<:AbstractFloat}
+
+    n = nrow(df)
+    col_names = names(df)
+    for fname in file_names
+        if fname ∉ col_names || eltype(df[!, fname]) === Missing
+            df[!, fname] = Vector{Union{Missing, T}}(missing, n)
+        end
+    end
+    return df
+end
 #Assume sorted by protein,peptide keys. Do this in batches and write a long and wide form .csv without
 #loading the entire table into memory. 
 function writePrecursorCSV(
@@ -299,12 +320,7 @@ function writePrecursorCSV(
                         CSV.write(io1, subdf, append=true, header=false, delim='\t')
                     end
                     subunstack = makeWideFormat(subdf, Symbol.(wide_columns), normalized)
-                    col_names = names(subunstack)
-                    for fname in file_names
-                        if fname ∉ col_names
-                            subunstack[!,fname] .= Vector{Union{Missing,Float32}}(missing, nrow(subunstack))
-                        end
-                    end
+                    _ensure_typed_missing_file_columns!(subunstack, file_names, Float32)
                     if write_csv
                         _sanitize_empty_strings!(subunstack)
                         CSV.write(io2, subunstack[!,sorted_columns], append=true,header=false,delim='\t')
@@ -514,12 +530,7 @@ function writePrecursorCSV_chunked(
                             CSV.write(io1, subdf, append=true, header=false, delim='\t')
                         end
                         subunstack = makeWideFormat(subdf, Symbol.(wide_columns), normalized)
-                        col_names = names(subunstack)
-                        for fname in file_names
-                            if fname ∉ col_names
-                                subunstack[!, fname] .= Vector{Union{Missing, Float32}}(missing, nrow(subunstack))
-                            end
-                        end
+                        _ensure_typed_missing_file_columns!(subunstack, file_names, Float32)
                         if write_csv
                             _sanitize_empty_strings!(subunstack)
                             CSV.write(io2, subunstack[!, sorted_columns], append=true, header=false, delim='\t')
@@ -668,12 +679,7 @@ function writeProteinGroupsCSV(
                         CSV.write(io1, subdf, append=true, header=false, delim='\t')
                     end
                     subunstack = makeWideFormat(subdf)
-                    col_names = names(subunstack)
-                    for fname in file_names
-                        if fname ∉ col_names
-                            subunstack[!,fname] = Vector{Union{Missing,Float64}}(missing, nrow(subunstack))
-                        end
-                    end
+                    _ensure_typed_missing_file_columns!(subunstack, file_names, Float64)
                     if write_csv
                         CSV.write(io2, subunstack[!,sorted_columns], append=true,header=false,delim='\t')
                     end

--- a/src/utils/ML/CLAUDE.md
+++ b/src/utils/ML/CLAUDE.md
@@ -74,7 +74,7 @@ abstract type FeatureSelectionStrategy end
 
 # 5. IterationScheme - Training iterations
 abstract type IterationScheme end
-├── FixedIterationScheme  # Fixed rounds per iteration [100, 200, 200]
+├── FixedIterationScheme  # Fixed rounds per iteration [100, 200, 200, 200]
 └── SinglePassScheme      # Single pass (for probit)
 
 # 6. MBRUpdateStrategy - Match-between-runs

--- a/src/utils/ML/CLAUDE.md
+++ b/src/utils/ML/CLAUDE.md
@@ -98,7 +98,6 @@ end
 
 # Create default LightGBM config
 config = default_scoring_config(
-    match_between_runs=true,
     features=base_features,
     max_q_value=0.01f0
 )
@@ -162,7 +161,7 @@ models = percolator_scoring!(psms, config; show_progress=true, verbose=false)
 Legacy wrapper that constructs a `ScoringConfig` and delegates to `percolator_scoring!`:
 
 ```julia
-function sort_of_percolator!(psms::AbstractPSMContainer, features, match_between_runs; kwargs...)
+function sort_of_percolator!(psms::AbstractPSMContainer, features; kwargs...)
     # Build ScoringConfig from keyword arguments
     config = ScoringConfig(
         LightGBMScorer(hyperparams),
@@ -170,7 +169,7 @@ function sort_of_percolator!(psms::AbstractPSMContainer, features, match_between
         QValueNegativeMining(max_q_value, min_pep_threshold),
         IterativeFeatureSelection(base_features, mbr_features, n_iters),
         FixedIterationScheme(iter_scheme),
-        match_between_runs ? PairBasedMBR(max_q_value) : NoMBR()
+        NoMBR()
     )
     return percolator_scoring!(psms, config; show_progress, verbose)
 end

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -92,7 +92,7 @@ Delegates to the trait-based `percolator_scoring!` function.
 """
 function sort_of_percolator!(psms::AbstractPSMContainer,
                   features::Vector{Symbol},
-                  match_between_runs::Bool = true;
+                  match_between_runs::Bool = false;
                   max_q_value_lightgbm_rescore::Float32 = 0.01f0,
                   max_q_value_mbr_itr::Float32 = 0.20f0,
                   min_PEP_neg_threshold_itr = 0.90f0,

--- a/src/utils/ML/percolatorSortOf.jl
+++ b/src/utils/ML/percolatorSortOf.jl
@@ -83,7 +83,7 @@ Delegates to the trait-based `percolator_scoring!` function.
 - `min_gain_to_split::Float64`: Minimum gain to split (default: 0.0)
 - `max_depth::Int`: Maximum tree depth (default: 10)
 - `num_leaves::Int`: Maximum leaves per tree (default: 63)
-- `iter_scheme::Vector{Int}`: Boosting rounds per iteration (default: [100, 200, 200])
+- `iter_scheme::Vector{Int}`: Boosting rounds per iteration (default: [100, 200, 200, 200])
 - `show_progress::Bool`: Show progress bar (default: true)
 - `verbose_logging::Bool`: Enable verbose output (default: false)
 
@@ -103,7 +103,7 @@ function sort_of_percolator!(psms::AbstractPSMContainer,
                   min_gain_to_split::Float64 = 0.0,
                   max_depth::Int = 10,
                   num_leaves::Int = 63,
-                  iter_scheme::Vector{Int} = [100, 200, 200],
+                  iter_scheme::Vector{Int} = [100, 200, 200, 200],
                   print_importance::Bool = false,
                   show_progress::Bool = true,
                   verbose_logging::Bool = false)

--- a/src/utils/ML/scoring_config.jl
+++ b/src/utils/ML/scoring_config.jl
@@ -45,12 +45,12 @@ struct ScoringConfig{M<:PSMScoringModel, P<:PairingStrategy, T<:TrainingDataStra
 end
 
 """
-    default_scoring_config(; match_between_runs=true, features=Symbol[], hyperparams=Dict())
+    default_scoring_config(; match_between_runs=false, features=Symbol[], hyperparams=Dict())
 
 Create default LightGBM scoring configuration.
 
 # Arguments
-- `match_between_runs::Bool`: Whether to enable MBR features
+- `match_between_runs::Bool`: Whether to enable MBR features (currently disabled by default)
 - `features::Vector{Symbol}`: Base feature set
 - `hyperparams::Dict{Symbol,Any}`: LightGBM hyperparameters
 
@@ -58,7 +58,7 @@ Create default LightGBM scoring configuration.
 - `ScoringConfig`: Configured scoring configuration
 """
 function default_scoring_config(;
-    match_between_runs::Bool = true,
+    match_between_runs::Bool = false,
     features::Vector{Symbol} = Symbol[],
     hyperparams::Dict{Symbol,Any} = Dict{Symbol,Any}(),
     max_q_value::Float32 = 0.01f0,

--- a/src/utils/ML/scoring_config.jl
+++ b/src/utils/ML/scoring_config.jl
@@ -77,7 +77,7 @@ function default_scoring_config(;
     base_features = [f for f in features if !startswith(String(f), "MBR_")]
 
     # Get iteration scheme from hyperparams
-    iter_scheme = get(hyperparams, :iter_scheme, [100, 200, 200])
+    iter_scheme = get(hyperparams, :iter_scheme, [100, 200, 200, 200])
 
     return ScoringConfig(
         LightGBMScorer(hyperparams),

--- a/src/utils/ML/scoring_traits.jl
+++ b/src/utils/ML/scoring_traits.jl
@@ -178,13 +178,13 @@ abstract type IterationScheme end
     FixedIterationScheme <: IterationScheme
 
 Fixed number of boosting rounds per iteration.
-Default: [100, 200, 200] = 3 iterations with increasing rounds.
+Default: [100, 200, 200, 200] = 4 iterations with increasing rounds.
 """
 struct FixedIterationScheme <: IterationScheme
     rounds::Vector{Int}
 end
 
-FixedIterationScheme() = FixedIterationScheme([100, 200, 200])
+FixedIterationScheme() = FixedIterationScheme([100, 200, 200, 200])
 
 """
     SinglePassScheme <: IterationScheme

--- a/test/utils/FileOperations/io/test_arrow_operations_basic.jl
+++ b/test/utils/FileOperations/io/test_arrow_operations_basic.jl
@@ -3,7 +3,8 @@ using DataFrames, Arrow, Tables
 
 using Pioneer: PSMFileReference,
                sort_file_by_keys!, write_arrow_file, transform_and_write!,
-               load_dataframe, column_names, has_columns, create_reference
+               load_dataframe, column_names, has_columns, create_reference,
+               _ensure_typed_missing_file_columns!
 
 @testset "ArrowOperations basics" begin
     temp_dir = mktempdir()
@@ -49,4 +50,68 @@ using Pioneer: PSMFileReference,
     # transform_and_write! to new path (no change to original)
     new_ref = transform_and_write!(d->d, ref, f2)
     @test load_dataframe(new_ref) == df_only_id
+end
+
+@testset "Arrow record-batch missing Float32 stability" begin
+    temp_dir = mktempdir()
+    out_path = joinpath(temp_dir, "missing_float32_batches.arrow")
+
+    open(Arrow.Writer, out_path; file=false) do writer
+        batch1 = DataFrame(
+            id = 1:2,
+            run_col = Union{Missing, Float32}[1.0f0, missing]
+        )
+        Arrow.write(writer, batch1)
+
+        # Match Pioneer write path: add absent run columns as typed Missing Float32.
+        batch2 = DataFrame(id = 3:4)
+        _ensure_typed_missing_file_columns!(batch2, ["run_col"], Float32)
+        Arrow.write(writer, batch2)
+    end
+
+    table = Arrow.Table(out_path)
+    c = Tables.getcolumn(table, :run_col)
+
+    @test eltype(c) == Union{Missing, Float32}
+    @test c[1] == 1.0f0
+    @test ismissing(c[2])
+    @test ismissing(c[3])
+    @test ismissing(c[4])
+end
+
+@testset "Arrow record-batch unstack all-missing stability" begin
+    temp_dir = mktempdir()
+    out_path = joinpath(temp_dir, "unstack_all_missing_batches.arrow")
+
+    long1 = DataFrame(
+        precursor_idx = UInt32[1, 2],
+        file_name = ["run_col", "run_col"],
+        peak_area = Union{Missing, Float32}[1.0f0, missing]
+    )
+    long2 = DataFrame(
+        precursor_idx = UInt32[3, 4],
+        file_name = ["run_col", "run_col"],
+        peak_area = Union{Missing, Float32}[missing, missing]
+    )
+
+    batch1 = unstack(long1, [:precursor_idx], :file_name, :peak_area; combine=sum)
+    batch2 = unstack(long2, [:precursor_idx], :file_name, :peak_area; combine=sum)
+    @test eltype(batch2.run_col) == Missing
+
+    _ensure_typed_missing_file_columns!(batch1, ["run_col"], Float32)
+    _ensure_typed_missing_file_columns!(batch2, ["run_col"], Float32)
+
+    open(Arrow.Writer, out_path; file=false) do writer
+        Arrow.write(writer, batch1)
+        Arrow.write(writer, batch2)
+    end
+
+    table = Arrow.Table(out_path)
+    c = Tables.getcolumn(table, :run_col)
+
+    @test eltype(c) == Union{Missing, Float32}
+    @test c[1] == 1.0f0
+    @test ismissing(c[2])
+    @test ismissing(c[3])
+    @test ismissing(c[4])
 end


### PR DESCRIPTION
Summary
- hardcode the global match-between-runs flag to false, drop obsolete config keys, and keep parsing/serialization deterministic
- remove all parameter references/docs describing MBR and mention cross-run transfer features are disabled