### PR TITLE
Remove event name from GitHub Actions test job name

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} on ${{ matrix.os }} (${{ github.event_name }})
+    name: Julia ${{ matrix.version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
### Motivation
- Simplify and stabilize the GitHub Actions job label by removing the `(${ { github.event_name } })` suffix from the test job name to reduce verbosity in the Actions UI.

### Description
- Updated `.github/workflows/tests.yml` to change the test job `name` from `Julia ${{ matrix.version }} on ${{ matrix.os }} (${{ github.event_name }})` to `Julia ${{ matrix.version }} on ${{ matrix.os }}` with no other changes to the matrix or steps.

### Testing
- No automated tests were run as part of this change and the existing CI matrix (`version: ['1.11']`, `os: ['ubuntu-latest']`, `arch: ['x64']`) was left unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b71a5fc66c8325a501dc31a5048310)