### PR TITLE
Fix for Arrow corruption bug

### DIFF
--- a/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
+++ b/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
@@ -127,6 +127,27 @@ function getModifiedSequence(
     mods = [("("*getModName(mod.match)*")", getModIndex(mod.match)) for mod in parseMods(mods)]
     return "_"*insert_at_indices(sequence, mods)*"_."*string(charge)
 end
+
+"""
+    _ensure_typed_missing_file_columns!(df, file_names, T)
+
+Ensure each file column in `file_names` exists in `df` and has element type
+`Union{Missing,T}` when the column is fully missing for a batch.
+"""
+function _ensure_typed_missing_file_columns!(
+    df::DataFrame,
+    file_names::AbstractVector{<:AbstractString},
+    ::Type{T}) where {T<:AbstractFloat}
+
+    n = nrow(df)
+    col_names = names(df)
+    for fname in file_names
+        if fname ∉ col_names || eltype(df[!, fname]) === Missing
+            df[!, fname] = Vector{Union{Missing, T}}(missing, n)
+        end
+    end
+    return df
+end
 #Assume sorted by protein,peptide keys. Do this in batches and write a long and wide form .csv without
 #loading the entire table into memory. 
 function writePrecursorCSV(
@@ -299,12 +320,7 @@ function writePrecursorCSV(
                         CSV.write(io1, subdf, append=true, header=false, delim='\t')
                     end
                     subunstack = makeWideFormat(subdf, Symbol.(wide_columns), normalized)
-                    col_names = names(subunstack)
-                    for fname in file_names
-                        if fname ∉ col_names
-                            subunstack[!,fname] .= Vector{Union{Missing,Float32}}(missing, nrow(subunstack))
-                        end
-                    end
+                    _ensure_typed_missing_file_columns!(subunstack, file_names, Float32)
                     if write_csv
                         _sanitize_empty_strings!(subunstack)
                         CSV.write(io2, subunstack[!,sorted_columns], append=true,header=false,delim='\t')
@@ -514,12 +530,7 @@ function writePrecursorCSV_chunked(
                             CSV.write(io1, subdf, append=true, header=false, delim='\t')
                         end
                         subunstack = makeWideFormat(subdf, Symbol.(wide_columns), normalized)
-                        col_names = names(subunstack)
-                        for fname in file_names
-                            if fname ∉ col_names
-                                subunstack[!, fname] .= Vector{Union{Missing, Float32}}(missing, nrow(subunstack))
-                            end
-                        end
+                        _ensure_typed_missing_file_columns!(subunstack, file_names, Float32)
                         if write_csv
                             _sanitize_empty_strings!(subunstack)
                             CSV.write(io2, subunstack[!, sorted_columns], append=true, header=false, delim='\t')
@@ -668,12 +679,7 @@ function writeProteinGroupsCSV(
                         CSV.write(io1, subdf, append=true, header=false, delim='\t')
                     end
                     subunstack = makeWideFormat(subdf)
-                    col_names = names(subunstack)
-                    for fname in file_names
-                        if fname ∉ col_names
-                            subunstack[!,fname] = Vector{Union{Missing,Float64}}(missing, nrow(subunstack))
-                        end
-                    end
+                    _ensure_typed_missing_file_columns!(subunstack, file_names, Float64)
                     if write_csv
                         CSV.write(io2, subunstack[!,sorted_columns], append=true,header=false,delim='\t')
                     end

--- a/test/utils/FileOperations/io/test_arrow_operations_basic.jl
+++ b/test/utils/FileOperations/io/test_arrow_operations_basic.jl
@@ -3,7 +3,8 @@ using DataFrames, Arrow, Tables
 
 using Pioneer: PSMFileReference,
                sort_file_by_keys!, write_arrow_file, transform_and_write!,
-               load_dataframe, column_names, has_columns, create_reference
+               load_dataframe, column_names, has_columns, create_reference,
+               _ensure_typed_missing_file_columns!
 
 @testset "ArrowOperations basics" begin
     temp_dir = mktempdir()
@@ -49,4 +50,68 @@ using Pioneer: PSMFileReference,
     # transform_and_write! to new path (no change to original)
     new_ref = transform_and_write!(d->d, ref, f2)
     @test load_dataframe(new_ref) == df_only_id
+end
+
+@testset "Arrow record-batch missing Float32 stability" begin
+    temp_dir = mktempdir()
+    out_path = joinpath(temp_dir, "missing_float32_batches.arrow")
+
+    open(Arrow.Writer, out_path; file=false) do writer
+        batch1 = DataFrame(
+            id = 1:2,
+            run_col = Union{Missing, Float32}[1.0f0, missing]
+        )
+        Arrow.write(writer, batch1)
+
+        # Match Pioneer write path: add absent run columns as typed Missing Float32.
+        batch2 = DataFrame(id = 3:4)
+        _ensure_typed_missing_file_columns!(batch2, ["run_col"], Float32)
+        Arrow.write(writer, batch2)
+    end
+
+    table = Arrow.Table(out_path)
+    c = Tables.getcolumn(table, :run_col)
+
+    @test eltype(c) == Union{Missing, Float32}
+    @test c[1] == 1.0f0
+    @test ismissing(c[2])
+    @test ismissing(c[3])
+    @test ismissing(c[4])
+end
+
+@testset "Arrow record-batch unstack all-missing stability" begin
+    temp_dir = mktempdir()
+    out_path = joinpath(temp_dir, "unstack_all_missing_batches.arrow")
+
+    long1 = DataFrame(
+        precursor_idx = UInt32[1, 2],
+        file_name = ["run_col", "run_col"],
+        peak_area = Union{Missing, Float32}[1.0f0, missing]
+    )
+    long2 = DataFrame(
+        precursor_idx = UInt32[3, 4],
+        file_name = ["run_col", "run_col"],
+        peak_area = Union{Missing, Float32}[missing, missing]
+    )
+
+    batch1 = unstack(long1, [:precursor_idx], :file_name, :peak_area; combine=sum)
+    batch2 = unstack(long2, [:precursor_idx], :file_name, :peak_area; combine=sum)
+    @test eltype(batch2.run_col) == Missing
+
+    _ensure_typed_missing_file_columns!(batch1, ["run_col"], Float32)
+    _ensure_typed_missing_file_columns!(batch2, ["run_col"], Float32)
+
+    open(Arrow.Writer, out_path; file=false) do writer
+        Arrow.write(writer, batch1)
+        Arrow.write(writer, batch2)
+    end
+
+    table = Arrow.Table(out_path)
+    c = Tables.getcolumn(table, :run_col)
+
+    @test eltype(c) == Union{Missing, Float32}
+    @test c[1] == 1.0f0
+    @test ismissing(c[2])
+    @test ismissing(c[3])
+    @test ismissing(c[4])
 end


### PR DESCRIPTION
The APMS dataset hit a very specific trigger pattern / bug in the arrow writing:

- precursors_wide.arrow is written in multiple record batches, and the crash starts exactly at the first row of batch 3 (145034), which is the signature of a cross-batch schema/type break.

- In the precursor wide path, a run column can become Vector{Missing} in a batch (either because the run is absent in that batch, or unstack(..., combine=sum) produces all-missing for that run in that batch).

- Earlier batches for that same run are Union{Missing,Float32}. Appending a Missing-typed batch after that corrupts Arrow buffers and then segfaults on read at the next batch boundary.

- Other files didn’t trip it because they didn’t combine those conditions:
protein_groups_wide.arrow was single-batch in your sample (no cross-batch transition),
long-format files don’t go through this wide unstack + per-run-column Arrow append path.
