### PR TITLE
Fix MaxLFQ sparse-graph quantification

### DIFF
--- a/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
+++ b/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
@@ -643,6 +643,7 @@ function writeProteinGroupsCSV(
         :global_qval,
         :qval,
         :pg_pep,
+        :total_peak_area,
         :abundance,
     ])
     select!(protein_groups_long, long_columns)

--- a/src/utils/maxLFQ.jl
+++ b/src/utils/maxLFQ.jl
@@ -37,81 +37,335 @@ was not seen in the i'th experiment, then S[i, j] == missing.
 
 """
 function getS(peptides::AbstractVector{UInt32}, peptides_dict::Dict{UInt32, Int64}, experiments::AbstractVector{UInt16}, experiments_dict::Dict{UInt16, Int64}, abundance::AbstractVector{Union{T, Missing}}, M::Int, N::Int) where {T<:Real}
-    #Initialize
-    S = Array{Union{Missing,T}}(undef, (M, N))
+    S = Matrix{Union{Missing, T}}(missing, M, N)
     for i in eachindex(peptides)
-            if !ismissing(abundance[i]) #Abundance of the the peptide 
-               if abundance[i] > 0.0
-                    S[peptides_dict[peptides[i]], experiments_dict[experiments[i]]] = abundance[i]
-               else
-                    S[peptides_dict[peptides[i]], experiments_dict[experiments[i]]] = missing
-               end
+        if !ismissing(abundance[i])
+            if abundance[i] > 0.0
+                S[peptides_dict[peptides[i]], experiments_dict[experiments[i]]] = abundance[i]
+            else
+                S[peptides_dict[peptides[i]], experiments_dict[experiments[i]]] = missing
             end
+        end
     end
     return S
 end
 
 """
-    getB(S::Matrix{Union{Missing, T}}, N::Int, M::Int) where {T<:Real}
+    get_log2_intensity_matrix(S::AbstractMatrix{Union{Missing, T}}) where {T<:Real}
 
