### PR TITLE
Upgrade mzML converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ pioneer search search_params.json
 - **Variable modifications:** Only oxidation of methionine (Unimod:35) is currently supported as a variable PTM
 - **Digestion:** Fully enzymatic digestion only (no semi-enzymatic or non-specific searches)
 - **Ion mobility:** We currently don't support ion mobility data. A single FAIMS CV throughout the dataset is fine though.
+- **mzML input:** Only centroided mzML is supported. Files containing profile-mode spectra are skipped during conversion.
 - **Interface:** Command-line only; no graphical user interface yet
 
 ## Regression Tests

--- a/docs/src/user_guide/quickstart.md
+++ b/docs/src/user_guide/quickstart.md
@@ -23,6 +23,8 @@ For mzML-formatted data, use:
 pioneer convert-mzml /path/to/mzml/or/folder
 ```
 
+Only centroided mzML is supported. Files containing profile-mode spectra are skipped during conversion.
+
 ## Starting Pioneer
 After installation, Pioneer is accessed from the command line. Running `pioneer --help` displays available subcommands:
 

--- a/src/Routines/mzmlConverter/convertMzML.jl
+++ b/src/Routines/mzmlConverter/convertMzML.jl
@@ -15,27 +15,137 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+const CONVERT_MZML_APP_NAME = "convertMzML"
+
+Base.@kwdef mutable struct ConvertMzMLOptions
+    mzml_path::String = ""
+    output_dir::String = ""
+    skip_existing::Bool = false
+    skip_scan_header::Bool = true
+    concurrent_files::Int = 2
+    should_show_help::Bool = false
+    should_show_version::Bool = false
+end
+
+function parse_convert_mzml_args(args::Vector{String})::ConvertMzMLOptions
+    options = ConvertMzMLOptions()
+
+    isempty(args) && return ConvertMzMLOptions(; should_show_help = true)
+
+    i = 1
+    while i <= length(args)
+        arg = args[i]
+        if arg == "-o" || arg == "--output-dir"
+            i += 1
+            i > length(args) && throw(ArgumentError("Missing value for $arg"))
+            options.output_dir = args[i]
+        elseif arg == "--skip-existing"
+            options.skip_existing = true
+        elseif arg == "-n" || arg == "--concurrent-files"
+            i += 1
+            i > length(args) && throw(ArgumentError("Missing value for $arg"))
+            try
+                options.concurrent_files = parse(Int, args[i])
+            catch
+                throw(ArgumentError("Invalid value for $arg"))
+            end
+        elseif arg == "--skip-header"
+            options.skip_scan_header = true
+        elseif arg == "--include-scan-header"
+            options.skip_scan_header = false
+        elseif arg == "--version"
+            options.should_show_version = true
+        elseif arg == "-h" || arg == "--help"
+            options.should_show_help = true
+        elseif startswith(arg, "-")
+            throw(ArgumentError("Unknown option: $arg"))
+        elseif isempty(options.mzml_path)
+            options.mzml_path = arg
+        elseif lowercase(arg) in ("true", "false")
+            # Backward compatibility for the old positional skip_header argument.
+            options.skip_scan_header = parse(Bool, lowercase(arg))
+        else
+            throw(ArgumentError("Unexpected argument: $arg"))
+        end
+
+        i += 1
+    end
+
+    return options
+end
+
+function show_convert_mzml_help(io::IO=stdout)
+    println(io, "$(CONVERT_MZML_APP_NAME) $(get_pioneer_version())")
+    println(io)
+    println(io, "Usage: $(CONVERT_MZML_APP_NAME) MZML_PATH [options]")
+    println(io)
+    println(io, "Arguments:")
+    println(io, "  MZML_PATH                  Path to .mzML file or directory containing .mzML files")
+    println(io)
+    println(io, "Options:")
+    println(io, "  -o, --output-dir <path>   Output directory for .arrow files (default: <input_dir>/arrow_out)")
+    println(io, "      --skip-existing       Skip conversion when existing output appears complete")
+    println(io, "  -n, --concurrent-files <n>")
+    println(io, "                            Number of files to convert at the same time (default: 2)")
+    println(io, "      --skip-header         Omit scan header information from output (default)")
+    println(io, "      --include-scan-header Include scan header information in output")
+    println(io, "      --version             Show version information")
+    println(io, "  -h, --help                Show help information")
+end
+
+function format_convert_mzml_duration(elapsed_ns::Integer)::String
+    elapsed_seconds = elapsed_ns / 1.0e9
+    if elapsed_seconds >= 3600
+        total_seconds = round(Int, elapsed_seconds)
+        hours = total_seconds ÷ 3600
+        minutes = (total_seconds % 3600) ÷ 60
+        seconds = total_seconds % 60
+        return "$(hours)h $(minutes)m $(seconds)s"
+    elseif elapsed_seconds >= 60
+        total_seconds = round(Int, elapsed_seconds)
+        minutes = total_seconds ÷ 60
+        seconds = total_seconds % 60
+        return "$(minutes)m $(seconds)s"
+    elseif elapsed_seconds >= 1
+        return string(round(elapsed_seconds; digits = 1), "s")
+    else
+        return string(round(elapsed_ns / 1.0e6), "ms")
+    end
+end
+
 # Entry point for PackageCompiler
 function main_convertMzML(argv=ARGS)::Cint
-    
-    settings = ArgParseSettings(; autofix_names = true)
-    @add_arg_table! settings begin
-        "mzml_dir"
-            help = "Directory containing mzML files"
-            arg_type = String
-        "skip_header"
-            help = "Skip scan header (true/false)"
-            arg_type = Bool
-            default = true
-            required = false
-    end
-    parsed_args = parse_args(argv, settings; as_symbols = true)
-    
     try
-        convertMzML(parsed_args[:mzml_dir]; 
-                    skip_scan_header = parsed_args[:skip_header])
-    catch
-        Base.invokelatest(Base.display_error, Base.catch_stack())
+        options = parse_convert_mzml_args(String[arg for arg in argv])
+
+        if options.should_show_version
+            println("$(CONVERT_MZML_APP_NAME) $(get_pioneer_version())")
+            return 0
+        end
+
+        if options.should_show_help
+            show_convert_mzml_help()
+            return 0
+        end
+
+        if isempty(options.mzml_path)
+            println("Missing required MZML_PATH argument.")
+            show_convert_mzml_help()
+            return 1
+        end
+
+        convertMzML(
+            options.mzml_path;
+            skip_scan_header = options.skip_scan_header,
+            output_dir = options.output_dir,
+            skip_existing = options.skip_existing,
+            concurrent_files = options.concurrent_files
+        )
+    catch e
+        println(sprint(showerror, e))
+        if e isa ArgumentError
+            show_convert_mzml_help()
+        end
         return 1
     end
     return 0
@@ -315,8 +425,130 @@ function parseSpectrumElement!(
 
 end
 
+function get_mzml_input_dir(mzml_path::String)::String
+    mzml_path = expanduser(mzml_path)
+
+    if isdir(mzml_path)
+        return abspath(mzml_path)
+    elseif isfile(mzml_path)
+        return dirname(abspath(mzml_path))
+    end
+
+    throw(ArgumentError("File or Directory does not exist: $mzml_path"))
+end
+
+function get_mzml_paths(mzml_path::String)::Vector{String}
+    mzml_path = expanduser(mzml_path)
+
+    if isfile(mzml_path)
+        return endswith(lowercase(mzml_path), ".mzml") ? [abspath(mzml_path)] : String[]
+    elseif isdir(mzml_path)
+        return sort([
+            abspath(fpath) for fpath in readdir(mzml_path, join = true)
+            if endswith(lowercase(fpath), ".mzml")
+        ])
+    end
+
+    return String[]
+end
+
+function build_convert_mzml_output_dir(input_dir::String, requested_output_dir::String)::String
+    output_dir = isempty(strip(requested_output_dir)) ?
+                 joinpath(input_dir, "arrow_out") :
+                 abspath(expanduser(requested_output_dir))
+
+    if isfile(output_dir)
+        throw(ArgumentError("Output path points to an existing file: $output_dir"))
+    end
+
+    mkpath(output_dir)
+    return output_dir
+end
+
+function get_convert_mzml_output_path(output_dir::String, mzml_path::String)::String
+    return joinpath(output_dir, "$(splitext(basename(mzml_path))[1]).arrow")
+end
+
+function get_convert_mzml_output_paths(output_dir::String, mzml_paths::Vector{String})::Vector{String}
+    return [get_convert_mzml_output_path(output_dir, mzml_path) for mzml_path in mzml_paths]
+end
+
+function get_mzml_last_scan_number(mzml_path::String)::Int
+    root_elements = EzXML.root(EzXML.readxml(mzml_path))
+    ns = Dict("ms" => "http://psi.hupo.org/ms/mzml")
+    mzML = findfirst("//ms:mzML", root_elements, ns)
+    run_element = findfirst("//ms:run", mzML, ns)
+    spectrum_list = findfirst("//ms:spectrumList", run_element, ns)
+
+    count_attr = try
+        strip(spectrum_list["count"])
+    catch
+        ""
+    end
+    if !isempty(count_attr)
+        return parse(Int, count_attr)
+    end
+
+    return length(collect(eachelement(spectrum_list)))
+end
+
+function get_convert_mzml_output_last_scan_number(output_path::String)::Union{Nothing, Int}
+    table = Arrow.Table(output_path)
+    scan_numbers = table[:scanNumber]
+    isempty(scan_numbers) && return nothing
+    return Int(scan_numbers[end])
+end
+
+function has_complete_existing_output(mzml_path::String, output_path::String)::Bool
+    try
+        return get_convert_mzml_output_last_scan_number(output_path) == get_mzml_last_scan_number(mzml_path)
+    catch
+        return false
+    end
+end
+
+function partition_convert_mzml_queue(
+    mzml_paths::Vector{String},
+    output_paths::Vector{String};
+    skip_existing::Bool)::NamedTuple
+
+    files_to_convert = Int[]
+    skipped_complete_files = 0
+    reconverted_incomplete_files = 0
+    missing_output_files = 0
+
+    for i in eachindex(mzml_paths, output_paths)
+        if !skip_existing
+            push!(files_to_convert, i)
+            continue
+        end
+
+        if !isfile(output_paths[i])
+            missing_output_files += 1
+            push!(files_to_convert, i)
+            continue
+        end
+
+        if has_complete_existing_output(mzml_paths[i], output_paths[i])
+            skipped_complete_files += 1
+            continue
+        end
+
+        reconverted_incomplete_files += 1
+        push!(files_to_convert, i)
+    end
+
+    return (
+        files_to_convert = files_to_convert,
+        skipped_complete_files = skipped_complete_files,
+        reconverted_incomplete_files = reconverted_incomplete_files,
+        missing_output_files = missing_output_files,
+    )
+end
+
 function readMzML(
     mzML_path::String,
+    output_path::String,
     skip_scan_header::Bool)
     root_elements = EzXML.root(EzXML.readxml(mzML_path))
     # Create a namespace map
@@ -336,29 +568,44 @@ function readMzML(
         )
     end
 
-    dir, filename = splitdir(mzML_path)
-    base_name = splitext(filename)[1]
-    arrow_path = joinpath(dir, "$(base_name).arrow")
-    Arrow.write(arrow_path, DataFrame(pairedSpectra))
+    Arrow.write(output_path, DataFrame(pairedSpectra))
+end
+
+function process_mzml_file(
+    input_path::String,
+    output_path::String,
+    skip_scan_header::Bool)
+
+    file_label = splitext(basename(input_path))[1]
+    println("Starting Conversion For: $file_label")
+
+    start_ns = time_ns()
+    readMzML(input_path, output_path, skip_scan_header)
+    elapsed_ns = time_ns() - start_ns
+
+    println("Execution Time: $(round(Int, elapsed_ns / 1.0e6)) ms for $file_label")
 end
 
 """
-    convertMzML(mzml_dir::String; skip_scan_header::Bool=true)
+    convertMzML(mzml_path::String; skip_scan_header::Bool=true, output_dir::String="", skip_existing::Bool=false, concurrent_files::Int=2)
 
 Convert mzML mass spectrometry data files to Arrow IPC format.
 
-Takes either a directory containing mzML files or a path to a single mzML file and converts them to 
+Takes either a directory containing mzML files or a path to a single mzML file and converts them to
 Arrow format, preserving scan data including m/z arrays, intensity arrays, and scan metadata.
 
 # Arguments
-- `mzml_dir::String`: Path to either a directory containing mzML files or a path to a single mzML file
+- `mzml_path::String`: Path to either a directory containing mzML files or a path to a single mzML file
 - `skip_scan_header::Bool=true`: When true, omits scan header information from the output to reduce file size
+- `output_dir::String=""`: Output directory for `.arrow` files. Defaults to `<input_dir>/arrow_out`
+- `skip_existing::Bool=false`: When true, skip files whose existing `.arrow` output appears complete
+- `concurrent_files::Int=2`: Number of mzML files to convert at the same time
 
 # Returns
 `nothing`
 
 # Output
-Creates Arrow (.arrow) files in the same directory as the input mzML files and with the same base filename.
+Creates Arrow (.arrow) files in the requested output directory with the same base filename as the input mzML files.
 
 # Examples
 ```julia
