### PR TITLE
fix(windows): make library cleanup resilient and always allow MSI overwrite

### DIFF
--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -200,9 +200,7 @@ jobs:
           $desc       = $info.description
           $identifier = $info.identifier
           $rawVersion = '${{ steps.get_version.outputs.version }}'
-          $isDevBuild = $rawVersion -like "dev-*"
-          $allowDowngrades = if ($isDevBuild) { "yes" } else { "no" }
-          Write-Host "MSI downgrade mode: $allowDowngrades (version=$rawVersion)"
+          Write-Host "MSI will replace any existing Pioneer install (version=$rawVersion)"
 
           & heat.exe dir $pioneerRoot `
             -cg ProductComponents `
@@ -217,7 +215,6 @@ jobs:
             -dProductVersion="${{ steps.norm.outputs.msi }}" `
             -dProductDescription="$desc" `
             -dPackageIdentifier="$identifier" `
-            -dAllowDowngrades="$allowDowngrades" `
             -dPlatform="x64" `
             -arch x64 `
             -ext WixUIExtension `

--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -399,12 +399,8 @@ function BuildSpecLib(params_path::String)
         dual_println("\nLibrary location: ", lib_dir)
     end
 
-    # cleanup temp files
-    GC.gc()
-    rm(joinpath(lib_dir, "raw_fragments.arrow"), force=true)
-    rm(joinpath(lib_dir,"fragments_table.arrow"), force=true);
-    rm(joinpath(lib_dir,"prec_to_frag.arrow"), force=true);
-    rm(joinpath(lib_dir,"precursors.arrow"), force=true);
+    # Clean up temp files after build; on Windows these may still be transiently locked.
+    cleanUpLibrary(lib_dir)
     GC.gc()
 
     return nothing

--- a/src/Routines/BuildSpecLib/build/build_poin_lib.jl
+++ b/src/Routines/BuildSpecLib/build/build_poin_lib.jl
@@ -190,6 +190,15 @@ function buildPionLib(spec_lib_path::String,
         pid_to_fid
     )
 
+    # Arrow tables can keep Windows file handles alive until GC runs.
+    # Release references before BuildSpecLib removes the intermediate Arrow files.
+    fragments_table = nothing
+    prec_to_frag = nothing
+    precursors_table = nothing
+    detailed_frags = nothing
+    pid_to_fid = nothing
+    GC.gc()
+
     return nothing
 end
 
@@ -386,6 +395,15 @@ function buildPionLib(spec_lib_path::String,
         pid_to_fid
     )
 
+    # Arrow tables can keep Windows file handles alive until GC runs.
+    # Release references before BuildSpecLib removes the intermediate Arrow files.
+    fragments_table = nothing
+    prec_to_frag = nothing
+    precursors_table = nothing
+    detailed_frags = nothing
+    pid_to_fid = nothing
+    GC.gc()
+
     return nothing
 end
 
@@ -399,6 +417,7 @@ Remove intermediate files after library building is complete.
 
 # Effects
 Removes the following files if they exist:
+- raw_fragments.arrow
 - fragments_table.arrow
 - prec_to_frag.arrow
 - precursors.arrow
@@ -408,12 +427,17 @@ Removes the following files if they exist:
 """
 function cleanUpLibrary(spec_lib_path::String)
     GC.gc()
-    for fname in ["fragments_table.arrow", "prec_to_frag.arrow", "precursors.arrow"]
+    for fname in ["raw_fragments.arrow", "fragments_table.arrow", "prec_to_frag.arrow", "precursors.arrow"]
         fpath = joinpath(spec_lib_path, fname)
         if isfile(fpath)
-            rm(fpath, force=true)
+            try
+                safeRm(fpath, nothing; force=true)
+            catch e
+                @user_warn "Failed to remove temporary file $(fpath): $(sprint(showerror, e))"
+            end
         end
     end
+    return nothing
 end
 
 """

--- a/src/Routines/SearchDIA.jl
+++ b/src/Routines/SearchDIA.jl
@@ -58,6 +58,20 @@ function asset_path(parts...)
     
 end
 
+function clean_search_output_dir(results_dir::String)
+    GC.gc()
+    for fpath in readdir(results_dir, join=true)
+        if endswith(fpath, ".tsv") || endswith(fpath, ".arrow")
+            try
+                safeRm(fpath, nothing; force=true)
+            catch e
+                @user_warn "Failed to remove stale search output $(fpath): $(sprint(showerror, e))"
+            end
+        end
+    end
+    return nothing
+end
+
 """
     Locate the isotope spline XML file bundled with the application.
 """
@@ -219,6 +233,7 @@ function SearchDIA(params_path::String)
     
     # Log initialization message
     @user_info "Pioneer logging system initialized"
+    previous_tmpdir = get(ENV, "TMPDIR", nothing)
     
     try
         @user_print "\n" * repeat("=", 90)
@@ -297,8 +312,7 @@ function SearchDIA(params_path::String)
             write(joinpath(normpath(params.paths[:results]), "config.json"), merged_json)
             nothing
         end
-        [rm(fpath) for fpath in readdir(getDataOutDir(SEARCH_CONTEXT), join=true) if endswith(fpath, ".tsv")]
-        [rm(fpath) for fpath in readdir(getDataOutDir(SEARCH_CONTEXT), join=true) if endswith(fpath, ".arrow")]
+        clean_search_output_dir(getDataOutDir(SEARCH_CONTEXT))
         timings["Search Context Initialization"] = context_timing
 
         # === Execute search pipeline ===
@@ -339,6 +353,12 @@ function SearchDIA(params_path::String)
         @user_error "Stacktrace: $(stacktrace(catch_backtrace()))"
         rethrow(e)
     finally
+        if previous_tmpdir === nothing
+            haskey(ENV, "TMPDIR") && delete!(ENV, "TMPDIR")
+        else
+            ENV["TMPDIR"] = previous_tmpdir
+        end
+
         # Count warnings if any exist
         warning_count = 0
         warnings_full_path = ""  # Store full path for display

--- a/src/Routines/SearchDIA/SearchMethods/MaxLFQSearch/MaxLFQSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MaxLFQSearch/MaxLFQSearch.jl
@@ -229,6 +229,7 @@ function summarize_results!(
             params.q_value_threshold,
             batch_size = params.batch_size
         )
+        chunk_paths = [file_path(ref) for ref in chunk_refs]
 
         # Create FileReference for output metadata tracking
         protein_ref = ProteinQuantFileReference(protein_long_path)
@@ -282,12 +283,16 @@ function summarize_results!(
         if isdir(chunk_dir)
             GC.gc()
             try
+                for chunk_path in chunk_paths
+                    isfile(chunk_path) && safeRm(chunk_path, nothing; force=true)
+                end
                 rm(chunk_dir; recursive=true, force=true)
             catch e
                 # On Windows, a chunk file may still be briefly locked by Arrow mmap state.
                 @debug "merge_chunks cleanup deferred" exception=e
             end
         end
+        chunk_paths = nothing
 
         if params.delete_temp
             @user_info "Removing temporary data..."

--- a/src/Routines/SearchDIA/SearchMethods/MaxLFQSearch/MaxLFQSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MaxLFQSearch/MaxLFQSearch.jl
@@ -251,15 +251,18 @@ function summarize_results!(
         # Stream-concatenate chunks into precursors_long.arrow for QC plots
         @user_info "Concatenating chunks to precursors_long.arrow..."
         for (i, chunk_ref) in enumerate(chunk_refs)
-            tbl = Arrow.Table(file_path(chunk_ref))
-            if i == 1
-                open(precursors_long_path, "w") do io
-                    Arrow.write(io, tbl; file=false)
+            let tbl = Arrow.Table(file_path(chunk_ref))
+                if i == 1
+                    open(precursors_long_path, "w") do io
+                        Arrow.write(io, tbl; file=false)
+                    end
+                else
+                    Arrow.append(precursors_long_path, tbl)
                 end
-            else
-                Arrow.append(precursors_long_path, tbl)
             end
         end
+        chunk_refs = nothing
+        GC.gc()
 
         @user_info "Creating QC plots..."
         # Create QC plots
@@ -275,13 +278,13 @@ function summarize_results!(
             all_file_names
         )
 
-        # Cleanup chunk files — GC first to release Arrow mmap handles (NFS silly-rename fix)
+        # Cleanup chunk files after dropping Arrow.Table references.
         if isdir(chunk_dir)
-            GC.gc(false)
+            GC.gc()
             try
                 rm(chunk_dir; recursive=true, force=true)
             catch e
-                # On NFS, stale .nfs* handles may linger; temp_data deletion below will retry
+                # On Windows, a chunk file may still be briefly locked by Arrow mmap state.
                 @debug "merge_chunks cleanup deferred" exception=e
             end
         end
@@ -293,7 +296,7 @@ function summarize_results!(
             try
                 isdir(temp_path) && rm(temp_path; recursive=true, force=true)
             catch e
-                @warn "Could not fully remove temp_data (NFS stale handles?)" exception=e
+                @warn "Could not fully remove temp_data (likely lingering file handles)" exception=e
             end
         end
 

--- a/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
+++ b/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
@@ -629,71 +629,79 @@ function writeProteinGroupsCSV(
                              :abundance])
 
     sorted_columns = vcat(wide_columns, file_names)
-    open(long_protein_groups_path,"w") do io1
-        open(wide_protein_groups_path, "w") do io2
-            #Make file headers
-            if write_csv
-                println(io1,join(names(protein_groups_long),"\t"))
-                println(io2,join(sorted_columns,"\t"))
-            end
-            batch_start_idx, batch_end_idx = 1, min(batch_size+1,n_rows)
-            open(Arrow.Writer, wide_protein_groups_arrow; file=false) do arrow_writer
-                while batch_start_idx <= n_rows
-                    #For the wide format, can't split a precursor between two batches.
-                    last_protein_group = protein_groups_long[batch_end_idx,:protein]
-                    while batch_end_idx < n_rows
-                        if  protein_groups_long[batch_end_idx + 1,:protein] != last_protein_group
-                            break
-                        end
-                        batch_end_idx += 1
+    batch_start_idx, batch_end_idx = 1, min(batch_size+1,n_rows)
+    function write_batches!(io1, io2)
+        #Make file headers
+        if write_csv
+            println(io1,join(names(protein_groups_long),"\t"))
+            println(io2,join(sorted_columns,"\t"))
+        end
+        open(Arrow.Writer, wide_protein_groups_arrow; file=false) do arrow_writer
+            while batch_start_idx <= n_rows
+                #For the wide format, can't split a precursor between two batches.
+                last_protein_group = protein_groups_long[batch_end_idx,:protein]
+                while batch_end_idx < n_rows
+                    if  protein_groups_long[batch_end_idx + 1,:protein] != last_protein_group
+                        break
                     end
-                    subdf = protein_groups_long[range(batch_start_idx, batch_end_idx),:]
-                    batch_start_idx = batch_end_idx + 1
-                    batch_end_idx = min(batch_start_idx + batch_size, n_rows)
-                    subdf[!,:modified_sequence] = Vector{String}(undef, size(subdf, 1))
-                    for i in range(1, size(subdf, 1))
-                        peptides = subdf[i,:peptides]
-                        modified_sequences = Vector{String}(undef, length(peptides))
-                        for (j, pid) in enumerate(peptides)
-                            if ismissing(pid)
-                                modified_sequences[j] = ""
-                                continue
-                            end
-                            modified_sequences[j] = getModifiedSequence(
-                                sequences[pid],
-                                isotope_mods[pid],
-                                structural_mods[pid],
-                                precursor_charge[pid])
-                        end
-                        subdf[i,:modified_sequence] = join(filter(!isempty, modified_sequences),';')
-                    end
-                    subdf[!,:peptides] = subdf[!,:modified_sequence]
-                    select!(subdf, Not([:modified_sequence]))
-                    # Replace empty peptide strings with missing to avoid writer edge-cases
-                    try
-                        allowmissing!(subdf, :peptides)
-                        replace!(subdf[!, :peptides], "" => missing)
-                    catch
-                    end
-                    if write_csv
-                        CSV.write(io1, subdf, append=true, header=false, delim='\t')
-                    end
-                    subunstack = makeWideFormat(subdf)
-                    _ensure_typed_missing_file_columns!(subunstack, file_names, Float64)
-                    if write_csv
-                        CSV.write(io2, subunstack[!,sorted_columns], append=true,header=false,delim='\t')
-                    end
-
-                    # Normalize column types for consistent Arrow schema across batches
-                    allowmissing!(subunstack)
-                    Arrow.write(arrow_writer, subunstack[!,sorted_columns])
+                    batch_end_idx += 1
                 end
+                subdf = protein_groups_long[range(batch_start_idx, batch_end_idx),:]
+                batch_start_idx = batch_end_idx + 1
+                batch_end_idx = min(batch_start_idx + batch_size, n_rows)
+                subdf[!,:modified_sequence] = Vector{String}(undef, size(subdf, 1))
+                for i in range(1, size(subdf, 1))
+                    peptides = subdf[i,:peptides]
+                    modified_sequences = Vector{String}(undef, length(peptides))
+                    for (j, pid) in enumerate(peptides)
+                        if ismissing(pid)
+                            modified_sequences[j] = ""
+                            continue
+                        end
+                        modified_sequences[j] = getModifiedSequence(
+                            sequences[pid],
+                            isotope_mods[pid],
+                            structural_mods[pid],
+                            precursor_charge[pid])
+                    end
+                    subdf[i,:modified_sequence] = join(filter(!isempty, modified_sequences),';')
+                end
+                subdf[!,:peptides] = subdf[!,:modified_sequence]
+                select!(subdf, Not([:modified_sequence]))
+                # Replace empty peptide strings with missing to avoid writer edge-cases
+                try
+                    allowmissing!(subdf, :peptides)
+                    replace!(subdf[!, :peptides], "" => missing)
+                catch
+                end
+                if write_csv
+                    CSV.write(io1, subdf, append=true, header=false, delim='\t')
+                end
+                subunstack = makeWideFormat(subdf)
+                _ensure_typed_missing_file_columns!(subunstack, file_names, Float64)
+                if write_csv
+                    CSV.write(io2, subunstack[!,sorted_columns], append=true,header=false,delim='\t')
+                end
+
+                # Normalize column types for consistent Arrow schema across batches
+                allowmissing!(subunstack)
+                Arrow.write(arrow_writer, subunstack[!,sorted_columns])
             end
         end
-        if write_csv == false
-            safeRm(long_protein_groups_path, nothing, force = true)
-            safeRm(wide_protein_groups_path, nothing, force = true)
+    end
+
+    if write_csv
+        open(long_protein_groups_path,"w") do io1
+            open(wide_protein_groups_path, "w") do io2
+                write_batches!(io1, io2)
+            end
         end
+    else
+        write_batches!(nothing, nothing)
+    end
+    if write_csv == false
+        safeRm(long_protein_groups_path, nothing, force = true)
+        safeRm(wide_protein_groups_path, nothing, force = true)
     end
     return wide_protein_groups_arrow
 end

--- a/src/build/snoop.jl
+++ b/src/build/snoop.jl
@@ -58,9 +58,9 @@ end
 ##########################################
 
 # Build a tiny Prosit library and search it with low memory thresholds
-maybe_run("BuildSpecLib") do
-    Pioneer.BuildSpecLib(joinpath(data_dir, "precompile", "build_ecoli_prosit.json"))
-end
+#maybe_run("BuildSpecLib") do
+#    Pioneer.BuildSpecLib(joinpath(data_dir, "precompile", "build_ecoli_prosit.json"))
+#end
 # Build a tiny Altimeter library
 maybe_run("BuildSpecLib") do
     Pioneer.BuildSpecLib(joinpath(data_dir, "precompile", "build_ecoli_altimeter.json"))
@@ -72,7 +72,7 @@ end
 ##########################################
 
 maybe_run("SearchDIA") do
-    Pioneer.SearchDIA(joinpath(data_dir, "precompile", "search_ecoli_prosit.json"))         # prosit
+#    Pioneer.SearchDIA(joinpath(data_dir, "precompile", "search_ecoli_prosit.json"))         # prosit
     Pioneer.SearchDIA(joinpath(data_dir, "precompile", "search_yeast_altimeter.json"))      # altimeter + MBR
     Pioneer.SearchDIA(joinpath(data_dir, "precompile", "search_yeast_altimeter_OOM.json"))  # altimeter + MBR + OOM
 end

--- a/src/build/windows/installer.wxs
+++ b/src/build/windows/installer.wxs
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
   xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-  <?ifndef AllowDowngrades?>
-  <?define AllowDowngrades = "no"?>
-  <?endif?>
-
   <Product Id="*" 
            Name="Pioneer CLI Tools" 
            Language="1033" 
@@ -17,11 +13,10 @@
              InstallScope="perMachine"
              Platform="x64" />
     
-    <?if $(var.AllowDowngrades) = yes ?>
+    <!-- Always replace an existing Pioneer install, even when the incoming MSI
+         version is numerically older than the installed one. AllowDowngrades
+         already covers same-version replacement. -->
     <MajorUpgrade AllowDowngrades="yes" />
-    <?else?>
-    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
-    <?endif?>
     <MediaTemplate EmbedCab="yes" />
 
     <!-- Display the project license during installation -->

--- a/src/utils/FileOperations/streaming/ColumnOperations.jl
+++ b/src/utils/FileOperations/streaming/ColumnOperations.jl
@@ -53,6 +53,7 @@ This function handles common Windows file locking issues that occur with Arrow f
 function safe_replace_file(temp_path::String, target_path::String, file_handle)
     # Clear the file handle before attempting replacement
     file_handle = nothing
+    target_path = normpath(target_path)
     
     if Sys.iswindows()
         # Try to delete the existing file with retries (if it exists)
@@ -60,18 +61,14 @@ function safe_replace_file(temp_path::String, target_path::String, file_handle)
             max_retries = 3  # Reduced retries since we're not relying on GC
             for i in 1:max_retries
                 try
-                    # Try to delete using Julia's rm with force flag
-                    run(`cmd /c del /f /q "$fpath"`)
-                    #rm(target_path, force=true)
+                    windows_delete_file(target_path)
                     break
                 catch
                     @user_info "safe_replace failed on try i=$i"
                     if i == max_retries
                         # If all retries failed, try Windows-specific deletion
                         try
-                            win_path = replace(abspath(target_path), "/" => "\\")
-                            cmd_del = Cmd(["cmd", "/c", "del", "/f", "/q", win_path])
-                            run(cmd_del)
+                            windows_delete_file(target_path)
                         catch
                             # If that also fails, rename the old file instead of deleting
                             backup_path = target_path * ".backup_" * string(time_ns())
@@ -249,4 +246,3 @@ function add_column_and_sort!(ref::FileReference, col_name::Symbol,
     
     return ref
 end
-

--- a/src/utils/safeFileOps.jl
+++ b/src/utils/safeFileOps.jl
@@ -18,6 +18,29 @@
 # Safe file operations for cross-platform compatibility
 
 """
+    windows_cmd_path(fpath::String)
+
+Normalize a file path for Windows `cmd.exe` built-ins like `del`.
+Converts relative or mixed-separator paths such as `./data/foo.arrow`
+into an absolute backslash-separated path so `cmd` does not interpret
+`/data` as an invalid switch.
+"""
+function windows_cmd_path(fpath::String)
+    return replace(abspath(normpath(fpath)), "/" => "\\")
+end
+
+"""
+    windows_delete_file(fpath::String)
+
+Delete a file through `cmd /c del` using a path format that Windows
+command parsing accepts reliably.
+"""
+function windows_delete_file(fpath::String)
+    run(Cmd(["cmd", "/c", "del", "/f", "/q", windows_cmd_path(fpath)]))
+    return nothing
+end
+
+"""
     safeRm(fpath::String, file_handle; force::Bool=false)
 
 Safely remove a file with Windows-specific handling for file locks and permissions.
@@ -38,6 +61,7 @@ and other binary formats that may have lingering file handles.
 function safeRm(fpath::String, file_handle; force::Bool=false)
     # Clear the file handle before attempting deletion
     file_handle = nothing
+    fpath = normpath(fpath)
     
     if Sys.iswindows()
         # Return early if file doesn't exist
@@ -48,19 +72,14 @@ function safeRm(fpath::String, file_handle; force::Bool=false)
         max_retries = 3  # Reduced since we're explicitly clearing handles
         for i in 1:max_retries
             try
-                # Try Julia's rm with force flag
-                #rm(fpath, force=force)
-                run(`cmd /c del /f /q "$fpath"`)
+                windows_delete_file(fpath)
                 return nothing
             catch
                 @user_info "safe_rm failed on try i=$i"
                 if i == max_retries
                     # If all retries failed, try Windows-specific deletion
                     try
-                        # Convert to a Windows-style path for the cmd call
-                        win_path = replace(abspath(fpath), "/" => "\\")
-                        cmd_del = Cmd(["cmd", "/c", "del", "/f", "/q", win_path])
-                        run(cmd_del)
+                        windows_delete_file(fpath)
                         return nothing
                     catch
                         # If that also fails, rename the old file instead of deleting

--- a/src/utils/writeArrow.jl
+++ b/src/utils/writeArrow.jl
@@ -45,7 +45,7 @@ function writeArrow(fpath::String, df::AbstractDataFrame)
         # Try to delete the existing file with retries
         if isfile(fpath)
             try
-                run(`cmd /c del /f /q "$fpath"`)#rm(fpath, force=true)
+                windows_delete_file(fpath)
             catch e 
                 #@user_info "Initial deletion failed for $fpath, attempting retries. \n"
                 @debug_l1 "Windows specifiec deletion failed for $fpath. \n"

--- a/test/UnitTests/BuildPionLibTest.jl
+++ b/test/UnitTests/BuildPionLibTest.jl
@@ -389,6 +389,7 @@ end
         
         # Create test files
         test_files = [
+            "raw_fragments.arrow",
             "fragments_table.arrow",
             "prec_to_frag.arrow",
             "precursors.arrow",
@@ -404,6 +405,7 @@ end
         cleanUpLibrary(test_dir)
 
         # Check that specified files were removed
+        @test !isfile(joinpath(test_dir, "raw_fragments.arrow"))
         @test !isfile(joinpath(test_dir, "fragments_table.arrow"))
         @test !isfile(joinpath(test_dir, "prec_to_frag.arrow"))
         @test !isfile(joinpath(test_dir, "precursors.arrow"))


### PR DESCRIPTION
## Summary

This PR fixes two Windows-specific issues:

1. `BuildSpecLib` could fail at the end of a successful run when deleting intermediate Arrow files, with errors like `permission denied (EACCES)` on `fragments_table.arrow`.
2. The Windows MSI could still block installation with “A newer version of [ProductName] is already installed,” even though installs should always replace the existing Pioneer version.

## What Changed

### BuildSpecLib cleanup hardening

- Released Arrow/table references before temp-file cleanup so Windows file handles can be collected more reliably.
- Replaced direct `rm(...)` cleanup in `BuildSpecLib` with the existing Windows-aware `cleanUpLibrary(...)` path.
- Updated `cleanUpLibrary(...)` to use `safeRm(...)` instead of raw `rm(...)`, so Windows gets retry/fallback deletion behavior instead of failing hard on transient locks.
- Added `raw_fragments.arrow` to the cleanup set.
- If a temp file still cannot be removed, cleanup now warns instead of aborting the completed build.

### Windows installer overwrite behavior

- Updated the WiX installer to always use `<MajorUpgrade AllowDowngrades="yes" />`.
- Removed workflow logic that only enabled downgrades for `dev-*` builds.
- The Windows installer should now always replace any existing Pioneer install, regardless of installed version ordering.

## Why

On some Windows systems, Arrow-backed files remain locked briefly due to GC/finalizer timing or external file access, which made end-of-build cleanup flaky.

Separately, the MSI still had version-based overwrite protection in its packaging config, which contradicted the intended install behavior.

## Testing

- Updated the `cleanUpLibrary` unit test to cover `raw_fragments.arrow`.
- Locally validated the cleanup helper path with a targeted Julia check.
- Did not run a full Windows MSI build in this environment.

## Notes

After merging, the Windows installer must be rebuilt for the MSI overwrite behavior to take effect. Existing MSI artifacts will still carry the old behavior.