### PR TITLE
Fix macOS app compile hangs

### DIFF
--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -150,6 +150,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          julia --threads auto --project=. -e 'using Pkg; Pkg.instantiate()'
           julia --threads auto --project=dev -e 'using Pkg; Pkg.instantiate()'
 
       - name: Precompile data (cache & download)
@@ -160,6 +161,8 @@ jobs:
       - name: Compile application
         run: |
           export LIGHTGBM_LOG_LIBRARY_DISCOVERY=false
+          export GKSwstype=100
+          export GKS_WSTYPE=100
           export JULIA_DEPOT_PATH="$RUNNER_TEMP/julia-depot:$HOME/.julia"
           mkdir -p "$RUNNER_TEMP/julia-depot"
           julia --threads auto --project=dev -e '

--- a/src/build/snoop.jl
+++ b/src/build/snoop.jl
@@ -7,13 +7,18 @@ cmd = get(ENV, "PIONEER_CMD", nothing)
 
 function maybe_run(f, name)
     if cmd === nothing || cmd == name
+        start_time = time()
+        @user_info "Starting precompile target $name"
         try
             f()
+            elapsed = round(time() - start_time; digits=1)
+            @user_info "Finished precompile target $name in $(elapsed)s"
         catch e
             bt = catch_backtrace()
             target_cmd = cmd === nothing ? "<all>" : cmd
+            elapsed = round(time() - start_time; digits=1)
             @user_warn "Error executing $name during precompile of $target_cmd: $(sprint(showerror, e))"
-            @warn "Precompile exception details for $name" exception=(e, bt)
+            @warn "Precompile exception details for $name after $(elapsed)s" exception=(e, bt)
         end
     end
 end

--- a/src/utils/pdfUtils.jl
+++ b/src/utils/pdfUtils.jl
@@ -3,10 +3,10 @@ import ..Plots
 const GR = Plots.GR
 
 function create_multipage_pdf(plots::Vector, dest::String)
-    # Ensure GR backend is active and set wstype for PDF output
-    Plots.gr()  # This will only initialize once
-    
-    withenv("GKSwstype" => "100") do
+    # Force a non-interactive GR workstation before backend initialization so
+    # headless environments do not attempt to open gksqt/Qt windows.
+    withenv("GKSwstype" => "100", "GKS_WSTYPE" => "100") do
+        Plots.gr()  # This will only initialize once
         GR.beginprint(dest)
         try
             for p in plots
@@ -24,7 +24,7 @@ function create_multipage_pdf(plots::Vector, dest::String)
 end
 end
 
-function save_multipage_pdf(plots::Vector{Plots.Plot}, dest::String)
+function save_multipage_pdf(plots::AbstractVector{<:Plots.Plot}, dest::String)
     ensure_directory_exists(dest)
     PDFGenerator.create_multipage_pdf(plots, dest)
     return dest

--- a/test/UnitTests/PdfUtilsTests.jl
+++ b/test/UnitTests/PdfUtilsTests.jl
@@ -1,0 +1,13 @@
+using Test
+using Pioneer: save_multipage_pdf
+using Plots
+
+@testset "PDF utils run headless" begin
+    output_path = tempname() * ".pdf"
+    plot_obj = Plots.plot(1:3, 1:3, title = "headless pdf smoke test")
+
+    save_multipage_pdf([plot_obj], output_path)
+
+    @test isfile(output_path)
+    @test filesize(output_path) > 0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,6 +173,7 @@ end
     include("./UnitTests/convertMzMLTests.jl")
     include("./UnitTests/LoggingTests.jl")
     include("./UnitTests/LogTruncationTests.jl")
+    include("./UnitTests/PdfUtilsTests.jl")
     include("./UnitTests/BuildPreferencesTests.jl")
     # Add focused FileOperations tests (Arrow IO, core, streaming)
     include("./utils/FileOperations/io/test_arrow_operations_basic.jl")


### PR DESCRIPTION
## Summary
- Force headless GR setup before PDF generation so plot export does not try to open a GUI workstation during compilation.
- Add a focused regression test for multipage PDF generation in headless mode.
- Harden the macOS app build by instantiating the root project, exporting GR headless env vars, and logging precompile target progress.

## Testing
- Ran the new Julia unit test for headless PDF generation successfully.
- Verified the updated PDF helper accepts normal `Plots.Plot` vectors and writes a non-empty PDF file.