@@ -368,38 +615,92 @@ convertMzML("path/to/mzml/files")
 # Convert a single mzML file
 convertMzML("path/to/single/file.mzML")
 
+# Convert to a custom output directory
+convertMzML("path/to/mzml/files", output_dir="path/to/arrow_out")
+
+# Skip files that already have complete Arrow outputs
+convertMzML("path/to/mzml/files", skip_existing=true)
+
 # Include scan headers in output
 convertMzML("path/to/mzml/files", skip_scan_header=false)
 ```
 # Notes
 
-Each mzML file is converted to a corresponding Arrow IPC (.arrow) file in the same directory. This is particularly useful for Sciex data where direct .wiff/.wiff2 conversion is not supported
+Each mzML file is converted to a corresponding Arrow IPC (.arrow) file in the output directory. This is particularly useful for Sciex data where direct .wiff/.wiff2 conversion is not supported
 """
 function convertMzML(
-    mzml_dir::String;
-    skip_scan_header= true)
+    mzml_path::String;
+    skip_scan_header::Bool = true,
+    output_dir::String = "",
+    skip_existing::Bool = false,
+    concurrent_files::Int = 2)
 
     # Clean up any old file handlers in case the program crashed
     GC.gc()
-    mzml_dir = expanduser(mzml_dir)
 
-    mzml_paths = missing
-    if isdir(mzml_dir)
-        mzml_paths = [fpath for fpath in readdir(mzml_dir, join=true) if endswith(fpath, ".mzML")]
-    elseif isfile(mzml_dir)
-        if endswith(mzml_dir, ".mzML")
-            mzml_paths = [mzml_dir]
+    input_dir = get_mzml_input_dir(mzml_path)
+    mzml_paths = get_mzml_paths(mzml_path)
+
+    output_dir = build_convert_mzml_output_dir(input_dir, output_dir)
+    output_paths = get_convert_mzml_output_paths(output_dir, mzml_paths)
+    queue = partition_convert_mzml_queue(mzml_paths, output_paths; skip_existing = skip_existing)
+
+    input_mode = isdir(expanduser(mzml_path)) ? "directory" : "file"
+    concurrent_files = max(1, concurrent_files)
+    total_start_ns = time_ns()
+
+    println("$(CONVERT_MZML_APP_NAME) $(get_pioneer_version())")
+    println("==================================================")
+    println("Config: concurrent-files=$concurrent_files  skip-header=$(lowercase(string(skip_scan_header)))")
+    println("Config: output=$output_dir")
+    println("Config: skip-existing=$(lowercase(string(skip_existing)))")
+    println()
+    println("Input : $input_mode $(expanduser(mzml_path))")
+    println("Queue : discovered=$(length(mzml_paths))  convert=$(length(queue.files_to_convert))")
+    if skip_existing
+        println(
+            "Queue : skipped-complete=$(queue.skipped_complete_files)  " *
+            "reconvert-incomplete=$(queue.reconverted_incomplete_files)  " *
+            "missing-output=$(queue.missing_output_files)"
+        )
+    end
+    println("==================================================")
+
+    if isempty(mzml_paths)
+        println("No .mzML files found to process")
+        println("Total conversion time: $(format_convert_mzml_duration(time_ns() - total_start_ns))")
+        return nothing
+    end
+
+    if isempty(queue.files_to_convert)
+        println("No files to convert.")
+        println("Total conversion time: $(format_convert_mzml_duration(time_ns() - total_start_ns))")
+        return nothing
+    end
+
+    if concurrent_files == 1 || length(queue.files_to_convert) == 1
+        for file_index in queue.files_to_convert
+            process_mzml_file(mzml_paths[file_index], output_paths[file_index], skip_scan_header)
+        end
+    else
+        sem = Base.Semaphore(concurrent_files)
+        @sync for file_index in queue.files_to_convert
+            Base.acquire(sem)
+            Threads.@spawn begin
+                try
+                    process_mzml_file(
+                        mzml_paths[file_index],
+                        output_paths[file_index],
+                        skip_scan_header
+                    )
+                finally
+                    Base.release(sem)
+                end
+            end
         end
     end
-    if ismissing(mzml_paths)
-        throw("Error $mzml_dir is not a directory containing .mzML nor a path to an .mzML file")
-    elseif iszero(length(mzml_paths))
-        throw("Error $mzml_dir is not a directory containing .mzML nor a path to an .mzML file")
-    end
 
-    for mzml_path in ProgressBar(mzml_paths)
-        readMzML(mzml_path, skip_scan_header)
-    end
+    println("Total conversion time: $(format_convert_mzml_duration(time_ns() - total_start_ns))")
     return nothing
 end
 

--- a/src/Routines/mzmlConverter/convertMzML.jl
+++ b/src/Routines/mzmlConverter/convertMzML.jl
@@ -172,6 +172,21 @@ end
 const CID_ACCESSION = "MS:1000133"  # collision-induced dissociation
 const BEAM_TYPE_CID_ACCESSION = "MS:1000422"  # beam-type collision-induced dissociation
 const COLLISION_ENERGY_ACCESSION = "MS:1000045"  # collision energy
+const CENTROID_SPECTRUM_ACCESSION = "MS:1000127"  # centroid spectrum
+const PROFILE_SPECTRUM_ACCESSION = "MS:1000128"  # profile spectrum
+
+struct ProfileModeMzMLError <: Exception
+    mzml_path::String
+    scan_index::Int
+end
+
+function Base.showerror(io::IO, err::ProfileModeMzMLError)
+    print(
+        io,
+        "Profile-mode spectrum detected in $(err.mzml_path) at scan $(err.scan_index). " *
+        "Pioneer only supports centroided mzML data."
+    )
+end
 
 function parseBinaryDataList(binary_data_list::EzXML.Node)
     mz_array, intensity_array = nothing, nothing
@@ -409,6 +424,12 @@ function parseSpectrumElement!(
         if scanElement.name=="binaryDataArrayList"
             mz_array, intensity_array = parseBinaryDataList(scanElement)
         elseif scanElement.name=="cvParam"
+            accession = scanElement["accession"]
+            if accession == PROFILE_SPECTRUM_ACCESSION
+                throw(ProfileModeMzMLError("", scanIndex))
+            elseif accession == CENTROID_SPECTRUM_ACCESSION
+                continue
+            end
             parseScanCvParam!(spectrum_dict, scanElement)
         elseif scanElement.name == "scanList"
             parseScanList!(spectrum_dict, scanElement)
@@ -560,12 +581,19 @@ function readMzML(
 
     pairedSpectra = Vector{PioneerScanElement}(undef, length(collect(eachelement(spectrum_list))))
     for (i, spectrum_element) in enumerate(collect(eachelement(spectrum_list)))
-        pairedSpectra[i] = parseSpectrumElement!(
-                                        init_spectrum_dict(),
-                                        spectrum_element, 
-                                        i,
-                                        skip_scan_header
-        )
+        try
+            pairedSpectra[i] = parseSpectrumElement!(
+                                            init_spectrum_dict(),
+                                            spectrum_element, 
+                                            i,
+                                            skip_scan_header
+            )
+        catch err
+            if err isa ProfileModeMzMLError
+                throw(ProfileModeMzMLError(mzML_path, err.scan_index))
+            end
+            rethrow()
+        end
     end
 
     Arrow.write(output_path, DataFrame(pairedSpectra))
@@ -580,10 +608,22 @@ function process_mzml_file(
     println("Starting Conversion For: $file_label")
 
     start_ns = time_ns()
-    readMzML(input_path, output_path, skip_scan_header)
+    try
+        readMzML(input_path, output_path, skip_scan_header)
+    catch err
+        if err isa ProfileModeMzMLError
+            println(
+                "Warning: skipping $file_label - profile-mode spectra detected. " *
+                "Pioneer only handles centroided mzML data."
+            )
+            return false
+        end
+        rethrow()
+    end
     elapsed_ns = time_ns() - start_ns
 
     println("Execution Time: $(round(Int, elapsed_ns / 1.0e6)) ms for $file_label")
+    return true
 end
 
 """

--- a/src/Routines/mzmlConverter/convertMzML.jl
+++ b/src/Routines/mzmlConverter/convertMzML.jl
@@ -46,8 +46,6 @@ struct PioneerScanElement
     intensity_array::Vector{Union{Missing, Float32}}
     scanHeader::String
     scanNumber::Int32
-    basePeakMz::Float32
-    basePeakIntensity::Float32
     packetType::Int32
     retentionTime::Float32
     lowMz::Float32
@@ -59,6 +57,12 @@ struct PioneerScanElement
     collisionEnergyEvField::Union{Missing, Float32}
     msOrder::UInt8
 end
+
+# PSI-MS activation terms we support when parsing precursor collision energy.
+const CID_ACCESSION = "MS:1000133"  # collision-induced dissociation
+const BEAM_TYPE_CID_ACCESSION = "MS:1000422"  # beam-type collision-induced dissociation
+const COLLISION_ENERGY_ACCESSION = "MS:1000045"  # collision energy
+
 function parseBinaryDataList(binary_data_list::EzXML.Node)
     mz_array, intensity_array = nothing, nothing
     is_mz_array, is_intensity_array = false, false
@@ -114,6 +118,39 @@ function decodeBinaryArray(encoded_data::String, ::Float64)
     end
 end
 
+function init_spectrum_dict()::Dict{String, String}
+    return Dict{String, String}(
+        "ms level" => "",
+        "total ion current" => "",
+        "collision energy" => "",
+        "spectrum title" => "",
+        "scan start time" => "",
+        "scan window upper limit" => "",
+        "scan window lower limit" => "",
+        "isolation window target m/z" => "",
+        "isolation window lower offset" => "",
+        "isolation window upper offset" => ""
+    )
+end
+
+function parse_required_cv_param(::Type{T},
+    spectrum_dict::Dict{String, String},
+    key::String,
+    scan_number::Int64)::T where {T <: Number}
+
+    value = strip(get(spectrum_dict, key, ""))
+    isempty(value) && throw(ArgumentError("missing \"$key\" for spectrum $scan_number"))
+    return parse(T, value)
+end
+
+function parse_optional_cv_param(::Type{T},
+    spectrum_dict::Dict{String, String},
+    key::String)::Union{Missing, T} where {T <: Number}
+
+    value = strip(get(spectrum_dict, key, ""))
+    return isempty(value) ? missing : parse(T, value)
+end
+
 
 function parseScanDictToScanElement(
     spectrum_dict::Dict{String, String},
@@ -128,29 +165,33 @@ function parseScanDictToScanElement(
         scanHeader = spectrum_dict["spectrum title"]
     end
     scanNumber = Int32(scan_number)
-    basePeakMz = parse(Float32, spectrum_dict["base peak m/z"])
-    basePeakIntensity = parse(Float32, spectrum_dict["base peak intensity"])
-    retentionTime = parse(Float32, spectrum_dict["scan start time"])
-    lowMz = parse(Float32, spectrum_dict["scan window lower limit"])
-    highMz = parse(Float32, spectrum_dict["scan window upper limit"])
-    msOrder = parse(UInt8, spectrum_dict["ms level"])
+    retentionTime = parse_required_cv_param(Float32, spectrum_dict, "scan start time", scan_number)
+    lowMz = parse_required_cv_param(Float32, spectrum_dict, "scan window lower limit", scan_number)
+    highMz = parse_required_cv_param(Float32, spectrum_dict, "scan window upper limit", scan_number)
+    msOrder = parse_required_cv_param(UInt8, spectrum_dict, "ms level", scan_number)
     if msOrder > 1
-        targetMz = parse(Float32, spectrum_dict["isolation window target m/z"])
-        lowerOffset = parse(Float32, spectrum_dict["isolation window lower offset"])
-        upperOffset = parse(Float32, spectrum_dict["isolation window lower offset"])
-        isolationWidthMz = lowerOffset + upperOffset
-        centerMz = targetMz + (upperOffset - lowerOffset)/2.0f0
+        targetMz = parse_optional_cv_param(Float32, spectrum_dict, "isolation window target m/z")
+        lowerOffset = parse_optional_cv_param(Float32, spectrum_dict, "isolation window lower offset")
+        upperOffset = parse_optional_cv_param(Float32, spectrum_dict, "isolation window upper offset")
+        if !ismissing(targetMz) && !ismissing(lowerOffset) && !ismissing(upperOffset)
+            isolationWidthMz = lowerOffset + upperOffset
+            centerMz = targetMz + (upperOffset - lowerOffset)/2.0f0
+        end
     end
-    TIC = parse(Float32, spectrum_dict["total ion current"])
-    dissociation = spectrum_dict["beam-type collision-induced dissociation"]
-    collisionEnergyField = (dissociation == "" ? missing : parse(Float32, dissociation))
+    TIC = coalesce(
+        parse_optional_cv_param(Float32, spectrum_dict, "total ion current"),
+        sum(intensity_array; init = zero(Float32))
+    )
+    collisionEnergyField = parse_optional_cv_param(
+        Float32,
+        spectrum_dict,
+        "collision energy"
+    )
     return PioneerScanElement(
         allowmissing(mz_array), 
         allowmissing(intensity_array),
         scanHeader,
         scanNumber,
-        basePeakMz,
-        basePeakIntensity,
         zero(Int32),
         retentionTime,
         lowMz,
@@ -172,6 +213,33 @@ function parseScanCvParam!(
         spectrum_dict[ScanCvParamName] =  ScanCvParam["value"]
     end
 end        
+
+function parseActivation!(
+    spectrum_dict::Dict{String, String},
+    activation::EzXML.Node)
+
+    has_supported_activation = false
+    collision_energy = ""
+
+    for activationElement in eachelement(activation)
+        if activationElement.name != "cvParam"
+            continue
+        end
+
+        accession = activationElement["accession"]
+        if accession == CID_ACCESSION || accession == BEAM_TYPE_CID_ACCESSION
+            has_supported_activation = true
+        elseif accession == COLLISION_ENERGY_ACCESSION
+            collision_energy = activationElement["value"]
+        end
+    end
+
+    if has_supported_activation
+        spectrum_dict["collision energy"] = collision_energy
+    end
+
+    return nothing
+end
 
 function parseScanList!(
     spectrum_dict::Dict{String, String},
@@ -212,11 +280,7 @@ function parsePrecursorList!(
                         end
                     end
                 elseif precursorElement.name == "activation"
-                    for activationElement in eachelement(precursorElement)
-                        if activationElement.name == "cvParam"
-                            parseScanCvParam!(spectrum_dict, activationElement)
-                        end
-                    end
+                    parseActivation!(spectrum_dict, precursorElement)
                 end
             end
         end
@@ -262,25 +326,10 @@ function readMzML(
     run_element = findfirst("//ms:run", mzML, ns)
     spectrum_list = findfirst("//ms:spectrumList", run_element, ns)
 
-    spectrum_dict = Dict{String, String}(
-        "ms level" => "",
-        "base peak intensity" => "",
-        "base peak m/z" => "",
-        "total ion current" => "",
-        "spectrum title" => "",
-        "scan start time" => "",
-        "scan window upper limit" => "",
-        "scan window lower limit" =>"",
-        "isolation window target m/z" => "",
-        "isolation window lower offset" => "",
-        "isolation window upper offset" => "",
-        "beam-type collision-induced dissociation" => ""
-    )
-
     pairedSpectra = Vector{PioneerScanElement}(undef, length(collect(eachelement(spectrum_list))))
     for (i, spectrum_element) in enumerate(collect(eachelement(spectrum_list)))
         pairedSpectra[i] = parseSpectrumElement!(
-                                        spectrum_dict, 
+                                        init_spectrum_dict(),
                                         spectrum_element, 
                                         i,
                                         skip_scan_header

--- a/src/Routines/mzmlConverter/convertMzML.jl
+++ b/src/Routines/mzmlConverter/convertMzML.jl
@@ -647,6 +647,9 @@ Arrow format, preserving scan data including m/z arrays, intensity arrays, and s
 # Output
 Creates Arrow (.arrow) files in the requested output directory with the same base filename as the input mzML files.
 
+# Requirements
+Only centroided mzML is supported. Files containing profile-mode spectra are skipped during conversion.
+
 # Examples
 ```julia
 # Convert all mzML files in a directory

