### PR TITLE
Update release workflow plan

### DIFF
--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -139,6 +139,12 @@ jobs:
             build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/
           chmod +x build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/pioneer
 
+      - name: Write bundled version
+        shell: bash
+        run: |
+          echo "${{ steps.get_version.outputs.version }}" > \
+            build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/VERSION
+
       - name: Pre-download artifacts
         shell: bash
         run: |

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -216,6 +216,12 @@ jobs:
             build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/
           chmod +x build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/pioneer
 
+      - name: Write bundled version
+        shell: bash
+        run: |
+          echo "${{ steps.get_version.outputs.version }}" > \
+            build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/VERSION
+
       - name: Codesign & package macOS app (release tags or forced dispatch)
         if: github.event_name != 'pull_request' && env.MACOS_CERT_P12 != '' && (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.force_pkg))
         env:

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -135,6 +135,12 @@ jobs:
         run: |
           Copy-Item src\build\CLI\pioneer.bat build\Pioneer_${{ matrix.identifier }}/Applications/Pioneer/
 
+      - name: Write bundled version
+        shell: pwsh
+        run: |
+          Set-Content -Path "build\Pioneer_${{ matrix.identifier }}\Applications\Pioneer\VERSION" `
+                      -Value "${{ steps.get_version.outputs.version }}"
+
       - name: Pre-download artifacts
         shell: pwsh
         run: |

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,162 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version to set in Project.toml (X.Y.Z)"
+        required: true
+        type: string
+      source_branch:
+        description: "Branch to update (usually develop)"
+        required: false
+        default: "develop"
+        type: string
+      target_branch:
+        description: "Branch to merge into for release (usually main)"
+        required: false
+        default: "main"
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source branch
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.source_branch }}
+
+      - name: Validate version and update Project.toml
+        id: bump
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ inputs.version }}"
+          SOURCE_BRANCH="${{ inputs.source_branch }}"
+          TARGET_BRANCH="${{ inputs.target_branch }}"
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: version must match X.Y.Z (received: $VERSION)"
+            exit 1
+          fi
+
+          git fetch --tags --force
+          if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
+            echo "ERROR: tag v${VERSION} already exists"
+            exit 1
+          fi
+
+          CURRENT_VERSION=$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' Project.toml | head -n1)
+          if [[ -z "$CURRENT_VERSION" ]]; then
+            echo "ERROR: unable to parse current Project.toml version"
+            exit 1
+          fi
+
+          sed -i -E 's/^version[[:space:]]*=[[:space:]]*"[^"]+".*/version = "'"$VERSION"'"/' Project.toml
+
+          NEW_VERSION=$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' Project.toml | head -n1)
+          if [[ "$NEW_VERSION" != "$VERSION" ]]; then
+            echo "ERROR: failed to update Project.toml version to $VERSION"
+            exit 1
+          fi
+
+          if [[ "$CURRENT_VERSION" == "$VERSION" ]]; then
+            echo "Project.toml already set to $VERSION"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          {
+            echo "version=$VERSION"
+            echo "source_branch=$SOURCE_BRANCH"
+            echo "target_branch=$TARGET_BRANCH"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push version bump
+        if: steps.bump.outputs.changed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Project.toml
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
+          git push origin "HEAD:${{ steps.bump.outputs.source_branch }}"
+
+      - name: Create or update release PR
+        uses: actions/github-script@v7
+        env:
+          RELEASE_VERSION: ${{ steps.bump.outputs.version }}
+          SOURCE_BRANCH: ${{ steps.bump.outputs.source_branch }}
+          TARGET_BRANCH: ${{ steps.bump.outputs.target_branch }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const version = process.env.RELEASE_VERSION;
+            const source = process.env.SOURCE_BRANCH;
+            const target = process.env.TARGET_BRANCH;
+
+            if (source === target) {
+              core.notice(`Source and target are both ${source}; skipping PR creation.`);
+              return;
+            }
+
+            const title = `release: v${version}`;
+            const body = [
+              `Prepare Pioneer release v${version}.`,
+              "",
+              "This PR is managed by the `Prepare Release` workflow.",
+              "",
+              "After merge:",
+              `1. Create tag \`v${version}\` on the merge commit in \`${target}\`.`,
+              "2. The `Release` workflow will publish binaries and installers."
+            ].join("\n");
+
+            const existing = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              head: `${owner}:${source}`,
+              base: target,
+              per_page: 100
+            });
+
+            if (existing.length > 0) {
+              const pr = existing[0];
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: pr.number,
+                title,
+                body
+              });
+              core.notice(`Updated existing PR #${pr.number}: ${pr.html_url}`);
+            } else {
+              try {
+                const pr = await github.rest.pulls.create({
+                  owner,
+                  repo,
+                  head: source,
+                  base: target,
+                  title,
+                  body
+                });
+                core.notice(`Created PR #${pr.data.number}: ${pr.data.html_url}`);
+              } catch (error) {
+                const msg = String(error?.message || error);
+                if (msg.includes("No commits between")) {
+                  core.notice(`No commits between ${source} and ${target}; skipping PR creation.`);
+                  return;
+                }
+                throw error;
+              }
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,46 @@ concurrency:
   cancel-in-progress: false 
 
 jobs:
+  validate_release_version:
+    name: Validate Release Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Verify tag matches Project.toml version
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" != refs/tags/v* ]]; then
+            echo "Non-tag release run; skipping Project.toml version validation."
+            exit 0
+          fi
+
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PROJECT_VERSION=$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' Project.toml | head -n1)
+
+          if [[ -z "$PROJECT_VERSION" ]]; then
+            echo "ERROR: Could not parse version from Project.toml"
+            exit 1
+          fi
+
+          if [[ "$TAG_VERSION" != "$PROJECT_VERSION" ]]; then
+            echo "ERROR: Tag version v$TAG_VERSION does not match Project.toml version $PROJECT_VERSION"
+            exit 1
+          fi
+
+          echo "Validated tag v$TAG_VERSION matches Project.toml version $PROJECT_VERSION"
+
   linux:
+    needs: validate_release_version
     uses: ./.github/workflows/build_app_linux.yml
   macos:
+    needs: validate_release_version
     uses: ./.github/workflows/build_app_macos.yml
     secrets: inherit
   windows:
+    needs: validate_release_version
     uses: ./.github/workflows/build_app_windows.yml
 
   publish:

--- a/src/Pioneer.jl
+++ b/src/Pioneer.jl
@@ -91,6 +91,68 @@ const DEBUG_CONSOLE_LEVEL = Ref{Int}(0)
 const MAX_LOG_MSG_BYTES = Ref{Int}(4096)
 
 """
+    get_pioneer_version()
+
+Return the Pioneer version string used for user-facing logs/CLI output.
+Lookup order:
+1. `ENV["PIONEER_VERSION"]` (if set)
+2. Bundled `VERSION` file near the executable/app root
+3. `Project.toml` version (source/development fallback)
+"""
+function get_pioneer_version()
+    env_version = strip(get(ENV, "PIONEER_VERSION", ""))
+    if !isempty(env_version)
+        return env_version
+    end
+
+    version_candidates = String[]
+
+    # Candidate paths near the currently executing program.
+    if !isempty(PROGRAM_FILE)
+        exe = PROGRAM_FILE
+        if !isabspath(exe)
+            exe_full = Sys.which(exe)
+            exe = exe_full === nothing ? exe : exe_full
+        end
+        if ispath(exe)
+            exe_real = realpath(exe)
+            exe_dir = dirname(exe_real)
+            push!(version_candidates, joinpath(exe_dir, "VERSION"))
+            push!(version_candidates, joinpath(exe_dir, "..", "VERSION"))
+        end
+    end
+
+    # Source/development fallbacks.
+    push!(version_candidates, joinpath(pkgdir(Pioneer), "VERSION"))
+    push!(version_candidates, joinpath(pkgdir(Pioneer), "Project.toml"))
+
+    for path in unique(version_candidates)
+        if !isfile(path)
+            continue
+        end
+
+        try
+            if endswith(path, "Project.toml")
+                content = read(path, String)
+                version_match = match(r"^version[ \t]*=[ \t]*\"([^\"]+)\""m, content)
+                if version_match !== nothing
+                    return strip(version_match[1])
+                end
+            else
+                v = strip(read(path, String))
+                if !isempty(v)
+                    return first(split(v, '\n'))
+                end
+            end
+        catch
+            # Ignore malformed or unreadable candidates and continue fallback chain.
+        end
+    end
+
+    return "unknown"
+end
+
+"""
     truncate_for_log(msg::String; max_bytes::Int=MAX_LOG_MSG_BYTES[])
 
 Safely truncate a message by bytes without splitting UTF-8 characters.
@@ -537,5 +599,6 @@ function __init__()
 end
 
 export SearchDIA, BuildSpecLib, GetSearchParams, GetBuildLibParams, convertMzML, # ParseSpecLib, GetParseSpecLibParams, # COMMENTED OUT: ParseSpecLib has loading issues
-       @user_info, @user_warn, @user_error, @user_print, @debug_l1, @debug_l2, @debug_l3, @trace
+       @user_info, @user_warn, @user_error, @user_print, @debug_l1, @debug_l2, @debug_l3, @trace,
+       get_pioneer_version
 end

--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -59,6 +59,7 @@ function BuildSpecLib(params_path::String)
     # Clean up any old file handlers in case the program crashed
     GC.gc()
     Random.seed!(1844)
+    pioneer_version = Pioneer.get_pioneer_version()
     # Initialize timing dictionary for performance tracking
     #params_path = "/Users/n.t.wamsley/RIS_temp/koina_testing/config.json"
     timings = Dict{String, Any}()
@@ -100,6 +101,7 @@ function BuildSpecLib(params_path::String)
     
         dual_println("\n", repeat("=", 90))
         dual_println("Spectral Library Building Process")
+        dual_println("Version: ", pioneer_version)
         dual_println(repeat("=", 90))
         dual_println("\nStarting library build at: ", Dates.now())
         dual_println("Output directory: ", lib_dir)
@@ -390,7 +392,8 @@ function BuildSpecLib(params_path::String)
         N_PRECURSORS = N_PRECURSORS,
         N_FRAGMENTS = N_FRAGMENTS,
         N_TARGETS = N_TARGETS,
-        N_DECOYS = N_DECOYS)
+        N_DECOYS = N_DECOYS,
+        pioneer_version = pioneer_version)
         
         dual_println("\nLibrary building completed at: ", Dates.now())
         dual_println("\nLibrary location: ", lib_dir)
@@ -493,6 +496,7 @@ function print_performance_report(timings, println_func; kwargs...)
     # Process statistics
     println_func("\nProcess Information:")
     println_func(repeat("-", 90))
+    println_func("Pioneer Version: $(get(kwargs, :pioneer_version, "unknown"))")
     println_func("Number of Threads: $(Threads.nthreads())")
     println_func("Julia Version: $(VERSION)")
     println_func("System: $(Sys.MACHINE)")

--- a/src/Routines/SearchDIA.jl
+++ b/src/Routines/SearchDIA.jl
@@ -167,16 +167,7 @@ function SearchDIA(params_path::String)
     Pioneer.DEBUG_FILE[] = open(debug_path, "w")
     Pioneer.WARNINGS_FILE[] = open(warnings_path, "w")
     
-    # Get Pioneer version from Project.toml
-    project_toml = joinpath(pkgdir(Pioneer), "Project.toml")
-    pioneer_version = "unknown"
-    if isfile(project_toml)
-        content = read(project_toml, String)
-        version_match = match(r"version\s*=\s*\"([^\"]+)\"", content)
-        if version_match !== nothing
-            pioneer_version = version_match[1]
-        end
-    end
+    pioneer_version = Pioneer.get_pioneer_version()
     
     # Essential file - clean header (like dual_println)
     essential_header = [
@@ -217,6 +208,7 @@ function SearchDIA(params_path::String)
     warnings_header = [
         "=" ^ 90,
         "Pioneer Warnings Log",
+        "Version: $pioneer_version",
         "Started: $(Dates.now())",
         "=" ^ 90,
         ""

--- a/src/build/CLI/pioneer
+++ b/src/build/CLI/pioneer
@@ -1,5 +1,48 @@
 #!/bin/bash
 
+resolve_script_dir() {
+    local script_path="$1"
+    while [ -L "$script_path" ]; do
+        local script_dir
+        script_dir="$(cd -P "$(dirname "$script_path")" && pwd)"
+        script_path="$(readlink "$script_path")"
+        [[ $script_path != /* ]] && script_path="$script_dir/$script_path"
+    done
+    cd -P "$(dirname "$script_path")" && pwd
+}
+
+read_project_version() {
+    local project_toml="$1"
+    if [ ! -f "$project_toml" ]; then
+        return 1
+    fi
+    sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' "$project_toml" | head -n1
+}
+
+get_pioneer_version() {
+    if [ -n "$PIONEER_VERSION" ]; then
+        echo "$PIONEER_VERSION"
+        return
+    fi
+
+    if [ -f "$SCRIPT_DIR/VERSION" ]; then
+        head -n1 "$SCRIPT_DIR/VERSION"
+        return
+    fi
+
+    local project_version=""
+    project_version="$(read_project_version "$SCRIPT_DIR/../../../Project.toml")"
+    if [ -n "$project_version" ]; then
+        echo "$project_version"
+        return
+    fi
+
+    echo "unknown"
+}
+
+SCRIPT_DIR="$(resolve_script_dir "$0")"
+PIONEER_VERSION="$(get_pioneer_version)"
+
 # Set default threads to auto if not specified
 if [ -z "$JULIA_NUM_THREADS" ]; then
     export JULIA_NUM_THREADS=auto
@@ -11,6 +54,7 @@ VALID_COMMANDS="search predict params-search params-predict convert-raw convert-
 
 show_help() {
     echo "Pioneer - Mass Spectrometry Data Analysis"
+    echo "Version: $PIONEER_VERSION"
     echo ""
     echo "Usage: pioneer [options] <subcommand> [subcommand-args...]"
     echo ""
@@ -18,6 +62,7 @@ show_help() {
     echo "  --threads N        Set number of Julia threads (default: auto)"
     echo "  --threads=N        Alternative syntax for setting threads"
     echo "  --help, -h         Show this help message"
+    echo "  --version, -V      Show Pioneer version"
     echo ""
     echo "Subcommands:"
     echo "  search <params.json>                        Perform DIA search analysis"
@@ -48,6 +93,10 @@ show_help() {
     echo "For subcommand-specific help:"
     echo "  pioneer <subcommand> --help"
 }
+
+show_version() {
+    echo "Pioneer version: $PIONEER_VERSION"
+}
 # Parse command line arguments for thread override
 SUBCOMMAND=""
 SUBCOMMAND_ARGS=()
@@ -70,6 +119,15 @@ while [[ $# -gt 0 ]]; do
         --help|-h|-help|/\?)
             if [[ -z "$SUBCOMMAND" ]]; then
                 show_help
+                exit 0
+            else
+                SUBCOMMAND_ARGS+=("$1")
+                shift
+            fi
+            ;;
+        --version|-V)
+            if [[ -z "$SUBCOMMAND" ]]; then
+                show_version
                 exit 0
             else
                 SUBCOMMAND_ARGS+=("$1")
@@ -161,15 +219,6 @@ esac
     #params-empirical)
     #    SUBCOMMAND="GetParseSpecLibParams"
     #    ;;
-
-# Resolve the actual script location, handling symlinks
-SCRIPT_PATH="$0"
-while [ -L "$SCRIPT_PATH" ]; do
-    SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
-    SCRIPT_PATH="$(readlink "$SCRIPT_PATH")"
-    [[ $SCRIPT_PATH != /* ]] && SCRIPT_PATH="$SCRIPT_DIR/$SCRIPT_PATH"
-done
-SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
 
 # Call the actual Pioneer executable with subcommand and its arguments
 # The executables are in the bin/ subdirectory relative to the script location

--- a/src/build/CLI/pioneer.bat
+++ b/src/build/CLI/pioneer.bat
@@ -4,6 +4,22 @@ setlocal enabledelayedexpansion
 if "%JULIA_NUM_THREADS%"=="" set JULIA_NUM_THREADS=auto
 
 set SCRIPT_DIR=%~dp0
+if not defined PIONEER_VERSION (
+    if exist "%SCRIPT_DIR%VERSION" (
+        set /p PIONEER_VERSION=<"%SCRIPT_DIR%VERSION"
+    ) else (
+        set "PROJECT_TOML=%SCRIPT_DIR%..\..\..\Project.toml"
+        if exist "!PROJECT_TOML!" (
+            for /f "tokens=2 delims=\" %%V in ('findstr /R /C:"^version *= *\".*\"" "!PROJECT_TOML!"') do (
+                set "PIONEER_VERSION=%%V"
+                goto version_ready
+            )
+        )
+    )
+)
+if not defined PIONEER_VERSION set "PIONEER_VERSION=unknown"
+
+:version_ready
 
 set SUBCOMMAND=
 set SUBCOMMAND_ARGS=
@@ -23,6 +39,7 @@ if "%~1"=="--threads" (
     goto parse_args
 )
 for %%H in (--help -h -help /?) do if /I "%~1"=="%%H" goto handle_help
+for %%V in (--version -V) do if /I "%~1"=="%%V" goto handle_version
 
 rem Check for --threads=value format
 echo %~1 | findstr /C:"--threads=" >nul
@@ -90,6 +107,7 @@ if "%SUBCOMMAND%"=="" (
 
 :show_help
 echo Pioneer - Mass Spectrometry Data Analysis
+echo Version: %PIONEER_VERSION%
 echo.
 echo Usage: pioneer [options] ^<subcommand^> [subcommand-args...]
 echo.
@@ -97,6 +115,7 @@ echo Options:
 echo   --threads N        Set number of Julia threads (default: auto)
 echo   --threads=N        Alternative syntax for setting threads
 echo   --help, -h         Show this help message
+echo   --version, -V      Show Pioneer version
 echo.
 echo Subcommands:
 echo   search ^<params.json^>                       Perform DIA search analysis
@@ -128,6 +147,22 @@ echo For subcommand-specific help:
 echo   pioneer ^<subcommand^> --help
 exit /b 0
 
+:handle_version
+if "%SUBCOMMAND%"=="" (
+    goto show_version
+) else (
+    if "%SUBCOMMAND_ARGS%"=="" (
+        set SUBCOMMAND_ARGS=%~1
+    ) else (
+        set SUBCOMMAND_ARGS=%SUBCOMMAND_ARGS% %~1
+    )
+    shift
+    goto parse_args
+)
+
+:show_version
+echo Pioneer version: %PIONEER_VERSION%
+exit /b 0
 
 :check_subcommand
 if "%SUBCOMMAND%"=="" (


### PR DESCRIPTION
Implemented version propagation so runtime/help/log outputs reflect the GitHub build/release version, plus a release prep workflow to keep `Project.toml` aligned.

### What changed

- Added a shared runtime resolver `Pioneer.get_pioneer_version()`:
  - `ENV["PIONEER_VERSION"]` (if set)
  - bundled `VERSION` file in app artifacts
  - fallback to `Project.toml`
- Updated Search logging to use the shared resolver (removed ad-hoc `Project.toml` parsing).
- Updated BuildSpecLib logging to include Pioneer version in header and performance report.
- Updated CLI wrappers:
  - `pioneer --help` now shows version
  - added `pioneer --version` / `-V`
  - Windows `pioneer.bat` gets the same behavior
- Build workflows now write a bundled `VERSION` file into each app artifact:
  - Linux, macOS, Windows
- Release workflow now validates: tag `vX.Y.Z` must match `Project.toml` version `X.Y.Z`.
- Added `Prepare Release` workflow:
  - manual input `X.Y.Z`
  - bumps `Project.toml` on source branch (default `develop`)
  - commits/pushes the bump
  - creates/updates release PR to target branch (default `main`)

### Why

This ensures one consistent, user-visible version value in:
- `pioneer --help` / `--version`
- search logs
- library build logs
- installed binaries/artifacts

while preserving `Project.toml` as release source-of-truth.

### Validation performed

- `bash -n src/build/CLI/pioneer` passed
- `julia --project=. -e 'using Pioneer; println(Pioneer.get_pioneer_version())'` passed (`0.4.1`)
- `bash src/build/CLI/pioneer --version` prints version
- `bash src/build/CLI/pioneer --help` shows version and `--version` flag

### New release flow

1. Run **Prepare Release** with `version = X.Y.Z` on `develop`.
2. Merge generated release PR into `main`.
3. Create tag `vX.Y.Z` on merge commit.
4. Existing **Release** workflow builds/publishes artifacts (with tag/version guard).
