### PR TITLE
chore: add pre-release and nightly installer validation

### DIFF
--- a/.github/actions/determine-version/action.yml
+++ b/.github/actions/determine-version/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "Fallback version when no tag is found"
     required: false
     default: "dev"
+  override:
+    description: "Explicit version to use instead of deriving from the git ref"
+    required: false
+    default: ""
 outputs:
   version:
     description: "Determined version string"
@@ -16,7 +20,9 @@ runs:
       id: version
       shell: bash
       run: |
-        if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.tag }}" ]]; then
+        if [[ -n "${{ inputs.override }}" ]]; then
+          echo "version=${{ inputs.override }}" >> "$GITHUB_OUTPUT"
+        elif [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.tag }}" ]]; then
           echo "version=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
         elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
           echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -1,22 +1,50 @@
 name: Build Linux
 
 on:
-  push:
-    branches:
-      - main
-      - develop
-  pull_request:
-    branches:
-      - main
-      - develop
   workflow_dispatch:
     inputs:
-      force_installer:
-        description: "Force .deb packaging/upload for manual runs"
+      checkout_ref:
+        description: "Explicit git ref or SHA to build instead of the workflow ref"
+        required: false
+        type: string
+        default: ""
+      package_installer:
+        description: "Build and upload the native .deb installer"
+        required: false
+        type: boolean
+        default: true
+      artifact_retention_days:
+        description: "Retention for uploaded installer artifacts"
+        required: false
+        type: number
+        default: 3
+      version_override:
+        description: "Explicit version to use instead of deriving from the git ref"
+        required: false
+        type: string
+        default: ""
+  workflow_call:
+    inputs:
+      checkout_ref:
+        description: "Explicit git ref or SHA to build instead of the workflow ref"
+        required: false
+        type: string
+        default: ""
+      package_installer:
+        description: "Build and upload the native .deb installer"
         required: false
         type: boolean
         default: false
-  workflow_call:
+      artifact_retention_days:
+        description: "Retention for uploaded installer artifacts"
+        required: false
+        type: number
+        default: 3
+      version_override:
+        description: "Explicit version to use instead of deriving from the git ref"
+        required: false
+        type: string
+        default: ""
     outputs:
       version:
         description: 'Build version'
@@ -48,12 +76,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Determine VERSION
         id: get_version
         uses: ./.github/actions/determine-version
         with:
           fallback: "dev"
+          override: ${{ inputs.version_override }}
 
       - name: Normalize versions
         id: norm
@@ -157,8 +187,8 @@ jobs:
           "$pioneer_root/pioneer" params-predict "$dummy" "$dummy" --params-path "$dummy/params.json"
           rm -rf "$dummy"
           