-Column vector of sum of median peptide ratios. See the following references. 
+Convert the linear-intensity peptide-by-run matrix `S` into log2 space while
+preserving `missing` entries.
+"""
+function get_log2_intensity_matrix(S::AbstractMatrix{Union{Missing, T}}) where {T<:Real}
+    X = Matrix{Union{Missing, Float64}}(missing, size(S)...)
+    for j in axes(S, 2)
+        for i in axes(S, 1)
+            if !ismissing(S[i, j])
+                X[i, j] = log2(Float64(S[i, j]))
+            end
+        end
+    end
+    return X
+end
+
+"""
+    get_connected_components(X::AbstractMatrix{Union{Missing, T}}) where {T<:Real}
+
+Return a connected-component label for each run column in `X`. Two runs are
+connected when they share at least one quantified peptide.
+"""
+function get_connected_components(X::AbstractMatrix{Union{Missing, T}}) where {T<:Real}
+    n_runs = size(X, 2)
+    labels = zeros(Int, n_runs)
+    component_id = 0
+
+    for seed_idx in 1:n_runs
+        if labels[seed_idx] != 0
+            continue
+        end
+
+        component_id += 1
+        stack = Int[seed_idx]
+        labels[seed_idx] = component_id
+
+        while !isempty(stack)
+            run_idx = pop!(stack)
+            for peptide_idx in axes(X, 1)
+                if ismissing(X[peptide_idx, run_idx])
+                    continue
+                end
+                for neighbor_idx in 1:n_runs
+                    if !ismissing(X[peptide_idx, neighbor_idx]) && labels[neighbor_idx] == 0
+                        labels[neighbor_idx] = component_id
+                        push!(stack, neighbor_idx)
+                    end
+                end
+            end
+        end
+    end
+
+    return labels
+end
+
+"""
+    get_component_sizes(labels::AbstractVector{Int})
+
+Return the size of the connected component for each element in `labels`.
+"""
+function get_component_sizes(labels::AbstractVector{Int})
+    counts = Dict{Int, Int}()
+    for label in labels
+        counts[label] = get(counts, label, 0) + 1
+    end
+    return [counts[label] for label in labels]
+end
+
+"""
+    get_component_priority(component_indices, run_priorities)
+
+Return the summed per-run priority for the provided component indices, ignoring
+`missing` priorities.
+"""
+function get_component_priority(
+    component_indices::AbstractVector{Int},
+    run_priorities::AbstractVector{Union{Missing, T}}
+) where {T<:Real}
+    total = 0.0
+    for run_idx in component_indices
+        priority = run_priorities[run_idx]
+        if !ismissing(priority)
+            total += Float64(priority)
+        end
+    end
+    return total
+end
+
+"""
+    get_best_component(component_labels, run_priorities)
+
+Select the component with the most runs. Break ties by the highest summed
+per-run priority.
+"""
+function get_best_component(
+    component_labels::AbstractVector{Int},
+    run_priorities::AbstractVector{Union{Missing, T}}
+) where {T<:Real}
+    best_component_id = 0
+    best_size = -1
+    best_priority = -Inf
+
+    for component_id in 1:maximum(component_labels)
+        component_indices = findall(==(component_id), component_labels)
+        component_size = length(component_indices)
+        component_priority = get_component_priority(component_indices, run_priorities)
+
+        if component_size > best_size ||
+           (component_size == best_size && component_priority > best_priority)
+            best_component_id = component_id
+            best_size = component_size
+            best_priority = component_priority
+        end
+    end
+
+    return best_component_id
+end
+
+"""
+    getB(X::AbstractMatrix{Union{Missing, T}}) where {T<:Real}
+
+Build the MaxLFQ normal-equation right-hand side using only valid run pairs that
+share at least one quantified peptide. `X` must already be in log2 space.
 
 * Yu F, Haynes SE, Nesvizhskii AI. IonQuant Enables Accurate and Sensitive Label-Free Quantification With FDR-Controlled Match-Between-Runs. Mol Cell Proteomics. 2021;20:100077. doi: 10.1016/j.mcpro.2021.100077. Epub 2021 Apr 2. PMID: 33813065; PMCID: PMC8131922.
 * https://rdrr.io/cran/iq/man/maxLFQ.html
 * Cox J, Hein MY, Luber CA, Paron I, Nagaraj N, Mann M. Accurate proteome-wide label-free quantification by delayed normalization and maximal peptide ratio extraction, termed MaxLFQ. Mol Cell Proteomics. 2014 Sep;13(9):2513-26. doi: 10.1074/mcp.M113.031591. Epub 2014 Jun 17. PMID: 24942700; PMCID: PMC4159666.
 
 """
-function getB(S::Matrix{Union{Missing, T}}, N::Int, M::Int) where {T<:Real}
-    B = zeros(Float32, N + 1)
-    for i in 1:N
-        for j in 1:N
-            if j != i
-                #Ratios of peptides commonly identified bewteen experiment i and j. 
-                r_i_j = skipmissing(-log2.( @view(S[:,j]) ) .+ log2.(@view(S[:,i])))
-                #r_i_j could be emptry if no peptides were commonly identified between experiment i and j. 
-                if !isempty(r_i_j)
-                    #median(r_i_j) is the median of all ratios between peptides commonly quantified between experiment
-                    #i and experiment j. 
-                    B[i] += median(r_i_j)
+function getB(X::AbstractMatrix{Union{Missing, T}}) where {T<:Real}
+    n_runs = size(X, 2)
+    Atb = zeros(Float64, n_runs)
+    valid_pairs = 0
+
+    for left_idx in 1:(n_runs - 1)
+        for right_idx in (left_idx + 1):n_runs
+            ratios = Float64[]
+            for peptide_idx in axes(X, 1)
+                left_val = X[peptide_idx, left_idx]
+                right_val = X[peptide_idx, right_idx]
+                if !ismissing(left_val) && !ismissing(right_val)
+                    push!(ratios, -Float64(left_val) + Float64(right_val))
                 end
             end
+
+            if isempty(ratios)
+                continue
+            end
+
+            ratio_median = median(ratios)
+            Atb[left_idx] -= ratio_median
+            Atb[right_idx] += ratio_median
+            valid_pairs += 1
         end
     end
-    B.*=2
-    norm = 0.0
 
-    #Relative abundances are correct without this step, but the absolute values should make sense. 
-    for row in eachrow(S)
-        norm += sum(log2.(skipmissing(row)))*(length(row)/(length(row) - sum(ismissing.(row))))
-    end
-    B[end] = norm/M #For scaling
-    B
+    return Atb, valid_pairs
 end
 
 """
