### PR TITLE
Installer downgrade fix

### DIFF
--- a/.github/actions/normalize-versions/action.yml
+++ b/.github/actions/normalize-versions/action.yml
@@ -26,6 +26,33 @@ runs:
         CLEAN="${RAW#[vV]}"
         CLEAN="${CLEAN%%+*}"
 
+        # ---- Dev builds: derive installer-safe numeric versions from timestamp ----
+        if [[ "$CLEAN" =~ ^[dD][eE][vV]-([0-9]{14})$ ]]; then
+          TS="${BASH_REMATCH[1]}"
+          YEAR="${TS:0:4}"
+          MONTH="${TS:4:2}"
+          DAY="${TS:6:2}"
+          HOUR="${TS:8:2}"
+          MINUTE="${TS:10:2}"
+          SECOND="${TS:12:2}"
+
+          # Debian supports explicit prerelease markers with '~'
+          DEB="0.0.0~dev.${TS}"
+
+          # pkgbuild requires numeric dotted version; use stable timestamp-derived encoding
+          PKG="0.$((10#$YEAR - 2000)).$((10#$MONTH * 10000 + 10#$DAY * 100 + 10#$HOUR))"
+
+          # MSI allows x.y.z[.w]; keep fields bounded and numeric.
+          MSI="1.$((10#$YEAR - 2000)).$((10#$MONTH * 1000 + 10#$DAY * 24 + 10#$HOUR)).$((10#$MINUTE * 60 + 10#$SECOND))"
+
+          {
+            echo "deb=$DEB"
+            echo "pkg=$PKG"
+            echo "msi=$MSI"
+          } >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
         BASE="${CLEAN%%-*}"   # before any -pre
         PRE="${CLEAN#*-}"
         HAS_PRE=0; [[ "$CLEAN" == *-* ]] && HAS_PRE=1

--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -165,10 +165,20 @@ jobs:
           ln -sf ../Pioneer/pioneer deb/usr/local/bin/pioneer
           chmod -R a+rwx deb/usr/local/Pioneer/share/julia
           info=src/build/package_info.json
-          PACKAGE=$(jq -r '.package' $info)
+          RAW_VERSION='${{ steps.get_version.outputs.version }}'
+          BASE_PACKAGE=$(jq -r '.package' $info)
+          PACKAGE="$BASE_PACKAGE"
           MAINTAINER=$(jq -r '.maintainer' $info)
           DESCRIPTION=$(jq -r '.description' $info)
           DEB_VERSION='${{ steps.norm.outputs.deb }}'
+          if [[ "$RAW_VERSION" == dev-* ]]; then
+            PACKAGE="${BASE_PACKAGE}-dev"
+            CONFLICTS="$BASE_PACKAGE"
+            REPLACES="$BASE_PACKAGE"
+          else
+            CONFLICTS="${BASE_PACKAGE}-dev"
+            REPLACES="${BASE_PACKAGE}-dev"
+          fi
 
           mkdir -p deb/DEBIAN
           cat <<EOF > deb/DEBIAN/control
@@ -176,6 +186,9 @@ jobs:
           Version: $DEB_VERSION
           Architecture: amd64
           Maintainer: $MAINTAINER
+          Provides: $BASE_PACKAGE
+          Conflicts: $CONFLICTS
+          Replaces: $REPLACES
           Description: $DESCRIPTION
           EOF
 

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -261,6 +261,7 @@ jobs:
           DIST="build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer"
           PKGROOT="pkgroot"
           VERSION='${{ steps.norm.outputs.pkg }}'
+          RAW_VERSION='${{ steps.get_version.outputs.version }}'
 
           echo "Starting codesigning at $(date)"
 
@@ -279,7 +280,13 @@ jobs:
           mkdir -p "$PKGROOT/usr/local/bin"
           ln -sf /usr/local/Pioneer/pioneer "$PKGROOT/usr/local/bin/pioneer"
 
-          IDENTIFIER=$(jq -r '.identifier' src/build/package_info.json)
+          BASE_IDENTIFIER=$(jq -r '.identifier' src/build/package_info.json)
+          if [[ "$RAW_VERSION" == dev-* ]]; then
+            IDENTIFIER="${BASE_IDENTIFIER}.dev"
+          else
+            IDENTIFIER="$BASE_IDENTIFIER"
+          fi
+          echo "Using package identifier: $IDENTIFIER"
 
           pkgbuild --root "$PKGROOT" \
                   --identifier "$IDENTIFIER" \

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -202,7 +202,6 @@ jobs:
           $rawVersion = '${{ steps.get_version.outputs.version }}'
           $isDevBuild = $rawVersion -like "dev-*"
           $allowDowngrades = if ($isDevBuild) { "yes" } else { "no" }
-          $allowSameVersionUpgrades = if ($isDevBuild) { "yes" } else { "no" }
           Write-Host "MSI downgrade mode: $allowDowngrades (version=$rawVersion)"
 
           & heat.exe dir $pioneerRoot `
@@ -219,7 +218,6 @@ jobs:
             -dProductDescription="$desc" `
             -dPackageIdentifier="$identifier" `
             -dAllowDowngrades="$allowDowngrades" `
-            -dAllowSameVersionUpgrades="$allowSameVersionUpgrades" `
             -dPlatform="x64" `
             -arch x64 `
             -ext WixUIExtension `

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -199,6 +199,11 @@ jobs:
           $info = Get-Content src\build\package_info.json | ConvertFrom-Json
           $desc       = $info.description
           $identifier = $info.identifier
+          $rawVersion = '${{ steps.get_version.outputs.version }}'
+          $isDevBuild = $rawVersion -like "dev-*"
+          $allowDowngrades = if ($isDevBuild) { "yes" } else { "no" }
+          $allowSameVersionUpgrades = if ($isDevBuild) { "yes" } else { "no" }
+          Write-Host "MSI downgrade mode: $allowDowngrades (version=$rawVersion)"
 
           & heat.exe dir $pioneerRoot `
             -cg ProductComponents `