--- a/src/build/CLI/pioneer
+++ b/src/build/CLI/pioneer
@@ -80,7 +80,7 @@ show_help() {
     echo "  convert-raw <data_path> [--output-dir <dir>] [--skip-existing] [--concurrent-files N] [--threads-per-file N]"
     echo "                                              Convert Thermo RAW files via PioneerConverter"
     echo "                                              For additional converter options, run: pioneer convert-raw --help"
-    echo "  convert-mzml <data_path> [skip_header]"
+    echo "  convert-mzml <data_path> [options]"
     echo "                                              Convert mzML files"
     echo ""
     echo "Examples:"

--- a/src/build/CLI/pioneer.bat
+++ b/src/build/CLI/pioneer.bat
@@ -133,7 +133,7 @@ rem echo                                                 Default params output p
 echo   convert-raw ^<data_path^> [--output-dir ^<dir^>] [--skip-existing] [--concurrent-files N] [--threads-per-file N]
 echo                                                 Convert Thermo RAW files via PioneerConverter
 echo                                                 For additional converter options, run: pioneer convert-raw --help
-echo   convert-mzml ^<data_path^> [skip_header]
+echo   convert-mzml ^<data_path^> [options]
 echo                                                 Convert mzML files
 echo.
 echo Examples:

--- a/src/structs/FilteredMassSpecData.jl
+++ b/src/structs/FilteredMassSpecData.jl
@@ -29,8 +29,6 @@ mutable struct FilteredMassSpecData{T<:AbstractFloat} <: MassSpecData
     # Metadata arrays - one entry per sampled scan
     scan_headers::Vector{String}
     scan_numbers::Vector{Int32}
-    base_peak_mzs::Vector{T}
-    base_peak_intensities::Vector{T}
     injection_times::Vector{T}
     retention_times::Vector{T}
     precursor_mzs::Vector{T}
@@ -296,8 +294,6 @@ function FilteredMassSpecData(
     
     scan_headers = Vector{String}(undef, n_sampled)
     scan_numbers = Vector{Int32}(undef, n_sampled)
-    base_peak_mzs = Vector{T}(undef, n_sampled)
-    base_peak_intensities = Vector{T}(undef, n_sampled)
     injection_times = Vector{T}(undef, n_sampled)
     retention_times = Vector{T}(undef, n_sampled)
     precursor_mzs = Vector{T}(undef, n_sampled)
@@ -339,8 +335,6 @@ function FilteredMassSpecData(
         # Copy all metadata
         scan_headers[filtered_idx] = getScanHeader(original, original_idx)
         scan_numbers[filtered_idx] = getScanNumber(original, original_idx)
-        base_peak_mzs[filtered_idx] = T(getBasePeakMz(original, original_idx))
-        base_peak_intensities[filtered_idx] = T(getBasePeakIntensity(original, original_idx))
         injection_times[filtered_idx] = zero(T)  # Default to zero - injection time not available in BasicNonIonMobilityMassSpecData
         retention_times[filtered_idx] = T(getRetentionTime(original, original_idx))
         precursor_mzs[filtered_idx] = T(getPrecursorMz(original, original_idx))
@@ -358,7 +352,6 @@ function FilteredMassSpecData(
     return FilteredMassSpecData{T}(
         mz_arrays, intensity_arrays,
         scan_headers, scan_numbers,
-        base_peak_mzs, base_peak_intensities,
         injection_times, retention_times,
         precursor_mzs, isolation_widths,
         precursor_charges, ms_orders,
@@ -458,8 +451,6 @@ getIntensityArray(ms_data::FilteredMassSpecData{T}, scan_idx::Integer) where T =
 # Metadata access - implement ALL methods from MassSpecData interface
 getScanHeader(ms_data::FilteredMassSpecData, scan_idx::Integer) = ms_data.scan_headers[scan_idx]
 getScanNumber(ms_data::FilteredMassSpecData, scan_idx::Integer) = ms_data.scan_numbers[scan_idx]
-getBasePeakMz(ms_data::FilteredMassSpecData{T}, scan_idx::Integer) where T = ms_data.base_peak_mzs[scan_idx]
-getBasePeakIntensity(ms_data::FilteredMassSpecData{T}, scan_idx::Integer) where T = ms_data.base_peak_intensities[scan_idx]
 getInjectionTime(ms_data::FilteredMassSpecData{T}, scan_idx::Integer) where T = ms_data.injection_times[scan_idx]
 getRetentionTime(ms_data::FilteredMassSpecData{T}, scan_idx::Integer) where T = ms_data.retention_times[scan_idx]
 getPrecursorMz(ms_data::FilteredMassSpecData{T}, scan_idx::Integer) where T = ms_data.precursor_mzs[scan_idx]
@@ -477,8 +468,6 @@ getMzArrays(ms_data::FilteredMassSpecData{T}) where T = ms_data.mz_arrays
 getIntensityArrays(ms_data::FilteredMassSpecData{T}) where T = ms_data.intensity_arrays
 getScanHeaders(ms_data::FilteredMassSpecData) = ms_data.scan_headers
 getScanNumbers(ms_data::FilteredMassSpecData) = ms_data.scan_numbers
-getBasePeakMzs(ms_data::FilteredMassSpecData{T}) where T = ms_data.base_peak_mzs
-getBasePeakIntensities(ms_data::FilteredMassSpecData{T}) where T = ms_data.base_peak_intensities
 getInjectionTimes(ms_data::FilteredMassSpecData{T}) where T = ms_data.injection_times
 getRetentionTimes(ms_data::FilteredMassSpecData{T}) where T = ms_data.retention_times
 getPrecursorMzs(ms_data::FilteredMassSpecData{T}) where T = ms_data.precursor_mzs
@@ -564,8 +553,6 @@ function Base.append!(
         # Append all metadata
         push!(filtered.scan_headers, getScanHeader(original, original_idx))
         push!(filtered.scan_numbers, getScanNumber(original, original_idx))
-        push!(filtered.base_peak_mzs, T(getBasePeakMz(original, original_idx)))
-        push!(filtered.base_peak_intensities, T(getBasePeakIntensity(original, original_idx)))
         push!(filtered.injection_times, zero(T))  # Default to zero - injection time not available in BasicNonIonMobilityMassSpecData
         push!(filtered.retention_times, T(getRetentionTime(original, original_idx)))
         push!(filtered.precursor_mzs, T(getPrecursorMz(original, original_idx)))
@@ -697,16 +684,6 @@ function getMsOrder(data::IndexedMassSpecData, virtual_idx::Integer)
     return getMsOrder(data.original_data, actual_idx)
 end
 
-function getBasePeakMz(data::IndexedMassSpecData, virtual_idx::Integer)
-    actual_idx = get_actual_index(data, virtual_idx)
-    return getBasePeakMz(data.original_data, actual_idx)
-end
-
-function getBasePeakIntensity(data::IndexedMassSpecData, virtual_idx::Integer)
-    actual_idx = get_actual_index(data, virtual_idx)
-    return getBasePeakIntensity(data.original_data, actual_idx)
-end
-
 function getTIC(data::IndexedMassSpecData, virtual_idx::Integer)
     actual_idx = get_actual_index(data, virtual_idx)
     return getTIC(data.original_data, actual_idx)
@@ -778,14 +755,6 @@ end
 
 function getMsOrders(data::IndexedMassSpecData)
     return [getMsOrder(data.original_data, actual_idx) for actual_idx in data.scan_indices]
-end
-
-function getBasePeakMzs(data::IndexedMassSpecData)
-    return [getBasePeakMz(data.original_data, actual_idx) for actual_idx in data.scan_indices]
-end
-
-function getBasePeakIntensities(data::IndexedMassSpecData)
-    return [getBasePeakIntensity(data.original_data, actual_idx) for actual_idx in data.scan_indices]
 end
 
 function getTICs(data::IndexedMassSpecData)

--- a/src/structs/MassSpecData.jl
+++ b/src/structs/MassSpecData.jl
@@ -112,22 +112,6 @@ function getScanNumber(ms_data::BasicNonIonMobilityMassSpecData, scan_idx::Integ
     getScanNumbers(ms_data)[scan_idx]
 end
 
-# Base peak m/z getters
-function getBasePeakMzs(ms_data::BasicNonIonMobilityMassSpecData{T}) where T
-    return ms_data.data[:basePeakMz]::Arrow.Primitive{T, Vector{T}}
-end
-function getBasePeakMz(ms_data::BasicNonIonMobilityMassSpecData{T}, scan_idx::Integer)::T where T
-    getBasePeakMzs(ms_data)[scan_idx]
-end
-
-# Base peak intensity getters
-function getBasePeakIntensities(ms_data::BasicNonIonMobilityMassSpecData{T}) where T
-    return ms_data.data[:basePeakIntensity]::Arrow.Primitive{T, Vector{T}}
-end
-function getBasePeakIntensity(ms_data::BasicNonIonMobilityMassSpecData{T}, scan_idx::Integer)::T where T
-    getBasePeakIntensities(ms_data)[scan_idx]
-end
-
 # Packet type getters remain Int32
 getPacketTypes(ms_data::BasicNonIonMobilityMassSpecData)::Arrow.Primitive{Int32, Vector{Int32}} = ms_data.data[:packetType]
 function getPacketType(ms_data::BasicNonIonMobilityMassSpecData, scan_idx::Integer)::Int32
@@ -252,22 +236,6 @@ end
 getScanNumbers(ms_data::BatchNonIonMobilityMassSpecData)::SentinelArrays.ChainedVector{Int32, Arrow.Primitive{Int32, Vector{Int32}}} = ms_data.data[:scanNumber]
 function getScanNumber(ms_data::BatchNonIonMobilityMassSpecData, scan_idx::Integer)::Int32
     getScanNumbers(ms_data)[scan_idx]
-end
-
-# Base peak m/z getters
-function getBasePeakMzs(ms_data::BatchNonIonMobilityMassSpecData{T}) where T
-    return ms_data.data[:basePeakMz]::SentinelArrays.ChainedVector{T, Arrow.Primitive{T, Vector{T}}}
-end
-function getBasePeakMz(ms_data::BatchNonIonMobilityMassSpecData{T}, scan_idx::Integer)::T where T
-    getBasePeakMzs(ms_data)[scan_idx]
-end
-
-# Base peak intensity getters
-function getBasePeakIntensities(ms_data::BatchNonIonMobilityMassSpecData{T}) where T
-    return ms_data.data[:basePeakIntensity]::SentinelArrays.ChainedVector{T, Arrow.Primitive{T, Vector{T}}}
-end
-function getBasePeakIntensity(ms_data::BatchNonIonMobilityMassSpecData{T}, scan_idx::Integer)::T where T
-    getBasePeakIntensities(ms_data)[scan_idx]
 end
 
 # Packet type getters remain Int32

--- a/test/UnitTests/MassSpecAndFilteredDataTests.jl
+++ b/test/UnitTests/MassSpecAndFilteredDataTests.jl
@@ -5,8 +5,7 @@ using Random
 
 # Import only what we need from Pioneer (avoid Pioneer.func calls)
 using Pioneer: BasicMassSpecData,
-               getScanHeader, getScanNumber, getBasePeakMz, getBasePeakIntensity,
-               getRetentionTime, getLowMz, getHighMz, getTIC, getMsOrder,
+               getScanHeader, getScanNumber, getRetentionTime, getLowMz, getHighMz, getTIC, getMsOrder,
                getMzArray, getIntensityArray, getCenterMz, getIsolationWidthMz,
                getCenterMzs, getIsolationWidthMzs, getRetentionTimes, getTICs, getMsOrders,
                FilteredMassSpecData, IndexedMassSpecData, create_scan_mapping,
@@ -22,8 +21,6 @@ function write_basic_ms_arrow(path::String; n::Int=5)
     int_arrays = Vector{Vector{Union{Missing,Float32}}}(undef, n)
     headers = ["scan_$(i)" for i in 1:n]
     scan_nums = Int32.(1:n)
-    base_mz = Float32.(100 .+ collect(1:n))
-    base_int = Float32.(1000 .+ 10 .* collect(1:n))
     rt = Float32.(range(10, length=n, step=0.5))
     low_mz = Float32.(fill(100.0, n))
     high_mz = Float32.(fill(1000.0, n))
@@ -43,8 +40,6 @@ function write_basic_ms_arrow(path::String; n::Int=5)
         intensity_array = int_arrays,
         scanHeader = headers,
         scanNumber = scan_nums,
-        basePeakMz = base_mz,
-        basePeakIntensity = base_int,
         retentionTime = rt,
         lowMz = low_mz,
         highMz = high_mz,
@@ -71,8 +66,6 @@ end
     # Spot-check getters (Basic)
     @test getScanHeader(original, 1) == "scan_1"
     @test getScanNumber(original, 2) == Int32(2)
-    @test getBasePeakMz(original, 3) ≈ Float32(103)
-    @test getBasePeakIntensity(original, 4) ≈ Float32(1040)
     @test getRetentionTime(original, 5) ≈ Float32(12.0)
     @test getLowMz(original, 1) ≈ Float32(100.0)
     @test getHighMz(original, 1) ≈ Float32(1000.0)
@@ -160,8 +153,6 @@ end
         orig_idx = getOriginalScanIndex(indexed, i)
         @test getScanHeader(indexed, i) == getScanHeader(original, orig_idx)
         @test getScanNumber(indexed, i) == getScanNumber(original, orig_idx)
-        @test getBasePeakMz(indexed, i) ≈ getBasePeakMz(original, orig_idx)
-        @test getBasePeakIntensity(indexed, i) ≈ getBasePeakIntensity(original, orig_idx)
         @test getRetentionTime(indexed, i) ≈ getRetentionTime(original, orig_idx)
         @test getLowMz(indexed, i) ≈ getLowMz(original, orig_idx)
         @test getHighMz(indexed, i) ≈ getHighMz(original, orig_idx)

--- a/test/UnitTests/convertMzMLTests.jl
+++ b/test/UnitTests/convertMzMLTests.jl
@@ -1,6 +1,29 @@
 using Test
+using Arrow
+using DataFrames
 using EzXML
-using Pioneer: init_spectrum_dict, parsePrecursorList!, parseScanDictToScanElement
+using Pioneer: build_convert_mzml_output_dir, get_convert_mzml_output_paths,
+               init_spectrum_dict, parsePrecursorList!, parseScanDictToScanElement,
+               parse_convert_mzml_args, partition_convert_mzml_queue
+
+function write_test_mzml(path::String; n_spectra::Int)
+    spectra = join(["<spectrum id=\"scan=$(i)\"/>" for i in 1:n_spectra], "\n")
+    write(path, """
+    <mzML xmlns="http://psi.hupo.org/ms/mzml">
+      <run>
+        <spectrumList count="$n_spectra">
+          $spectra
+        </spectrumList>
+      </run>
+    </mzML>
+    """)
+    return path
+end
+
+function write_test_scan_numbers(path::String, scan_numbers::Vector{Int32})
+    Arrow.write(path, DataFrame(scanNumber = scan_numbers))
+    return path
+end
 
 @testset "convertMzML metadata parsing" begin
     spectrum_dict = Dict{String, String}(
@@ -104,4 +127,50 @@ end
     parsePrecursorList!(spectrum_dict, precursor_list)
 
     @test isempty(spectrum_dict["collision energy"])
+end
+
+@testset "convertMzML CLI argument parsing" begin
+    options = parse_convert_mzml_args([
+        "input_dir",
+        "-o", "custom_out",
+        "--skip-existing",
+        "-n", "4",
+        "--include-scan-header",
+    ])
+
+    @test options.mzml_path == "input_dir"
+    @test options.output_dir == "custom_out"
+    @test options.skip_existing
+    @test options.concurrent_files == 4
+    @test !options.skip_scan_header
+
+    compat_options = parse_convert_mzml_args(["input_dir", "false"])
+    @test compat_options.mzml_path == "input_dir"
+    @test !compat_options.skip_scan_header
+end
+
+@testset "convertMzML output directory and queue planning" begin
+    temp_dir = mktempdir()
+    mzml_dir = joinpath(temp_dir, "mzml")
+    mkpath(mzml_dir)
+
+    mzml_paths = [
+        write_test_mzml(joinpath(mzml_dir, "complete.mzML"), n_spectra = 3),
+        write_test_mzml(joinpath(mzml_dir, "incomplete.mzML"), n_spectra = 3),
+        write_test_mzml(joinpath(mzml_dir, "missing.mzML"), n_spectra = 2),
+    ]
+
+    output_dir = build_convert_mzml_output_dir(mzml_dir, "")
+    @test output_dir == joinpath(mzml_dir, "arrow_out")
+
+    output_paths = get_convert_mzml_output_paths(output_dir, mzml_paths)
+    write_test_scan_numbers(output_paths[1], Int32[1, 2, 3])
+    write_test_scan_numbers(output_paths[2], Int32[1, 2])
+
+    queue = partition_convert_mzml_queue(mzml_paths, output_paths; skip_existing = true)
+
+    @test queue.files_to_convert == [2, 3]
+    @test queue.skipped_complete_files == 1
+    @test queue.reconverted_incomplete_files == 1
+    @test queue.missing_output_files == 1
 end

--- a/test/UnitTests/convertMzMLTests.jl
+++ b/test/UnitTests/convertMzMLTests.jl
@@ -4,10 +4,18 @@ using DataFrames
 using EzXML
 using Pioneer: build_convert_mzml_output_dir, get_convert_mzml_output_paths,
                init_spectrum_dict, parsePrecursorList!, parseScanDictToScanElement,
-               parse_convert_mzml_args, partition_convert_mzml_queue
+               parse_convert_mzml_args, partition_convert_mzml_queue,
+               process_mzml_file
 
-function write_test_mzml(path::String; n_spectra::Int)
-    spectra = join(["<spectrum id=\"scan=$(i)\"/>" for i in 1:n_spectra], "\n")
+function write_test_mzml(path::String; n_spectra::Int, spectrum_body::String = "")
+    spectra = join([
+        """
+        <spectrum id="scan=$(i)">
+          $spectrum_body
+        </spectrum>
+        """
+        for i in 1:n_spectra
+    ], "\n")
     write(path, """
     <mzML xmlns="http://psi.hupo.org/ms/mzml">
       <run>
@@ -173,4 +181,21 @@ end
     @test queue.skipped_complete_files == 1
     @test queue.reconverted_incomplete_files == 1
     @test queue.missing_output_files == 1
+end
+
+@testset "convertMzML skips profile-mode files" begin
+    temp_dir = mktempdir()
+    mzml_path = write_test_mzml(
+        joinpath(temp_dir, "profile.mzML");
+        n_spectra = 1,
+        spectrum_body = """
+        <cvParam accession="MS:1000128" name="profile spectrum" value=""/>
+        """
+    )
+    output_path = joinpath(temp_dir, "profile.arrow")
+
+    converted = process_mzml_file(mzml_path, output_path, true)
+
+    @test !converted
+    @test !isfile(output_path)
 end

--- a/test/UnitTests/convertMzMLTests.jl
+++ b/test/UnitTests/convertMzMLTests.jl
@@ -1,0 +1,107 @@
+using Test
+using EzXML
+using Pioneer: init_spectrum_dict, parsePrecursorList!, parseScanDictToScanElement
+
+@testset "convertMzML metadata parsing" begin
+    spectrum_dict = Dict{String, String}(
+        "ms level" => "2",
+        "total ion current" => "",
+        "collision energy" => "30.0",
+        "spectrum title" => "",
+        "scan start time" => "10.5",
+        "scan window upper limit" => "900.0",
+        "scan window lower limit" => "100.0",
+        "isolation window target m/z" => "500.0",
+        "isolation window lower offset" => "1.0",
+        "isolation window upper offset" => "2.0"
+    )
+    mz_array = Float32[100.0, 200.0, 300.0]
+    intensity_array = Float32[10.0, 25.0, 15.0]
+
+    scan = parseScanDictToScanElement(
+        spectrum_dict,
+        7,
+        mz_array,
+        intensity_array,
+        true
+    )
+
+    @test scan.TIC == Float32(50.0)
+    @test scan.centerMz == Float32(500.5)
+    @test scan.isolationWidthMz == Float32(3.0)
+    @test scan.collisionEnergyField == Float32(30.0)
+end
+
+@testset "convertMzML required metadata validation" begin
+    spectrum_dict = Dict{String, String}(
+        "ms level" => "1",
+        "total ion current" => "",
+        "collision energy" => "",
+        "spectrum title" => "",
+        "scan start time" => "",
+        "scan window upper limit" => "900.0",
+        "scan window lower limit" => "100.0",
+        "isolation window target m/z" => "",
+        "isolation window lower offset" => "",
+        "isolation window upper offset" => ""
+    )
+
+    error = try
+        parseScanDictToScanElement(
+            spectrum_dict,
+            3,
+            Float32[100.0],
+            Float32[1.0],
+            true
+        )
+        nothing
+    catch err
+        err
+    end
+
+    @test error isa ArgumentError
+    @test occursin("scan start time", sprint(showerror, error))
+    @test occursin("spectrum 3", sprint(showerror, error))
+end
+
+@testset "convertMzML activation accession parsing" begin
+    precursor_list = EzXML.root(EzXML.parsexml("""
+    <precursorList>
+      <precursor>
+        <activation>
+          <cvParam accession="MS:1000133" name="collision-induced dissociation" value=""/>
+          <cvParam accession="MS:1000045" name="collision energy" value="27.5"/>
+        </activation>
+      </precursor>
+      <precursor>
+        <activation>
+          <cvParam accession="MS:1000422" name="beam-type collision-induced dissociation" value=""/>
+          <cvParam accession="MS:1000045" name="collision energy" value="31.0"/>
+        </activation>
+      </precursor>
+    </precursorList>
+    """))
+
+    spectrum_dict = init_spectrum_dict()
+    parsePrecursorList!(spectrum_dict, precursor_list)
+
+    @test spectrum_dict["collision energy"] == "31.0"
+end
+
+@testset "convertMzML ignores unsupported activation types" begin
+    precursor_list = EzXML.root(EzXML.parsexml("""
+    <precursorList>
+      <precursor>
+        <activation>
+          <cvParam accession="MS:9999999" name="unsupported activation" value=""/>
+          <cvParam accession="MS:1000045" name="collision energy" value="42.0"/>
+        </activation>
+      </precursor>
+    </precursorList>
+    """))
+
+    spectrum_dict = init_spectrum_dict()
+    parsePrecursorList!(spectrum_dict, precursor_list)
+
+    @test isempty(spectrum_dict["collision energy"])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -168,6 +168,7 @@ end
 
     # Active: only run mass-spec data tests for quick iteration
     include("./UnitTests/MassSpecAndFilteredDataTests.jl")
+    include("./UnitTests/convertMzMLTests.jl")
     include("./UnitTests/LoggingTests.jl")
     include("./UnitTests/LogTruncationTests.jl")
     include("./UnitTests/BuildPreferencesTests.jl")


### PR DESCRIPTION
This PR brings `convertMzML` much closer to `PioneerConverter` behavior and hardens mzML ingestion for real-world files.

It adds a queue-style CLI with `--output-dir`, `--skip-existing`, and `--concurrent-files`, improves logging, detects unsupported profile-mode spectra and skips those files with a warning, and makes mzML metadata parsing more robust.

It also removes unused base peak fields from the mzML Arrow schema and related in-memory wrappers.

## Motivation

The previous `convertMzML` path was much more minimal than `PioneerConverter` and was brittle against common mzML variations:

- missing optional metadata could crash conversion
- activation parsing relied on vendor-style names instead of PSI-MS accessions
- profile-mode mzML files were not explicitly rejected
- output handling did not support skip-existing or custom output directories
- logging and CLI behavior did not match `convert-raw`
- unused base peak columns were still being parsed and carried through the schema

## What Changed

### mzML parsing and validation

- parse precursor activation using PSI-MS accessions instead of relying on free-text names
- support both:
  - `MS:1000133` `collision-induced dissociation`
  - `MS:1000422` `beam-type collision-induced dissociation`
- read numeric collision energy from `MS:1000045` `collision energy`
- detect profile-mode spectra via `MS:1000128` `profile spectrum`
- warn and skip the entire file if any scan is profile-mode, since Pioneer only supports centroided mzML
- treat `MS:1000127` `centroid spectrum` as the supported case

### Robustness fixes

- initialize a fresh spectrum metadata dictionary per scan to avoid stale values leaking between scans
- improve required-field parsing so missing required scan metadata throws a clearer error
- keep optional metadata optional instead of failing on empty strings
- preserve isolation window parsing while handling missing values more safely
- retain collision energy support only for supported CID / beam-type CID activation types

### CLI and conversion workflow

- update `convertMzML` CLI to more closely mirror `PioneerConverter`
- add:
  - `-o, --output-dir`
  - `--skip-existing`
  - `-n, --concurrent-files`
  - `--skip-header`
  - `--include-scan-header`
  - `--help`
  - `--version`
- keep backward compatibility for the old positional `skip_header` boolean
- default Arrow output location to `<input_dir>/arrow_out`
- add queue/config logging similar to `convert-raw`
- add per-file start and execution-time logging
- add total conversion-time logging
- support bounded parallel conversion across mzML files
- implement `skip-existing` by checking whether an existing Arrow file appears complete using the final `scanNumber` against the mzML spectrum count

### Schema cleanup

- stop parsing base peak values from mzML
- remove `basePeakMz` and `basePeakIntensity` from:
  - `PioneerScanElement`
  - mzML Arrow output
  - `MassSpecData` Arrow-backed accessors
  - `FilteredMassSpecData`
  - `IndexedMassSpecData`
- update mass spec tests to match the schema change

## Breaking Changes

- mzML-converted Arrow outputs no longer include:
  - `basePeakMz`
  - `basePeakIntensity`

Any downstream code outside this repo that depends on those columns will need to be updated.

## Testing

Focused tests were added/updated for:

- required and optional mzML metadata parsing
- CID and beam-type CID activation parsing by accession
- unsupported activation handling
- CLI argument parsing
- output directory and `skip-existing` queue planning
- profile-mode file detection and skip behavior
- mass spec wrapper compatibility after removing base peak fields

Commands run:

```bash
julia --project=. -e 'using Test, Pioneer; include("test/UnitTests/convertMzMLTests.jl")'
julia --project=. -e 'using Test, Pioneer; include("test/UnitTests/convertMzMLTests.jl"); include("test/UnitTests/MassSpecAndFilteredDataTests.jl")'