-      - name: Package Linux .deb (release tags or forced dispatch)
-        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.force_installer)
+      - name: Package Linux .deb
+        if: startsWith(github.ref, 'refs/tags/v') || inputs.package_installer
         run: |
           mkdir -p deb/usr/local/Pioneer
           cp -r build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/* deb/usr/local/Pioneer/
@@ -198,20 +228,10 @@ jobs:
           dpkg-deb --build --root-owner-group deb \
             Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.deb
 
-      - name: Package zipped binaries
-        run: |
-          cd build/Pioneer_${{ matrix.identifier }}/Applications
-          zip -qr ../../../Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.zip Pioneer
-
-      - name: Upload zipped binaries
-        uses: actions/upload-artifact@v7
-        with:
-          name: Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}
-          path: Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.zip
-
-      - name: Upload .deb (release tags or forced dispatch)
-        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.force_installer)
+      - name: Upload .deb
+        if: startsWith(github.ref, 'refs/tags/v') || inputs.package_installer
         uses: actions/upload-artifact@v7
         with:
           name: Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}-deb
           path: Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.deb
+          retention-days: ${{ inputs.artifact_retention_days }}

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -1,22 +1,50 @@
 name: Build macOS
 
 on:
-  push:
-    branches:
-      - main
-      - develop
-  pull_request:
-    branches:
-      - main
-      - develop
   workflow_dispatch:
     inputs:
-      force_pkg:
-        description: "Force pkg signing/notarization/upload for manual runs"
+      checkout_ref:
+        description: "Explicit git ref or SHA to build instead of the workflow ref"
+        required: false
+        type: string
+        default: ""
+      package_installer:
+        description: "Build, notarize, and upload the native .pkg installer"
+        required: false
+        type: boolean
+        default: true
+      artifact_retention_days:
+        description: "Retention for uploaded installer artifacts"
+        required: false
+        type: number
+        default: 3
+      version_override:
+        description: "Explicit version to use instead of deriving from the git ref"
+        required: false
+        type: string
+        default: ""
+  workflow_call:
+    inputs:
+      checkout_ref:
+        description: "Explicit git ref or SHA to build instead of the workflow ref"
+        required: false
+        type: string
+        default: ""
+      package_installer:
+        description: "Build, notarize, and upload the native .pkg installer"
         required: false
         type: boolean
         default: false
-  workflow_call:
+      artifact_retention_days:
+        description: "Retention for uploaded installer artifacts"
+        required: false
+        type: number
+        default: 3
+      version_override:
+        description: "Explicit version to use instead of deriving from the git ref"
+        required: false
+        type: string
+        default: ""
     outputs:
       version:
         description: 'Build version'
@@ -53,12 +81,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Determine VERSION
         id: get_version
         uses: ./.github/actions/determine-version
         with:
           fallback: "dev"
+          override: ${{ inputs.version_override }}
 
       - name: Install Rosetta 2 (arm64)
         if: matrix.arch == 'arm64'
@@ -225,8 +255,8 @@ jobs:
           echo "${{ steps.get_version.outputs.version }}" > \
             build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/VERSION
 
-      - name: Codesign & package macOS app (release tags or forced dispatch)
-        if: github.event_name != 'pull_request' && env.MACOS_CERT_P12 != '' && (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.force_pkg))
+      - name: Codesign & package macOS app
+        if: env.MACOS_CERT_P12 != '' && (startsWith(github.ref, 'refs/tags/v') || inputs.package_installer)
         env:
           CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
           PKG_SIGN_IDENTITY: ${{ secrets.PKG_SIGN_IDENTITY }}
@@ -303,8 +333,8 @@ jobs:
           rm PioneerUnsigned.pkg
 
 
-      - name: Notarize macOS package (release tags or forced dispatch)
-        if: github.event_name != 'pull_request' && env.MACOS_CERT_P12 != '' && (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.force_pkg))
+      - name: Notarize macOS package
+        if: env.MACOS_CERT_P12 != '' && (startsWith(github.ref, 'refs/tags/v') || inputs.package_installer)
         timeout-minutes: 240
         env:
           AC_USERNAME: ${{ secrets.NOTARIZE_APPLE_ID }}
@@ -339,26 +369,21 @@ jobs:
           fi
           echo "Notarization successful at $(date)"
 
-      - name: Staple notarization ticket (release tags or forced dispatch)
-        if: github.event_name != 'pull_request' && env.MACOS_CERT_P12 != '' && (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.force_pkg))
+      - name: Staple notarization ticket
+        if: env.MACOS_CERT_P12 != '' && (startsWith(github.ref, 'refs/tags/v') || inputs.package_installer)
         run: |
           xcrun stapler staple \
             Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.pkg
 
-      - name: Package zipped binaries
-        run: |
-          cd build/Pioneer_${{ matrix.identifier }}/Applications
-          zip -qr ../../../Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.zip Pioneer
-
-      - name: Validate signed pkg (release tags or forced dispatch)
-        if: github.event_name != 'pull_request' && env.MACOS_CERT_P12 != '' && (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.force_pkg))
+      - name: Validate signed pkg
+        if: env.MACOS_CERT_P12 != '' && (startsWith(github.ref, 'refs/tags/v') || inputs.package_installer)
         run: |
           PKG="Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.pkg"
           echo "Validating pkg with spctl: $PKG"
           spctl -a -vv -t install "$PKG"
 
       - name: Clean up temporary signing keychain
-        if: always() && github.event_name != 'pull_request' && env.MACOS_CERT_P12 != ''
+        if: always() && env.MACOS_CERT_P12 != ''
         run: |
           if [[ -n "${KEYCHAIN_PATH:-}" ]]; then
             security delete-keychain "$KEYCHAIN_PATH" || true
@@ -366,15 +391,10 @@ jobs:
           security default-keychain -d user -s login.keychain
           security list-keychains -d user -s login.keychain
 
-      - name: Upload zipped binaries
-        uses: actions/upload-artifact@v7
-        with:
-          name: Pioneer-${{ matrix.identifier }}
-          path: Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.zip
-
-      - name: Upload signed package (release tags or forced dispatch)
-        if: github.event_name != 'pull_request' && env.MACOS_CERT_P12 != '' && (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.force_pkg))
+      - name: Upload signed package
+        if: env.MACOS_CERT_P12 != '' && (startsWith(github.ref, 'refs/tags/v') || inputs.package_installer)
         uses: actions/upload-artifact@v7
         with:
           name: Pioneer-${{ matrix.identifier }}-pkg
           path: Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.pkg
+          retention-days: ${{ inputs.artifact_retention_days }}

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -1,22 +1,50 @@
 name: Build Windows
 
 on:
-  push:
-    branches:
-      - main
-      - develop
-  pull_request:
-    branches:
-      - main
-      - develop
   workflow_dispatch:
     inputs:
-      force_installer:
-        description: "Force MSI packaging/upload for manual runs"
+      checkout_ref:
+        description: "Explicit git ref or SHA to build instead of the workflow ref"
+        required: false
+        type: string
+        default: ""
+      package_installer:
+        description: "Build and upload the native MSI installer"
+        required: false
+        type: boolean
+        default: true
+      artifact_retention_days:
+        description: "Retention for uploaded installer artifacts"
+        required: false
+        type: number
+        default: 3
+      version_override:
+        description: "Explicit version to use instead of deriving from the git ref"
+        required: false
+        type: string
+        default: ""
+  workflow_call:
+    inputs:
+      checkout_ref:
+        description: "Explicit git ref or SHA to build instead of the workflow ref"
+        required: false
+        type: string
+        default: ""
+      package_installer:
+        description: "Build and upload the native MSI installer"
         required: false
         type: boolean
         default: false
-  workflow_call:
+      artifact_retention_days:
+        description: "Retention for uploaded installer artifacts"
+        required: false
+        type: number
+        default: 3
+      version_override:
+        description: "Explicit version to use instead of deriving from the git ref"
+        required: false
+        type: string
+        default: ""
     outputs:
       version:
         description: 'Build version'
@@ -48,12 +76,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Determine VERSION
         id: get_version
         uses: ./.github/actions/determine-version
         with:
           fallback: "dev"
+          override: ${{ inputs.version_override }}
 
       - name: Normalize versions
         id: norm
@@ -177,8 +207,8 @@ jobs:
           "msi_version=$clean" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           Write-Host "MSI_VERSION=$clean"
 
-      - name: Package Windows MSI (release tags or forced dispatch)
-        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.force_installer)
+      - name: Package Windows MSI
+        if: startsWith(github.ref, 'refs/tags/v') || inputs.package_installer
         shell: pwsh
         run: |
           $pioneerRoot = "build\Pioneer_${{ matrix.identifier }}\Applications\Pioneer"
@@ -231,22 +261,10 @@ jobs:
             -out "Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.msi" `
             installer.wixobj components.wixobj
 
-      - name: Package zipped binaries
-        shell: pwsh
-        run: |
-          $pioneerRoot = "build\Pioneer_${{ matrix.identifier }}\Applications\Pioneer"
-          Compress-Archive -Path "$pioneerRoot\*" `
-                           -DestinationPath "Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.zip"
-
-      - name: Upload zipped binaries
-        uses: actions/upload-artifact@v7
-        with:
-          name: Pioneer-${{ matrix.identifier }}
-          path: Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.zip
-
-      - name: Upload MSI (release tags or forced dispatch)
-        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.force_installer)
+      - name: Upload MSI
+        if: startsWith(github.ref, 'refs/tags/v') || inputs.package_installer
         uses: actions/upload-artifact@v7
         with:
           name: Pioneer-${{ matrix.identifier }}-msi
           path: Pioneer-${{ steps.get_version.outputs.version }}-${{ matrix.identifier }}.msi
+          retention-days: ${{ inputs.artifact_retention_days }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,95 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  check_develop_changes:
+    name: Check develop for new commits
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+      reason: ${{ steps.decide.outputs.reason }}
+    steps:
+      - name: Decide whether nightly validation should run
+        id: decide
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const branch = context.ref.replace('refs/heads/', '');
+            const currentSha = context.sha;
+            let shouldRun = true;
+            let reason = `Running nightly validation for ${branch} at ${currentSha.slice(0, 7)}.`;
+
+            if (context.eventName === 'schedule') {
+              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'nightly.yml',
+                branch,
+                event: 'schedule',
+                status: 'completed',
+                per_page: 100,
+              });
+
+              const previousSuccess = runs.find((run) => run.conclusion === 'success');
+
+              if (previousSuccess && previousSuccess.head_sha === currentSha) {
+                shouldRun = false;
+                reason = `Skipping nightly validation because ${branch} is still at ${currentSha.slice(0, 7)}, which already passed nightly run #${previousSuccess.run_number}.`;
+              } else if (previousSuccess) {
+                reason = `Running nightly validation because ${branch} advanced from ${previousSuccess.head_sha.slice(0, 7)} to ${currentSha.slice(0, 7)} since the last successful nightly run.`;
+              } else {
+                reason = `Running nightly validation because no previous successful scheduled nightly run was found for ${branch}.`;
+              }
+            } else {
+              reason = `Running nightly validation because this workflow was started manually for ${branch} at ${currentSha.slice(0, 7)}.`;
+            }
+
+            core.info(reason);
+            core.setOutput('should_run', shouldRun ? 'true' : 'false');
+            core.setOutput('reason', reason);
+
+      - name: Write decision summary
+        shell: bash
+        run: |
+          {
+            echo "## Nightly decision"
+            echo
+            echo "${{ steps.decide.outputs.reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  validate:
+    name: Run nightly installer validation
+    needs: check_develop_changes
+    if: needs.check_develop_changes.outputs.should_run == 'true'
+    uses: ./.github/workflows/validate_installers.yml
+    with:
+      artifact_retention_days: 3
+      smoke_artifact_prefix: nightly
+    secrets: inherit
+
+  skipped:
+    name: Skip nightly installer validation
+    needs: check_develop_changes
+    if: needs.check_develop_changes.outputs.should_run != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record skip summary
+        shell: bash
+        run: |
+          {
+            echo "## Nightly skipped"
+            echo
+            echo "${{ needs.check_develop_changes.outputs.reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,85 @@
+name: Pre-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      checkout_ref:
+        description: "Explicit git ref or SHA to validate instead of the selected branch head"
+        required: false
+        type: string
+        default: ""
+  pull_request:
+    types:
+      - closed
+
+concurrency:
+  group: pre-release-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  resolve_target:
+    name: Resolve pre-release target
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.resolve.outputs.should_run }}
+      checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
+      reason: ${{ steps.resolve.outputs.reason }}
+    steps:
+      - name: Resolve target commit
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SHOULD_RUN="false"
+          CHECKOUT_REF=""
+          REASON="Pre-release was not requested."
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            CHECKOUT_REF="${{ inputs.checkout_ref }}"
+            if [[ -z "$CHECKOUT_REF" ]]; then
+              CHECKOUT_REF="${GITHUB_SHA}"
+            fi
+            SHOULD_RUN="true"
+            REASON="Manual pre-release validation requested for ${CHECKOUT_REF}."
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            MERGED="${{ github.event.pull_request.merged }}"
+            TITLE="${{ github.event.pull_request.title }}"
+            MERGE_COMMIT_SHA="${{ github.event.pull_request.merge_commit_sha }}"
+
+            if [[ "$MERGED" == "true" && "$TITLE" == release:\ v* && -n "$MERGE_COMMIT_SHA" ]]; then
+              SHOULD_RUN="true"
+              CHECKOUT_REF="$MERGE_COMMIT_SHA"
+              REASON="Auto-running pre-release validation for merged release PR on ${MERGE_COMMIT_SHA}."
+            else
+              REASON="Skipping pre-release because this was not a merged release PR."
+            fi
+          fi
+
+          {
+            echo "should_run=$SHOULD_RUN"
+            echo "checkout_ref=$CHECKOUT_REF"
+            echo "reason=$REASON"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Write decision summary
+        shell: bash
+        run: |
+          {
+            echo "## Pre-release decision"
+            echo
+            echo "${{ steps.resolve.outputs.reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  validate:
+    needs: resolve_target
+    if: needs.resolve_target.outputs.should_run == 'true'
+    uses: ./.github/workflows/validate_installers.yml
+    with:
+      checkout_ref: ${{ needs.resolve_target.outputs.checkout_ref }}
+      artifact_retention_days: 3
+      smoke_artifact_prefix: pre-release
+    secrets: inherit

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -117,8 +117,10 @@ jobs:
               "This PR is managed by the `Prepare Release` workflow.",
               "",
               "After merge:",
-              `1. Create tag \`v${version}\` on the merge commit in \`${target}\`.`,
-              "2. The `Release` workflow will publish binaries and installers."
+              `1. \`pre-release.yml\` will run automatically on the merge commit in \`${target}\`.`,
+              `2. Review the pre-release validation results.`,
+              `3. If pre-release validation passes, create tag \`v${version}\` on that same commit.`,
+              "4. The `Release` workflow will publish the supported installer artifacts."
             ].join("\n");
 
             const existing = await github.paginate(github.rest.pulls.list, {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*.*.*'
-  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.ref }}
@@ -45,13 +44,22 @@ jobs:
   linux:
     needs: validate_release_version
     uses: ./.github/workflows/build_app_linux.yml
+    with:
+      package_installer: true
+      artifact_retention_days: 3
   macos:
     needs: validate_release_version
     uses: ./.github/workflows/build_app_macos.yml
+    with:
+      package_installer: true
+      artifact_retention_days: 3
     secrets: inherit
   windows:
     needs: validate_release_version
     uses: ./.github/workflows/build_app_windows.yml
+    with:
+      package_installer: true
+      artifact_retention_days: 3
 
   publish:
     name: Publish GitHub Release

--- a/.github/workflows/validate_installers.yml
+++ b/.github/workflows/validate_installers.yml
@@ -1,0 +1,535 @@
+name: Validate Installers
+
+on:
+  workflow_call:
+    inputs:
+      checkout_ref:
+        description: "Explicit git ref or SHA to validate instead of the caller SHA"
+        required: false
+        type: string
+        default: ""
+      artifact_retention_days:
+        description: "Retention for uploaded installer and smoke-test artifacts"
+        required: false
+        type: number
+        default: 3
+      smoke_artifact_prefix:
+        description: "Prefix used when uploading smoke-test artifacts"
+        required: false
+        type: string
+        default: "pre-release"
+
+permissions:
+  contents: read
+
+env:
+  RAW_FIXTURE_RELEASE: ci-fixtures-v1
+  RAW_FIXTURE_NAME: pioneer-convert-raw-smoke-v1.raw
+  RAW_FIXTURE_SHA256: 86ace2fadee24439af8e42d872db64b55527fd052a642a8a27f0e6deaa91cb2e
+
+jobs:
+  resolve_version:
+    name: Resolve release version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.checkout_ref || github.sha }}
+
+      - name: Read Project.toml version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' Project.toml | head -n1)
+          if [[ -z "$VERSION" ]]; then
+            echo "ERROR: Could not parse version from Project.toml"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Validation version: $VERSION"
+
+  build_linux:
+    name: Build Linux installer
+    needs: resolve_version
+    uses: ./.github/workflows/build_app_linux.yml
+    with:
+      checkout_ref: ${{ inputs.checkout_ref }}
+      package_installer: true
+      artifact_retention_days: ${{ inputs.artifact_retention_days }}
+      version_override: ${{ needs.resolve_version.outputs.version }}
+
+  build_macos:
+    name: Build macOS installers
+    needs: resolve_version
+    uses: ./.github/workflows/build_app_macos.yml
+    with:
+      checkout_ref: ${{ inputs.checkout_ref }}
+      package_installer: true
+      artifact_retention_days: ${{ inputs.artifact_retention_days }}
+      version_override: ${{ needs.resolve_version.outputs.version }}
+    secrets: inherit
+
+  build_windows:
+    name: Build Windows installer
+    needs: resolve_version
+    uses: ./.github/workflows/build_app_windows.yml
+    with:
+      checkout_ref: ${{ inputs.checkout_ref }}
+      package_installer: true
+      artifact_retention_days: ${{ inputs.artifact_retention_days }}
+      version_override: ${{ needs.resolve_version.outputs.version }}
+
+  validate_linux:
+    name: validate linux
+    needs:
+      - build_linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.checkout_ref || github.sha }}
+
+      - name: Download Linux installer
+        uses: actions/download-artifact@v4
+        with:
+          name: Pioneer-${{ needs.build_linux.outputs.version }}-linux-x64-deb
+          path: installer
+
+      - name: Install Linux package
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo dpkg -i installer/*.deb
+
+      - name: Cache RAW fixture
+        id: raw_fixture_cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ci-raw-fixture
+          key: raw-fixture-${{ runner.os }}-${{ env.RAW_FIXTURE_RELEASE }}
+
+      - name: Download RAW fixture
+        if: steps.raw_fixture_cache.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          FIXTURE_DIR="$RUNNER_TEMP/ci-raw-fixture"
+          mkdir -p "$FIXTURE_DIR"
+          gh release download "$RAW_FIXTURE_RELEASE" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "$RAW_FIXTURE_NAME" \
+            --pattern "$RAW_FIXTURE_NAME.sha256" \
+            --dir "$FIXTURE_DIR"
+
+      - name: Verify RAW fixture checksum
+        shell: bash
+        run: |
+          set -euo pipefail
+          FIXTURE_DIR="$RUNNER_TEMP/ci-raw-fixture"
+          cd "$FIXTURE_DIR"
+          shasum -a 256 -c "$RAW_FIXTURE_NAME.sha256"
+
+      - name: Run Linux smoke validation
+        shell: bash
+        run: |
+          set -euo pipefail
+          SMOKE_DIR="$RUNNER_TEMP/pre-release-smoke"
+          PIONEER="/usr/local/bin/pioneer"
+          RAW_FIXTURE="$RUNNER_TEMP/ci-raw-fixture/$RAW_FIXTURE_NAME"
+
+          python3 scripts/prepare_release_smoke_inputs.py \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --output-dir "$SMOKE_DIR"
+
+          "$PIONEER" --help > /dev/null
+          "$PIONEER" convert-raw \
+            "$RAW_FIXTURE" \
+            --output-dir "$SMOKE_DIR/raw_arrow" \
+            --concurrent-files 1 \
+            --threads-per-file 2
+          find "$SMOKE_DIR/raw_arrow" -name '*.arrow' -print -quit | grep -q .
+
+          "$PIONEER" params-predict \
+            "$SMOKE_DIR/generated_from_cli" \
+            "$GITHUB_WORKSPACE/data/precompile/ecoli.fasta" \
+            --params-path "$SMOKE_DIR/build_template.json"
+          test -f "$SMOKE_DIR/build_template.json"
+
+          "$PIONEER" params-search \
+            "$GITHUB_WORKSPACE/data/ecoli_test/Prosit_ECOLI_500_600mz_062625.poin" \
+            "$GITHUB_WORKSPACE/data/ecoli_test/raw" \
+            "$SMOKE_DIR/search_results_from_cli" \
+            --params-path "$SMOKE_DIR/search_template.json"
+          test -f "$SMOKE_DIR/search_template.json"
+
+          "$PIONEER" convert-mzml \
+            "$GITHUB_WORKSPACE/data/precompile/convert_example.mzML" \
+            --output-dir "$SMOKE_DIR/mzml_arrow"
+          find "$SMOKE_DIR/mzml_arrow" -name '*.arrow' -print -quit | grep -q .
+
+          "$PIONEER" predict "$SMOKE_DIR/build_predict.json"
+          test -f "$SMOKE_DIR/predicted_library.poin/config.json"
+
+          "$PIONEER" search "$SMOKE_DIR/search.json"
+          test -f "$SMOKE_DIR/search_results/config.json"
+
+      - name: Upload Linux smoke outputs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ format('{0}-smoke-linux', inputs.smoke_artifact_prefix) }}
+          path: ${{ runner.temp }}/pre-release-smoke
+          retention-days: ${{ inputs.artifact_retention_days }}
+
+  validate_windows:
+    name: validate windows
+    needs:
+      - build_windows
+    runs-on: windows-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.checkout_ref || github.sha }}
+
+      - name: Download Windows installer
+        uses: actions/download-artifact@v4
+        with:
+          name: Pioneer-windows-x64-msi
+          path: installer
+
+      - name: Install MSI
+        shell: pwsh
+        run: |
+          $msi = Get-ChildItem -Path installer -Filter *.msi | Select-Object -First 1
+          if (-not $msi) {
+            throw "MSI artifact not found"
+          }
+
+          $process = Start-Process msiexec.exe `
+            -ArgumentList @('/i', $msi.FullName, '/qn', '/norestart') `
+            -Wait `
+            -PassThru
+
+          if ($process.ExitCode -ne 0) {
+            throw "MSI installation failed with exit code $($process.ExitCode)"
+          }
+
+      - name: Cache RAW fixture
+        id: raw_fixture_cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}\ci-raw-fixture
+          key: raw-fixture-${{ runner.os }}-${{ env.RAW_FIXTURE_RELEASE }}
+
+      - name: Download RAW fixture
+        if: steps.raw_fixture_cache.outputs.cache-hit != 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $fixtureDir = Join-Path $env:RUNNER_TEMP 'ci-raw-fixture'
+          New-Item -ItemType Directory -Force -Path $fixtureDir | Out-Null
+          gh release download $env:RAW_FIXTURE_RELEASE `
+            --repo $env:GITHUB_REPOSITORY `
+            --pattern $env:RAW_FIXTURE_NAME `
+            --pattern "$($env:RAW_FIXTURE_NAME).sha256" `
+            --dir $fixtureDir
+
+      - name: Verify RAW fixture checksum
+        shell: pwsh
+        run: |
+          $fixtureDir = Join-Path $env:RUNNER_TEMP 'ci-raw-fixture'
+          $fixturePath = Join-Path $fixtureDir $env:RAW_FIXTURE_NAME
+          $checksumPath = Join-Path $fixtureDir "$($env:RAW_FIXTURE_NAME).sha256"
+          $expected = (((Get-Content $checksumPath -Raw).Trim()) -split '\s+')[0].ToLower()
+          $actual = (Get-FileHash -Algorithm SHA256 $fixturePath).Hash.ToLower()
+          if ($actual -ne $expected) {
+            throw "RAW fixture checksum mismatch: expected $expected but got $actual"
+          }
+
+      - name: Run Windows smoke validation
+        shell: pwsh
+        run: |
+          $smokeDir = Join-Path $env:RUNNER_TEMP 'pre-release-smoke'
+          $pioneer = 'C:\Program Files\Pioneer\pioneer.bat'
+          $rawFixture = Join-Path (Join-Path $env:RUNNER_TEMP 'ci-raw-fixture') $env:RAW_FIXTURE_NAME
+
+          python scripts/prepare_release_smoke_inputs.py `
+            --repo-root $env:GITHUB_WORKSPACE `
+            --output-dir $smokeDir
+
+          & $pioneer --help | Out-Null
+          & $pioneer convert-raw `
+            $rawFixture `
+            --output-dir (Join-Path $smokeDir 'raw_arrow') `
+            --concurrent-files 1 `
+            --threads-per-file 2
+          $rawArrowFiles = Get-ChildItem -Path (Join-Path $smokeDir 'raw_arrow') -Filter *.arrow -Recurse
+          if ($rawArrowFiles.Count -eq 0) {
+            throw 'convert-raw did not produce any .arrow output'
+          }
+
+          & $pioneer params-predict `
+            (Join-Path $smokeDir 'generated_from_cli') `
+            (Join-Path $env:GITHUB_WORKSPACE 'data\precompile\ecoli.fasta') `
+            --params-path (Join-Path $smokeDir 'build_template.json')
+          if (-not (Test-Path (Join-Path $smokeDir 'build_template.json'))) {
+            throw 'build_template.json was not created'
+          }
+
+          & $pioneer params-search `
+            (Join-Path $env:GITHUB_WORKSPACE 'data\ecoli_test\Prosit_ECOLI_500_600mz_062625.poin') `
+            (Join-Path $env:GITHUB_WORKSPACE 'data\ecoli_test\raw') `
+            (Join-Path $smokeDir 'search_results_from_cli') `
+            --params-path (Join-Path $smokeDir 'search_template.json')
+          if (-not (Test-Path (Join-Path $smokeDir 'search_template.json'))) {
+            throw 'search_template.json was not created'
+          }
+
+          & $pioneer convert-mzml `
+            (Join-Path $env:GITHUB_WORKSPACE 'data\precompile\convert_example.mzML') `
+            --output-dir (Join-Path $smokeDir 'mzml_arrow')
+          $arrowFiles = Get-ChildItem -Path (Join-Path $smokeDir 'mzml_arrow') -Filter *.arrow -Recurse
+          if ($arrowFiles.Count -eq 0) {
+            throw 'convert-mzml did not produce any .arrow output'
+          }
+
+          & $pioneer predict (Join-Path $smokeDir 'build_predict.json')
+          if (-not (Test-Path (Join-Path $smokeDir 'predicted_library.poin\config.json'))) {
+            throw 'predict did not create the expected library output'
+          }
+
+          & $pioneer search (Join-Path $smokeDir 'search.json')
+          if (-not (Test-Path (Join-Path $smokeDir 'search_results\config.json'))) {
+            throw 'search did not create the expected results output'
+          }
+
+      - name: Upload Windows smoke outputs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ format('{0}-smoke-windows', inputs.smoke_artifact_prefix) }}
+          path: ${{ runner.temp }}\pre-release-smoke
+          retention-days: ${{ inputs.artifact_retention_days }}
+
+  validate_osx_intel:
+    name: validate osx intel
+    needs:
+      - build_macos
+    runs-on: macos-15-intel
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.checkout_ref || github.sha }}
+
+      - name: Download macOS Intel installer
+        uses: actions/download-artifact@v4
+        with:
+          name: Pioneer-macos-x64-pkg
+          path: installer
+
+      - name: Install macOS Intel package
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo installer -pkg installer/*.pkg -target /
+
+      - name: Cache RAW fixture
+        id: raw_fixture_cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ci-raw-fixture
+          key: raw-fixture-${{ runner.os }}-${{ env.RAW_FIXTURE_RELEASE }}
+
+      - name: Download RAW fixture
+        if: steps.raw_fixture_cache.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          FIXTURE_DIR="$RUNNER_TEMP/ci-raw-fixture"
+          mkdir -p "$FIXTURE_DIR"
+          gh release download "$RAW_FIXTURE_RELEASE" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "$RAW_FIXTURE_NAME" \
+            --pattern "$RAW_FIXTURE_NAME.sha256" \
+            --dir "$FIXTURE_DIR"
+
+      - name: Verify RAW fixture checksum
+        shell: bash
+        run: |
+          set -euo pipefail
+          FIXTURE_DIR="$RUNNER_TEMP/ci-raw-fixture"
+          cd "$FIXTURE_DIR"
+          shasum -a 256 -c "$RAW_FIXTURE_NAME.sha256"
+
+      - name: Run macOS Intel smoke validation
+        shell: bash
+        run: |
+          set -euo pipefail
+          SMOKE_DIR="$RUNNER_TEMP/pre-release-smoke"
+          PIONEER="/usr/local/bin/pioneer"
+          RAW_FIXTURE="$RUNNER_TEMP/ci-raw-fixture/$RAW_FIXTURE_NAME"
+
+          python3 scripts/prepare_release_smoke_inputs.py \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --output-dir "$SMOKE_DIR"
+
+          "$PIONEER" --help > /dev/null
+          "$PIONEER" convert-raw \
+            "$RAW_FIXTURE" \
+            --output-dir "$SMOKE_DIR/raw_arrow" \
+            --concurrent-files 1 \
+            --threads-per-file 2
+          find "$SMOKE_DIR/raw_arrow" -name '*.arrow' -print -quit | grep -q .
+
+          "$PIONEER" params-predict \
+            "$SMOKE_DIR/generated_from_cli" \
+            "$GITHUB_WORKSPACE/data/precompile/ecoli.fasta" \
+            --params-path "$SMOKE_DIR/build_template.json"
+          test -f "$SMOKE_DIR/build_template.json"
+
+          "$PIONEER" params-search \
+            "$GITHUB_WORKSPACE/data/ecoli_test/Prosit_ECOLI_500_600mz_062625.poin" \
+            "$GITHUB_WORKSPACE/data/ecoli_test/raw" \
+            "$SMOKE_DIR/search_results_from_cli" \
+            --params-path "$SMOKE_DIR/search_template.json"
+          test -f "$SMOKE_DIR/search_template.json"
+
+          "$PIONEER" convert-mzml \
+            "$GITHUB_WORKSPACE/data/precompile/convert_example.mzML" \
+            --output-dir "$SMOKE_DIR/mzml_arrow"
+          find "$SMOKE_DIR/mzml_arrow" -name '*.arrow' -print -quit | grep -q .
+
+          "$PIONEER" predict "$SMOKE_DIR/build_predict.json"
+          test -f "$SMOKE_DIR/predicted_library.poin/config.json"
+
+          "$PIONEER" search "$SMOKE_DIR/search.json"
+          test -f "$SMOKE_DIR/search_results/config.json"
+
+      - name: Upload macOS Intel smoke outputs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ format('{0}-smoke-macos-intel', inputs.smoke_artifact_prefix) }}
+          path: ${{ runner.temp }}/pre-release-smoke
+          retention-days: ${{ inputs.artifact_retention_days }}
+
+  validate_osx_apple_silicon:
+    name: validate osx apple silicon
+    needs:
+      - build_macos
+    runs-on: macos-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.checkout_ref || github.sha }}
+
+      - name: Download macOS Apple Silicon installer
+        uses: actions/download-artifact@v4
+        with:
+          name: Pioneer-macos-arm64-pkg
+          path: installer
+
+      - name: Install macOS Apple Silicon package
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo installer -pkg installer/*.pkg -target /
+
+      - name: Cache RAW fixture
+        id: raw_fixture_cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ci-raw-fixture
+          key: raw-fixture-${{ runner.os }}-${{ env.RAW_FIXTURE_RELEASE }}
+
+      - name: Download RAW fixture
+        if: steps.raw_fixture_cache.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          FIXTURE_DIR="$RUNNER_TEMP/ci-raw-fixture"
+          mkdir -p "$FIXTURE_DIR"
+          gh release download "$RAW_FIXTURE_RELEASE" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "$RAW_FIXTURE_NAME" \
+            --pattern "$RAW_FIXTURE_NAME.sha256" \
+            --dir "$FIXTURE_DIR"
+
+      - name: Verify RAW fixture checksum
+        shell: bash
+        run: |
+          set -euo pipefail
+          FIXTURE_DIR="$RUNNER_TEMP/ci-raw-fixture"
+          cd "$FIXTURE_DIR"
+          shasum -a 256 -c "$RAW_FIXTURE_NAME.sha256"
+
+      - name: Run macOS Apple Silicon smoke validation
+        shell: bash
+        run: |
+          set -euo pipefail
+          SMOKE_DIR="$RUNNER_TEMP/pre-release-smoke"
+          PIONEER="/usr/local/bin/pioneer"
+          RAW_FIXTURE="$RUNNER_TEMP/ci-raw-fixture/$RAW_FIXTURE_NAME"
+
+          python3 scripts/prepare_release_smoke_inputs.py \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --output-dir "$SMOKE_DIR"
+
+          "$PIONEER" --help > /dev/null
+          "$PIONEER" convert-raw \
+            "$RAW_FIXTURE" \
+            --output-dir "$SMOKE_DIR/raw_arrow" \
+            --concurrent-files 1 \
+            --threads-per-file 2
+          find "$SMOKE_DIR/raw_arrow" -name '*.arrow' -print -quit | grep -q .
+
+          "$PIONEER" params-predict \
+            "$SMOKE_DIR/generated_from_cli" \
+            "$GITHUB_WORKSPACE/data/precompile/ecoli.fasta" \
+            --params-path "$SMOKE_DIR/build_template.json"
+          test -f "$SMOKE_DIR/build_template.json"
+
+          "$PIONEER" params-search \
+            "$GITHUB_WORKSPACE/data/ecoli_test/Prosit_ECOLI_500_600mz_062625.poin" \
+            "$GITHUB_WORKSPACE/data/ecoli_test/raw" \
+            "$SMOKE_DIR/search_results_from_cli" \
+            --params-path "$SMOKE_DIR/search_template.json"
+          test -f "$SMOKE_DIR/search_template.json"
+
+          "$PIONEER" convert-mzml \
+            "$GITHUB_WORKSPACE/data/precompile/convert_example.mzML" \
+            --output-dir "$SMOKE_DIR/mzml_arrow"
+          find "$SMOKE_DIR/mzml_arrow" -name '*.arrow' -print -quit | grep -q .
+
+          "$PIONEER" predict "$SMOKE_DIR/build_predict.json"
+          test -f "$SMOKE_DIR/predicted_library.poin/config.json"
+
+          "$PIONEER" search "$SMOKE_DIR/search.json"
+          test -f "$SMOKE_DIR/search_results/config.json"
+
+      - name: Upload macOS Apple Silicon smoke outputs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ format('{0}-smoke-macos-apple-silicon', inputs.smoke_artifact_prefix) }}
+          path: ${{ runner.temp }}/pre-release-smoke
+          retention-days: ${{ inputs.artifact_retention_days }}

--- a/docs/ci_cd_workflow.md
+++ b/docs/ci_cd_workflow.md
@@ -1,0 +1,123 @@
+# CI/CD Workflow Overview
+
+This is internal developer documentation for the GitHub Actions workflows in Pioneer.jl.
+
+This file is intentionally kept outside `docs/src` so it is not included in the compiled Documenter site.
+
+For the operator-facing release checklist, see `docs/release.md`.
+
+## Workflow Inventory
+
+The repository currently contains these GitHub Actions workflows:
+
+- `tests.yml` - runs the source test suite on Ubuntu.
+- `docs.yml` - builds docs for pull requests, branch pushes, tags, and manual runs; deploys docs from `develop` and `v*` tags.
+- `build_app_linux.yml` - reusable/manual Linux installer build workflow that produces `.deb` packages.
+- `build_app_macos.yml` - reusable/manual macOS installer build workflow for Intel and Apple Silicon that produces notarized `.pkg` packages.
+- `build_app_windows.yml` - reusable/manual Windows installer build workflow that produces `.msi` packages.
+- `validate_installers.yml` - reusable installer-validation workflow shared by manual pre-release runs and nightly validation.
+- `pre-release.yml` - automatic post-merge and manual rerun workflow for installer validation before tagging.
+- `nightly.yml` - nightly installer-validation workflow that runs on `develop` only when `develop` has advanced since the last successful nightly run.
+- `prepare_release.yml` - updates `Project.toml` and opens or refreshes the release PR.
+- `release.yml` - validates the tagged version, rebuilds the installer artifacts for the tag, publishes the GitHub release, and pushes Docker images.
+- `regression_slurm.yml` - runs the large regression suite on the cluster and publishes regression reports.
+- `cancel_regression_on_merge.yml` - cancels in-flight regression runs when a pull request merges.
+- `CompatHelper.yml` - opens dependency compatibility update PRs on a daily schedule.
+- `registrator.yml` - manually invokes Julia Registrator.
+- `TagBot.yml` - handles Julia package tagging automation.
+
+## Current Trigger Summary
+
+| Workflow | Primary triggers | Notes |
+| --- | --- | --- |
+| `tests.yml` | `push` to `main`/`develop`, pull requests, manual dispatch | Source tests only. |
+| `docs.yml` | `push` to `main`/`develop`, `v*` tags, pull requests, manual dispatch | Builds on all triggers; deploys only from `develop` and version tags. |
+| `build_app_*` | manual dispatch, `workflow_call` | Reusable installer builders used by `pre-release.yml` and `release.yml`. |
+| `validate_installers.yml` | `workflow_call` | Shared installer build-and-validate body. |
+| `pre-release.yml` | merged release PRs, manual dispatch | Runs automatically on merged release PRs and stays available for manual reruns. |
+| `nightly.yml` | daily schedule on `develop`, manual dispatch | Runs heavy installer validation only when `develop` has moved since the last successful nightly. |
+| `prepare_release.yml` | manual dispatch | Bumps `Project.toml` and updates the release PR. |
+| `release.yml` | `push` of `v*.*.*` tags | Publication workflow. |
+| `regression_slurm.yml` | `develop` pushes, release events, PRs, manual dispatch | Long-running cluster regressions. |
+| `cancel_regression_on_merge.yml` | merged pull requests | Cleanup helper. |
+| `CompatHelper.yml` | daily schedule, manual dispatch | Dependency maintenance. |
+| `registrator.yml` | manual dispatch | Julia package registration. |
+| `TagBot.yml` | tag pushes, issue comments, manual dispatch | Registry/tag automation. |
+
+## Current Behavior By Stage
+
+### Source Validation
+
+- `tests.yml` is the main source-validation workflow.
+- It currently runs on Ubuntu only.
+- It intentionally stays focused on package tests, not installer validation.
+
+### Documentation
+
+- `docs.yml` always builds docs when triggered.
+- It only deploys documentation for `develop` and tagged releases.
+- Versioned docs are published through Documenter using the `stable`, `v#.#`, and `dev` channels defined in `docs/make.jl`.
+
+### Packaging
+
+- The three `build_app_*` workflows are reusable building blocks for release automation.
+- They are no longer part of the default branch/PR validation flow.
+- They publish installer artifacts only.
+- Raw zipped binaries are no longer treated as supported release deliverables.
+
+### Installed-Artifact Validation
+
+- `validate_installers.yml` is the single reusable workflow for native-installer validation.
+- `pre-release.yml` uses it as the release gate before tagging.
+- Merging the PR opened by `prepare_release.yml` automatically triggers `pre-release.yml` on the merge commit.
+- `pre-release.yml` also remains manually dispatchable for reruns against a specific ref or SHA.
+- `nightly.yml` uses it on `develop` as an early warning lane.
+- The nightly run skips automatically when the current `develop` HEAD already has a successful nightly result.
+
+### Release Orchestration
+
+The current release-related automation is split across several workflows:
+
+1. `prepare_release.yml` updates `Project.toml` and opens or refreshes the release PR.
+2. Merging that release PR automatically triggers `pre-release.yml` on the merge commit.
+3. `nightly.yml` gives `develop` a recurring installed-artifact check between releases.
+4. `registrator.yml` is dispatched manually to register the Julia package version.
+5. `TagBot.yml` handles registry-driven tagging automation.
+6. `release.yml` responds to the pushed release tag, rebuilds the platform installer artifacts, publishes the GitHub release, and pushes Docker images.
+7. `regression_slurm.yml` also reacts to release publication and generates the cluster-backed regression report.
+
+## Pre-release Validation Scope
+
+`pre-release.yml` validates the installed CLI on clean OS runners by:
+
+- installing the native package for each supported OS target
+- checking `pioneer --help`
+- downloading the stable RAW fixture from the `ci-fixtures-v1` release asset, verifying its checksum, and converting it with `pioneer convert-raw`
+- generating search and library-build parameter templates
+- converting the checked-in mzML smoke input
+- building a small predicted library
+- running a search against the checked-in Arrow and `.poin` test data
+
+Smoke outputs and installer artifacts from the pre-release run are retained for 3 days.
+
+`nightly.yml` runs the same validation scope on `develop`. Scheduled nightly runs only proceed when `develop` has advanced since the last successful nightly run. Manual dispatch of `nightly.yml` always runs the full validation path.
+
+## Release Flow
+
+The release sequence is:
+
+1. Merge the release-preparation PR onto the target release branch.
+2. Let `pre-release.yml` run automatically on the merge commit.
+3. Review the installer validation jobs:
+   - `validate windows`
+   - `validate linux`
+   - `validate osx intel`
+   - `validate osx apple silicon`
+4. If the pre-release workflow passes, create the `vX.Y.Z` tag on that same commit.
+5. Let `release.yml` rebuild the installers for publication and publish only the supported installer artifacts.
+
+This intentionally separates "prove the installers work" from "publish the release".
+
+## Maintenance Rule
+
+If workflow triggers, artifact policy, or the release ritual change, update this file and `docs/release.md` in the same pull request.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,40 @@
+# Release Runbook
+
+This file is the operator-facing checklist for Pioneer releases.
+
+The internal workflow reference at `docs/ci_cd_workflow.md` explains the full GitHub Actions map. This runbook is intentionally shorter and answers one question: what do we do when we are about to ship a release?
+
+## Release Ritual
+
+The release process is:
+
+1. Run `prepare_release.yml` and merge the release-preparation PR.
+2. Let `pre-release.yml` run automatically on the merge commit.
+3. Review the installer validation jobs for:
+   - Windows
+   - Linux
+   - macOS Intel
+   - macOS Apple Silicon
+4. If the pre-release checks look good, create the `vX.Y.Z` tag on the same commit.
+5. Let `release.yml` publish the release artifacts.
+
+`pre-release.yml` remains manually dispatchable for reruns, but the normal path is the automatic run after the release PR merges. `nightly.yml` runs the same installed-artifact checks on `develop` as an early warning lane, but it does not replace the merged-PR `pre-release.yml` gate before tagging.
+
+Those installed-artifact checks now include a real `convert-raw` smoke test using the stable `ci-fixtures-v1` RAW fixture release asset, plus checksum verification before conversion.
+
+## Artifact Policy
+
+The release should publish only native installer artifacts:
+
+- Windows: `.msi`
+- Linux: `.deb`
+- macOS Intel: `.pkg`
+- macOS Apple Silicon: `.pkg`
+
+Raw zipped binaries should not be treated as supported release downloads.
+
+`release.yml` publishes the GitHub release installer assets only. Installer-validation logs and smoke outputs live in the `pre-release.yml` run artifacts for 3 days.
+
+## Update Rule
+
+If the release ritual changes, update this file and `docs/ci_cd_workflow.md` in the same pull request as the workflow change.

--- a/scripts/prepare_release_smoke_inputs.py
+++ b/scripts/prepare_release_smoke_inputs.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Prepare absolute-path config files for pre-release smoke validation."
+    )
+    parser.add_argument("--repo-root", required=True, help="Path to the repository root")
+    parser.add_argument("--output-dir", required=True, help="Directory where smoke inputs should be written")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    predict_config = json.loads((repo_root / "data" / "precompile" / "build_ecoli_altimeter.json").read_text(encoding="utf-8"))
+    predict_config["library_path"] = str(output_dir / "predicted_library")
+    predict_config["out_dir"] = str(output_dir)
+    predict_config["lib_name"] = "predicted_library"
+    predict_config["new_lib_name"] = "predicted_library"
+    predict_config["out_name"] = "predicted_library.tsv"
+    predict_config["max_koina_requests"] = 4
+    predict_config["max_koina_batch"] = 250
+    predict_config["fasta_paths"] = [str((repo_root / "data" / "precompile" / "ecoli.fasta").resolve())]
+    predict_config["calibration_raw_file"] = str((repo_root / "data" / "ecoli_test" / "raw" / "ecoli_filtered_01.arrow").resolve())
+    write_json(output_dir / "build_predict.json", predict_config)
+
+    search_config = json.loads((repo_root / "data" / "ecoli_test" / "ecoli_test_params.json").read_text(encoding="utf-8"))
+    search_config["paths"]["library"] = str((repo_root / "data" / "ecoli_test" / "Prosit_ECOLI_500_600mz_062625.poin").resolve())
+    search_config["paths"]["ms_data"] = str((repo_root / "data" / "ecoli_test" / "raw").resolve())
+    search_config["paths"]["results"] = str((output_dir / "search_results").resolve())
+    search_config["output"]["write_csv"] = False
+    search_config["output"]["write_decoys"] = False
+    write_json(output_dir / "search.json", search_config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Added a reusable installer-validation workflow in `validate_installers.yml` and use it from `pre-release.yml` and new `nightly.yml`.
- Auto-run `pre-release.yml` after a merged release PR, while keeping manual reruns available; validate the exact merge commit via explicit checkout refs.
- Added nightly installer validation on `develop` that skips when `develop` has not changed since the last successful nightly run.
- Updated the reusable platform build workflows to accept explicit checkout refs/version overrides and support the new validation flow.
- Publish installer artifacts only in releases; stop treating raw binary zips as supported release downloads.
- Added a real `convert-raw` smoke test using the stable `ci-fixtures-v1` RAW release asset with checksum verification.
- Added `scripts/prepare_release_smoke_inputs.py` to generate portable smoke-test configs across runners.
- Restored and update dthe internal release/CI docs in `docs/ci_cd_workflow.md` and `docs/release.md` to match the new release ritual.