@@ -213,6 +218,8 @@ jobs:
             -dProductVersion="${{ steps.norm.outputs.msi }}" `
             -dProductDescription="$desc" `
             -dPackageIdentifier="$identifier" `
+            -dAllowDowngrades="$allowDowngrades" `
+            -dAllowSameVersionUpgrades="$allowSameVersionUpgrades" `
             -dPlatform="x64" `
             -arch x64 `
             -ext WixUIExtension `

--- a/src/build/windows/installer.wxs
+++ b/src/build/windows/installer.wxs
@@ -4,9 +4,6 @@
   <?ifndef AllowDowngrades?>
   <?define AllowDowngrades = "no"?>
   <?endif?>
-  <?ifndef AllowSameVersionUpgrades?>
-  <?define AllowSameVersionUpgrades = "no"?>
-  <?endif?>
 
   <Product Id="*" 
            Name="Pioneer CLI Tools" 
@@ -20,10 +17,11 @@
              InstallScope="perMachine"
              Platform="x64" />
     
-    <MajorUpgrade
-      AllowDowngrades="$(var.AllowDowngrades)"
-      AllowSameVersionUpgrades="$(var.AllowSameVersionUpgrades)"
-      DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <?if $(var.AllowDowngrades) = yes ?>
+    <MajorUpgrade AllowDowngrades="yes" />
+    <?else?>
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <?endif?>
     <MediaTemplate EmbedCab="yes" />
 
     <!-- Display the project license during installation -->

--- a/src/build/windows/installer.wxs
+++ b/src/build/windows/installer.wxs
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
   xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <?ifndef AllowDowngrades?>
+  <?define AllowDowngrades = "no"?>
+  <?endif?>
+  <?ifndef AllowSameVersionUpgrades?>
+  <?define AllowSameVersionUpgrades = "no"?>
+  <?endif?>
 
   <Product Id="*" 
            Name="Pioneer CLI Tools" 
@@ -14,7 +20,10 @@
              InstallScope="perMachine"
              Platform="x64" />
     
-    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <MajorUpgrade
+      AllowDowngrades="$(var.AllowDowngrades)"
+      AllowSameVersionUpgrades="$(var.AllowSameVersionUpgrades)"
+      DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
     <MediaTemplate EmbedCab="yes" />
 
     <!-- Display the project license during installation -->


### PR DESCRIPTION
## Summary

Fix installer behavior so dev builds can be installed over existing Pioneer installs (including downgrade/side-grade scenarios), and make channel switching consistent across Windows, macOS, and Linux.

This addresses the issue where Windows dev `.msi` could show “a newer version is already installed” and skip install.

## Changes

### 1) Dev version normalization for installers
Updated [`.github/actions/normalize-versions/action.yml`](/Users/dennisgoldfarb/Programming/Pioneer.jl/.github/actions/normalize-versions/action.yml) so `dev-YYYYMMDDHHMMSS` is converted to installer-safe numeric versions instead of falling back to `0.0.0`:

- `deb`: `0.0.0~dev.<timestamp>`
- `pkg`: timestamp-derived numeric dotted version
- `msi`: timestamp-derived numeric dotted version

Release/tag normalization behavior remains unchanged.

### 2) Windows MSI: allow dev downgrade/same-version replacement
Updated [`src/build/windows/installer.wxs`](/Users/dennisgoldfarb/Programming/Pioneer.jl/src/build/windows/installer.wxs) and [`.github/workflows/build_app_windows.yml`](/Users/dennisgoldfarb/Programming/Pioneer.jl/.github/workflows/build_app_windows.yml):

- Added WiX variables `AllowDowngrades` and `AllowSameVersionUpgrades` (default `no`)
- For dev builds (`version` starts with `dev-`), workflow passes both as `yes`
- For release builds, both remain `no`

Result: dev MSI can replace existing install regardless of version ordering.

### 3) Linux DEB: explicit dev/release package channel switching
Updated [`.github/workflows/build_app_linux.yml`](/Users/dennisgoldfarb/Programming/Pioneer.jl/.github/workflows/build_app_linux.yml):

- Dev builds package as `pioneer-dev`
- Release builds package as `pioneer`
- Added control fields to both channels:
  - `Provides: pioneer`
  - `Conflicts` and `Replaces` against the opposite channel

Result: switching between dev and release packages is straightforward and not dependent on semver ordering.

### 4) macOS PKG: separate dev package identifier
Updated [`.github/workflows/build_app_macos.yml`](/Users/dennisgoldfarb/Programming/Pioneer.jl/.github/workflows/build_app_macos.yml):

- Dev builds use package identifier `<base_identifier>.dev`
- Release builds keep base identifier

Result: dev pkg installs are isolated from release receipt version ordering, reducing install blocks due to “newer installed” logic.

## Why

Dev builds do not have a strict monotonic “newer/older” scheme from a user perspective. Installer behavior should allow easy replacement/downgrade for dev artifacts across all platforms.

## Validation

- Reviewed generated installer metadata/wiring for dev vs release paths.
- Ran normalization logic checks for:
  - `dev-20260310123456`
  - `v0.4.1`
  - `v1.2.3-rc.1`
- Full installer install-over-install validation should be executed in CI/manual platform runs.

## Suggested verification in GitHub Actions

1. Build dev installers (`force_installer`/`force_pkg`).
2. Install a release build, then install dev build over it.
3. Reinstall a different dev build over existing dev build.
4. Switch back to release build.
5. Confirm install succeeds in all transitions on Windows/macOS/Linux.