-    getA(N::Int)
+    getA(X::AbstractMatrix{Union{Missing, T}}) where {T<:Real}
 
-Design matrix for maxLFQ. See the following
+Build the MaxLFQ normal-equation left-hand side using only valid run pairs that
+share at least one quantified peptide. `X` must already be in log2 space.
 
     * Yu F, Haynes SE, Nesvizhskii AI. IonQuant Enables Accurate and Sensitive Label-Free Quantification With FDR-Controlled Match-Between-Runs. Mol Cell Proteomics. 2021;20:100077. doi: 10.1016/j.mcpro.2021.100077. Epub 2021 Apr 2. PMID: 33813065; PMCID: PMC8131922.
     * https://rdrr.io/cran/iq/man/maxLFQ.html
     * Cox J, Hein MY, Luber CA, Paron I, Nagaraj N, Mann M. Accurate proteome-wide label-free quantification by delayed normalization and maximal peptide ratio extraction, termed MaxLFQ. Mol Cell Proteomics. 2014 Sep;13(9):2513-26. doi: 10.1074/mcp.M113.031591. Epub 2014 Jun 17. PMID: 24942700; PMCID: PMC4159666.
     
 """
-function getA(N::Int)
-    A = ones(Float32, N+1, N+1)
-    for i in 1:(N)
-        for j in 1:N
-            if i == j
-                A[i, j] = 2*(N - 1)
-            else
-                A[i, j] = -2
+function getA(X::AbstractMatrix{Union{Missing, T}}) where {T<:Real}
+    n_runs = size(X, 2)
+    AtA = zeros(Float64, n_runs, n_runs)
+
+    for left_idx in 1:(n_runs - 1)
+        for right_idx in (left_idx + 1):n_runs
+            has_overlap = false
+            for peptide_idx in axes(X, 1)
+                if !ismissing(X[peptide_idx, left_idx]) && !ismissing(X[peptide_idx, right_idx])
+                    has_overlap = true
+                    break
+                end
+            end
+
+            if has_overlap
+                AtA[left_idx, right_idx] = -1.0
+                AtA[right_idx, left_idx] = -1.0
+                AtA[left_idx, left_idx] += 1.0
+                AtA[right_idx, right_idx] += 1.0
             end
         end
     end
-    A[end, end] = 0
 
-    A
+    return AtA
+end
+
+"""
+    solve_maxlfq_component(X::AbstractMatrix{Union{Missing, T}}) where {T<:Real}
+
+Solve the MaxLFQ system for a single connected run component in log2 space.
+"""
+function solve_maxlfq_component(X::AbstractMatrix{Union{Missing, T}}) where {T<:Real}
+    n_runs = size(X, 2)
+    n_runs == 0 && return Union{Missing, Float32}[]
+
+    observed_values = skipmissing(vec(X))
+    if isempty(observed_values)
+        return Vector{Union{Missing, Float32}}(missing, n_runs)
+    end
+
+    AtA = getA(X)
+    Atb, valid_pairs = getB(X)
+    if valid_pairs == 0
+        return Vector{Union{Missing, Float32}}(missing, n_runs)
+    end
+
+    system_matrix = Matrix{Float64}(undef, n_runs + 1, n_runs + 1)
+    system_matrix[1:n_runs, 1:n_runs] = 2.0 .* AtA
+    system_matrix[1:n_runs, end] .= 1.0
+    system_matrix[end, 1:n_runs] .= 1.0
+    system_matrix[end, end] = 0.0
+
+    rhs = Vector{Float64}(undef, n_runs + 1)
+    rhs[1:n_runs] = 2.0 .* Atb
+    rhs[end] = mean(observed_values) * n_runs
+
+    solution = system_matrix \ rhs
+    estimates = Vector{Union{Missing, Float32}}(missing, n_runs)
+    for run_idx in 1:n_runs
+        if isfinite(solution[run_idx])
+            estimates[run_idx] = solution[run_idx]
+        end
+    end
+
+    return estimates
+end
+
+"""
+    solve_maxlfq(
+        X::AbstractMatrix{Union{Missing, T}},
+        run_priorities::AbstractVector{Union{Missing, F}}
+    ) where {T<:Real, F<:Real}
+
+Solve MaxLFQ in log2 space using only the single best connected component,
+leaving all other runs as `missing`. The best component is the one with the most
+runs, with ties broken by the highest summed per-run priority.
+"""
+function solve_maxlfq(
+    X::AbstractMatrix{Union{Missing, T}},
+    run_priorities::AbstractVector{Union{Missing, F}}
+) where {T<:Real, F<:Real}
+    n_runs = size(X, 2)
+    estimates = Vector{Union{Missing, Float32}}(missing, n_runs)
+    n_runs == 0 && return estimates, Int[]
+    @assert length(run_priorities) == n_runs "run priorities must align with MaxLFQ run columns"
+
+    component_labels = get_connected_components(X)
+    component_sizes = get_component_sizes(component_labels)
+    best_component_id = get_best_component(component_labels, run_priorities)
+
+    component_indices = findall(==(best_component_id), component_labels)
+    if length(component_indices) > 1
+        component_estimates = solve_maxlfq_component(@view X[:, component_indices])
+        for (local_idx, global_idx) in enumerate(component_indices)
+            estimates[global_idx] = component_estimates[local_idx]
+        end
+    end
+
+    if maximum(component_sizes; init = 0) < n_runs
+        @debug "MaxLFQ protein graph disconnected" component_sizes=component_sizes best_component_id=best_component_id
+    end
+
+    return estimates, component_labels
+end
+
+"""
+    get_linear_abundance(log2_abundance::AbstractVector{Union{Missing, T}}) where {T<:Real}
+
+Convert MaxLFQ log2 abundances back to linear space while preserving a nullable
+column type for downstream Arrow writes.
+"""
+function get_linear_abundance(log2_abundance::AbstractVector{Union{Missing, T}}) where {T<:Real}
+    abundance = Vector{Union{Missing, Float32}}(missing, length(log2_abundance))
+    for idx in eachindex(log2_abundance)
+        if !ismissing(log2_abundance[idx])
+            abundance[idx] = exp2(log2_abundance[idx])
+        end
+    end
+    return abundance
+end
+
+"""
+    get_total_peak_area(S::AbstractMatrix{Union{Missing, T}}) where {T<:Real}
+
+Sum the quantified precursor peak areas for each run column in `S`, preserving
+`missing` when a run has no quantified precursors.
+"""
+function get_total_peak_area(S::AbstractMatrix{Union{Missing, T}}) where {T<:Real}
+    total_peak_area = Vector{Union{Missing, Float32}}(missing, size(S, 2))
+    for run_idx in axes(S, 2)
+        total = 0.0
+        has_signal = false
+        for precursor_idx in axes(S, 1)
+            value = S[precursor_idx, run_idx]
+            if !ismissing(value)
+                total += Float64(value)
+                has_signal = true
+            end
+        end
+        if has_signal
+            total_peak_area[run_idx] = total
+        end
+    end
+    return total_peak_area
 end
 
 
@@ -218,7 +472,8 @@ function getProtAbundance(protein::String,
                             qval_out::Vector{Union{Missing, Float32}},
                             pep_out::Vector{Union{Missing, Float32}},
                             pg_score_out::Vector{Union{Missing, Float32}},
-                            global_pg_score_out::Vector{Union{Missing, Float32}}) where {T <: Real, F <: Real}
+                            global_pg_score_out::Vector{Union{Missing, Float32}},
+                            total_peak_area_out::Vector{Union{Missing, Float32}}) where {T <: Real, F <: Real}
 
     unique_experiments = unique(experiments)
     unique_peptides = unique(peptides)
@@ -229,6 +484,24 @@ function getProtAbundance(protein::String,
     peptides_dict = Dict(zip(unique_peptides, 1:M))
     experiments_dict = Dict(zip(unique_experiments, 1:N))
 
+    pep_map = Dict{UInt32, Union{Missing, Float32}}()
+    score_map = Dict{UInt32, Union{Missing, Float32}}()
+    global_score_map = Dict{UInt32, Union{Missing, Float32}}()
+    qval_map = Dict{UInt32, Union{Missing, Float32}}()
+    global_qval_map = Dict{UInt32, Union{Missing, Float32}}()
+    for j in eachindex(experiments)
+        exp = UInt32(experiments[j])
+        if !haskey(pep_map, exp)
+            pep_map[exp] = peps[j]
+            score_map[exp] = pg_scores[j]
+            global_score_map[exp] = global_pg_scores[j]
+            qval_map[exp] = qvals[j]
+            global_qval_map[exp] = global_qvals[j]
+        end
+    end
+
+    run_pg_scores = Union{Missing, Float32}[get(score_map, UInt32(exp), missing) for exp in unique_experiments]
+
     #Appends the results to the inputs `protein_out`, `peptides_out`, `experiments_out` and `log2_abundance_out`
     function appendResults!(row_idx::Int64,
                             N::Int64,
@@ -237,7 +510,7 @@ function getProtAbundance(protein::String,
                             species::String,
                             protein::String,
                             unique_peptides::Vector{UInt32}, 
-                            log2_abundances::Vector{T},
+                            log2_abundances::AbstractVector{Union{Missing, T}},
                             global_qvals::AbstractVector{Union{Float32,Missing}},
                             qvals::AbstractVector{Union{Float32,Missing}},
                             peps::AbstractVector{Union{Float32,Missing}},
@@ -254,8 +527,10 @@ function getProtAbundance(protein::String,
                             pep_out::Vector{Union{Missing, Float32}},
                             pg_score_out::Vector{Union{Missing, Float32}},
                             global_pg_score_out::Vector{Union{Missing, Float32}},
+                            total_peak_area_out::Vector{Union{Missing, Float32}},
                             experiments_out::Vector{Union{Missing, I}}, 
-                            S::Matrix{Union{Missing, T}}) where {T<:Real,I<:Integer}
+                            S::Matrix{Union{Missing, T}},
+                            total_peak_area::AbstractVector{Union{Missing, Float32}}) where {T<:Real,I<:Integer}
         
         function appendPeptides!(peptides_out::Vector{Union{Missing, Vector{Union{Missing, UInt32}}}}, 
                                 row_idx::Int64,
@@ -279,23 +554,6 @@ function getProtAbundance(protein::String,
         end
 
 
-        # Map experiment → metrics using the first occurrence for each experiment
-        pep_map = Dict{UInt32, Float32}()
-        score_map = Dict{UInt32, Float32}()
-        global_score_map = Dict{UInt32, Float32}()
-        qval_map = Dict{UInt32, Float32}()
-        global_qval_map = Dict{UInt32, Float32}()
-        for j in eachindex(experiments)
-            exp = UInt32(experiments[j])
-            if !haskey(pep_map, exp)
-                pep_map[exp] = peps[j]
-                score_map[exp] = pg_scores[j]
-                global_score_map[exp] = global_pg_scores[j]
-                qval_map[exp] = qvals[j]
-                global_qval_map[exp] = global_qvals[j]
-            end
-        end
-
         for i in range(0, N-1)
             exp = UInt32(unique_experiments[i + 1])
             log2_abundance_out[row_idx + i] = log2_abundances[i + 1]
@@ -309,6 +567,7 @@ function getProtAbundance(protein::String,
             species_out[row_idx + i] = species
             target_out[row_idx + i] = target
             entrap_id_out[row_idx + i] = entrap_id
+            total_peak_area_out[row_idx + i] = total_peak_area[i + 1]
         end
         appendPeptides!(peptides_out, 
                         row_idx,
@@ -318,21 +577,22 @@ function getProtAbundance(protein::String,
 
     #ixj matrix where rows are for experiments and columns are for peptides. Each entry is the abundance of the peptide
     #in the given experiment, or missing if peptide j was not seen in experiment i. 
-    S = allowmissing(getS(peptides, peptides_dict, experiments, experiments_dict, abundance, M, N))
-
-    #Column vector. The response matrix in Ax=B
-    B = getB(S, N, M)
-
-    #Design matrix. See references in docstring. 
-    A = getA(N)
-
-    #Solve linear system to get log-2 abundances 
-    log2_abundances = (A\B)[1:(end - 1)]
+    S = getS(peptides, peptides_dict, experiments, experiments_dict, abundance, M, N)
+    X = get_log2_intensity_matrix(S)
+    total_peak_area = get_total_peak_area(S)
+    log2_abundances, component_labels = solve_maxlfq(X, run_pg_scores)
+    quantified_runs = findall(x -> !ismissing(x), total_peak_area)
+    if length(quantified_runs) == 1
+        run_idx = only(quantified_runs)
+        log2_abundances[run_idx] = log2(total_peak_area[run_idx])
+    end
     
     # Debug: Check if all abundances are missing/NaN/Inf
     n_valid_abundances = sum(!ismissing(x) && isfinite(x) for x in log2_abundances)
     if n_valid_abundances == 0
         @debug "MaxLFQ produced all invalid abundances for protein" protein=protein n_peptides=M n_experiments=N
+    elseif maximum(component_labels; init = 0) > 1
+        @debug "MaxLFQ protein solved with disconnected components" protein=protein component_labels=component_labels
     end
     
     appendResults!(
@@ -360,8 +620,10 @@ function getProtAbundance(protein::String,
                    pep_out,
                    pg_score_out,
                    global_pg_score_out,
+                   total_peak_area_out,
                    experiments_out,
-                   S)
+                   S,
+                   total_peak_area)
 
 end
 
@@ -445,6 +707,7 @@ function LFQ(prot_ref,  # PSMFileReference - using Any to avoid dependency issue
             :pg_pep => Vector{Union{Missing, Float32}}(missing, nrows),
             :pg_score => Vector{Union{Missing, Float32}}(missing, nrows),
             :global_pg_score => Vector{Union{Missing, Float32}}(missing, nrows),
+            :total_peak_area => Vector{Union{Missing, Float32}}(missing, nrows),
         )
 
         for (group_idx, (protein, data)) in enumerate(pairs(gpsms))
@@ -473,7 +736,8 @@ function LFQ(prot_ref,  # PSMFileReference - using Any to avoid dependency issue
                                 out[:qval],
                                 out[:pg_pep],
                                 out[:pg_score],
-                                out[:global_pg_score]
+                                out[:global_pg_score],
+                                out[:total_peak_area]
                             )
         end
         out = DataFrame(out)
@@ -495,7 +759,7 @@ function LFQ(prot_ref,  # PSMFileReference - using Any to avoid dependency issue
             end
         end
         filter!(x->(!ismissing(x.n_peptides)), out);#&(x.n_peptides>=min_peptides), out);
-        out[!,:abundance] = exp2.(out[!,:log2_abundance])
+        out[!,:abundance] = get_linear_abundance(out[!,:log2_abundance])
         output_cols = enabled_output_columns(output_schema_policy, :protein_groups, Symbol[
             :file_name,
             :target,
@@ -511,10 +775,10 @@ function LFQ(prot_ref,  # PSMFileReference - using Any to avoid dependency issue
             :pg_pep,
             :pg_score,
             :global_pg_score,
+            :total_peak_area,
             :abundance,
         ])
-        
-        # Write results
+
         if isnothing(writer_ref[])
             isfile(protein_quant_path) && rm(protein_quant_path)
             writer_ref[] = open(Arrow.Writer, protein_quant_path; file=true)

--- a/test/UnitTests/test_maxlfq.jl
+++ b/test/UnitTests/test_maxlfq.jl
@@ -1,0 +1,163 @@
+@testset "MaxLFQ Sparse Graph Handling" begin
+    function run_maxlfq_case(
+        peptides::Vector{UInt32},
+        experiments::Vector{UInt16},
+        abundances::Vector{Union{Missing, Float32}};
+        scores::Vector{Union{Missing, Float32}} = Union{Missing, Float32}[fill(1.0f0, length(peptides))...]
+    )
+        n_runs = length(unique(experiments))
+
+        target_out = Vector{Union{Missing, Bool}}(missing, n_runs)
+        entrap_id_out = Vector{Union{Missing, UInt8}}(missing, n_runs)
+        species_out = Vector{Union{Missing, String}}(missing, n_runs)
+        protein_out = Vector{Union{Missing, String}}(missing, n_runs)
+        peptides_out = Vector{Union{Missing, Vector{Union{Missing, UInt32}}}}(missing, n_runs)
+        experiments_out = Vector{Union{Missing, UInt32}}(missing, n_runs)
+        log2_abundance_out = Vector{Union{Missing, Float32}}(missing, n_runs)
+        global_qval_out = Vector{Union{Missing, Float32}}(missing, n_runs)
+        qval_out = Vector{Union{Missing, Float32}}(missing, n_runs)
+        pep_out = Vector{Union{Missing, Float32}}(missing, n_runs)
+        pg_score_out = Vector{Union{Missing, Float32}}(missing, n_runs)
+        global_pg_score_out = Vector{Union{Missing, Float32}}(missing, n_runs)
+        total_peak_area_out = Vector{Union{Missing, Float32}}(missing, n_runs)
+
+        metrics = Union{Missing, Float32}[fill(0.001f0, length(peptides))...]
+
+        Pioneer.getProtAbundance(
+            "P",
+            1,
+            true,
+            UInt8(1),
+            "species",
+            peptides,
+            experiments,
+            fill(true, length(peptides)),
+            abundances,
+            metrics,
+            metrics,
+            metrics,
+            scores,
+            scores,
+            target_out,
+            entrap_id_out,
+            species_out,
+            protein_out,
+            peptides_out,
+            experiments_out,
+            log2_abundance_out,
+            global_qval_out,
+            qval_out,
+            pep_out,
+            pg_score_out,
+            global_pg_score_out,
+            total_peak_area_out
+        )
+
+        return (
+            experiments = experiments_out,
+            log2_abundance = log2_abundance_out,
+            peptides = peptides_out,
+            total_peak_area = total_peak_area_out
+        )
+    end
+
+    @testset "Disconnected singleton run is missing" begin
+        result = run_maxlfq_case(
+            UInt32[1, 1, 2],
+            UInt16[1, 2, 3],
+            Union{Missing, Float32}[100.0f0, 200.0f0, 50.0f0]
+        )
+
+        @test result.experiments == Union{Missing, UInt32}[UInt32(1), UInt32(2), UInt32(3)]
+        @test !ismissing(result.log2_abundance[1])
+        @test !ismissing(result.log2_abundance[2])
+        @test ismissing(result.log2_abundance[3])
+        @test result.log2_abundance[2] - result.log2_abundance[1] ≈ 1.0f0 atol = 1f-4
+        @test isequal(result.total_peak_area, Union{Missing, Float32}[100.0f0, 200.0f0, 50.0f0])
+    end
+
+    @testset "Sparse connected chain preserves pairwise ratios" begin
+        result = run_maxlfq_case(
+            UInt32[1, 1, 2, 2],
+            UInt16[1, 2, 2, 3],
+            Union{Missing, Float32}[100.0f0, 200.0f0, 300.0f0, 600.0f0]
+        )
+
+        @test all(x -> !ismissing(x), result.log2_abundance)
+        @test result.log2_abundance[2] - result.log2_abundance[1] ≈ 1.0f0 atol = 1f-4
+        @test result.log2_abundance[3] - result.log2_abundance[2] ≈ 1.0f0 atol = 1f-4
+    end
+
+    @testset "Tied largest component uses higher summed pg_score" begin
+        result = run_maxlfq_case(
+            UInt32[1, 1, 2, 2],
+            UInt16[1, 2, 3, 4],
+            Union{Missing, Float32}[100.0f0, 200.0f0, 300.0f0, 600.0f0];
+            scores = Union{Missing, Float32}[1.0f0, 1.0f0, 5.0f0, 5.0f0]
+        )
+
+        @test ismissing(result.log2_abundance[1])
+        @test ismissing(result.log2_abundance[2])
+        @test !ismissing(result.log2_abundance[3])
+        @test !ismissing(result.log2_abundance[4])
+        @test result.log2_abundance[4] - result.log2_abundance[3] ≈ 1.0f0 atol = 1f-4
+    end
+
+    @testset "Dense graph remains quantified across runs" begin
+        result = run_maxlfq_case(
+            UInt32[1, 1, 1, 2, 2, 2],
+            UInt16[1, 2, 3, 1, 2, 3],
+            Union{Missing, Float32}[100.0f0, 200.0f0, 400.0f0, 10.0f0, 20.0f0, 40.0f0]
+        )
+
+        @test all(x -> !ismissing(x), result.log2_abundance)
+        @test result.log2_abundance[2] - result.log2_abundance[1] ≈ 1.0f0 atol = 1f-4
+        @test result.log2_abundance[3] - result.log2_abundance[2] ≈ 1.0f0 atol = 1f-4
+    end
+
+    @testset "Nonpositive intensities remain missing" begin
+        result = run_maxlfq_case(
+            UInt32[1, 1, 2],
+            UInt16[1, 2, 3],
+            Union{Missing, Float32}[0.0f0, missing, -5.0f0]
+        )
+
+        @test all(ismissing, result.log2_abundance)
+    end
+
+    @testset "Singleton protein falls back to total peak area" begin
+        result = run_maxlfq_case(
+            UInt32[1, 2],
+            UInt16[7, 7],
+            Union{Missing, Float32}[100.0f0, 25.0f0]
+        )
+
+        @test result.experiments == Union{Missing, UInt32}[UInt32(7)]
+        @test !ismissing(result.log2_abundance[1])
+        @test result.log2_abundance[1] ≈ log2(125.0f0) atol = 1f-4
+        @test isequal(result.total_peak_area, Union{Missing, Float32}[125.0f0])
+    end
+
+    @testset "Arrow append schema stays nullable across LFQ batches" begin
+        batch1_abundance = Pioneer.get_linear_abundance(Union{Missing, Float32}[1.0f0, 2.0f0])
+        batch2_abundance = Pioneer.get_linear_abundance(Union{Missing, Float32}[1.0f0, missing])
+
+        @test eltype(batch1_abundance) == Union{Missing, Float32}
+        @test eltype(batch2_abundance) == Union{Missing, Float32}
+
+        mktempdir() do tmpdir
+            output_path = joinpath(tmpdir, "lfq.arrow")
+
+            batch1 = DataFrame(abundance = batch1_abundance)
+            batch2 = DataFrame(abundance = batch2_abundance)
+
+            open(output_path, "w") do io
+                Arrow.write(io, batch1; file = false)
+            end
+            Arrow.append(output_path, batch2)
+
+            appended = DataFrame(Arrow.Table(output_path))
+            @test isequal(appended.abundance, Union{Missing, Float32}[2.0f0, 4.0f0, 2.0f0, missing])
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -157,6 +157,7 @@ end
     include("./UnitTests/uniformBassisCubicSpline.jl")
     include("./UnitTests/test_protein_inference.jl")
     include("./UnitTests/test_protein_group_peak_area_features.jl")
+    include("./UnitTests/test_maxlfq.jl")
     include("./UnitTests/ChronologerPrepTests.jl")
     include("./UnitTests/FastaDigestTests.jl")
     include("./UnitTests/FastaEntryConstructorsTests.jl")


### PR DESCRIPTION
### Summary

Fixes MaxLFQ protein quantification for sparse or disconnected precursor evidence.

### Changes

- Build MaxLFQ constraints only from run pairs that share quantified precursors.
- Solve only the largest connected run component for each protein group.
- Break tied component sizes by highest summed `pg_score`.
- Leave non-selected disconnected components as missing instead of fabricating abundances.
- Add a singleton fallback: if a protein is quantified in exactly one run, use `log2(total_peak_area)` as its MaxLFQ abundance.
- Add `total_peak_area` to the long-format protein group output.
- Keep wide-format protein group output based on MaxLFQ `abundance` only.
- Preserve nullable Arrow schema for protein `abundance` across LFQ batches.
- Add focused MaxLFQ regression tests for disconnected graphs, component tie-breaking, singleton fallback, and Arrow append schema stability.

### Testing

- `julia --project=. -e 'using Pioneer, Test, Arrow, DataFrames; include("test/UnitTests/test_maxlfq.jl")'`
- Focused MaxLFQ tests pass: `25/25`