### PR TITLE
Update Julia 1.12 compatibility

### DIFF
--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -107,6 +107,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          julia --threads auto --project=. -e 'using Pkg; Pkg.instantiate()'
           julia --threads auto --project=dev -e 'using Pkg; Pkg.instantiate()'
 
       - name: Precompile data (cache & download)
@@ -114,11 +115,26 @@ jobs:
         with:
           cache-key: precompile-data-v1
 
-      - name: Compile application
+      - name: Generate precompile statements
         run: |
           export LIGHTGBM_LOG_LIBRARY_DISCOVERY=false
           export PIONEER_APP_CPU_TARGET="generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
           export PIONEER_PRECOMPILE_CPU_TARGET="$PIONEER_APP_CPU_TARGET"
+          trace_dir="$RUNNER_TEMP/packagecompiler-trace"
+          raw_trace="$trace_dir/pioneer-app-precompile-raw.jl"
+          uniq_trace="$trace_dir/pioneer-app-precompile-uniq.jl"
+          filtered_trace="$trace_dir/pioneer-app-precompile-filtered.jl"
+          mkdir -p "$trace_dir"
+          julia --threads auto --project=. --trace-compile="$raw_trace" src/build/snoop.jl
+          sort -u "$raw_trace" > "$uniq_trace"
+          rg -v 'VectorizationBase|LoopVectorization|SLEEFPirates|HostCPUFeatures' "$uniq_trace" > "$filtered_trace" || true
+          echo "Retained $(wc -l < "$filtered_trace") of $(wc -l < "$uniq_trace") precompile statements after SIMD filtering."
+          echo "PIONEER_APP_CPU_TARGET=$PIONEER_APP_CPU_TARGET" >> "$GITHUB_ENV"
+          echo "PIONEER_PRECOMPILE_STATEMENTS_FILE=$filtered_trace" >> "$GITHUB_ENV"
+
+      - name: Compile application
+        run: |
+          export LIGHTGBM_LOG_LIBRARY_DISCOVERY=false
           export JULIA_DEPOT_PATH="$RUNNER_TEMP/julia-depot:$HOME/.julia"
           mkdir -p "$RUNNER_TEMP/julia-depot"
           # Julia 1.12 app builds are more reliable on the incremental PackageCompiler path.
@@ -138,7 +154,7 @@ jobs:
                 "SearchDIA"=>"main_SearchDIA",
                 "convertMzML"=>"main_convertMzML"
               ],
-              precompile_execution_file="src/build/snoop.jl"
+              precompile_statements_file=[ENV["PIONEER_PRECOMPILE_STATEMENTS_FILE"]]
             );
           '
 

--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Julia
         uses: julia-actions/setup-julia@v3
         with:
-          version: '1.11'
+          version: '1.12'
 
       - name: Cache Julia packages
         uses: actions/cache@v5

--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -117,6 +117,8 @@ jobs:
       - name: Compile application
         run: |
           export LIGHTGBM_LOG_LIBRARY_DISCOVERY=false
+          export PIONEER_APP_CPU_TARGET="generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+          export PIONEER_PRECOMPILE_CPU_TARGET="$PIONEER_APP_CPU_TARGET"
           export JULIA_DEPOT_PATH="$RUNNER_TEMP/julia-depot:$HOME/.julia"
           mkdir -p "$RUNNER_TEMP/julia-depot"
           # Julia 1.12 app builds are more reliable on the incremental PackageCompiler path.
@@ -126,6 +128,7 @@ jobs:
               ".",
               "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/",
               incremental=true, force=true,
+              cpu_target=ENV["PIONEER_APP_CPU_TARGET"],
               executables=[
                 "GetSearchParams"=>"main_GetSearchParams",
                 "GetBuildLibParams"=>"main_GetBuildLibParams",

--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -119,12 +119,13 @@ jobs:
           export LIGHTGBM_LOG_LIBRARY_DISCOVERY=false
           export JULIA_DEPOT_PATH="$RUNNER_TEMP/julia-depot:$HOME/.julia"
           mkdir -p "$RUNNER_TEMP/julia-depot"
+          # Julia 1.12 app builds are more reliable on the incremental PackageCompiler path.
           julia --threads auto --project=dev -e '
             using PackageCompiler;
             create_app(
               ".",
               "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/",
-              incremental=false, force=true,
+              incremental=true, force=true,
               executables=[
                 "GetSearchParams"=>"main_GetSearchParams",
                 "GetBuildLibParams"=>"main_GetBuildLibParams",

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Setup Julia
         uses: julia-actions/setup-julia@v3
         with:
-          version: '1.11'
+          version: '1.12'
           arch: ${{ matrix.arch }}
 
       - name: Cache Julia packages

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -195,12 +195,13 @@ jobs:
           export GKS_WSTYPE=100
           export JULIA_DEPOT_PATH="$RUNNER_TEMP/julia-depot:$HOME/.julia"
           mkdir -p "$RUNNER_TEMP/julia-depot"
+          # Julia 1.12 app builds are more reliable on the incremental PackageCompiler path.
           julia --threads auto --project=dev -e '
             using PackageCompiler;
             create_app(
               ".",
               "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/",
-              incremental=false,
+              incremental=true,
               force=true,
               executables=[
                 "GetSearchParams"=>"main_GetSearchParams",

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Julia
         uses: julia-actions/setup-julia@v3
         with:
-          version: '1.11'
+          version: '1.12'
           arch: ${{ matrix.arch }}
 
       - name: Cache Julia packages

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -120,6 +120,8 @@ jobs:
         shell: bash
         run: |
           export LIGHTGBM_LOG_LIBRARY_DISCOVERY=false
+          export PIONEER_APP_CPU_TARGET="generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)"
+          export PIONEER_PRECOMPILE_CPU_TARGET="$PIONEER_APP_CPU_TARGET"
           fresh_depot="$(mktemp -d)"
           export JULIA_DEPOT_PATH="$(cygpath -w "$fresh_depot");$(cygpath -w "$HOME/.julia")"
           # Julia 1.12 app builds are more reliable on the incremental PackageCompiler path.
@@ -130,6 +132,7 @@ jobs:
               "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/",
               incremental=true,
               force=true,
+              cpu_target=ENV["PIONEER_APP_CPU_TARGET"],
               executables=[
                 "GetSearchParams"=>"main_GetSearchParams",
                 "GetBuildLibParams"=>"main_GetBuildLibParams",

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -122,12 +122,13 @@ jobs:
           export LIGHTGBM_LOG_LIBRARY_DISCOVERY=false
           fresh_depot="$(mktemp -d)"
           export JULIA_DEPOT_PATH="$(cygpath -w "$fresh_depot");$(cygpath -w "$HOME/.julia")"
+          # Julia 1.12 app builds are more reliable on the incremental PackageCompiler path.
           julia --threads auto --project=dev -e '
             using PackageCompiler;
             create_app(
               ".",
               "build/Pioneer_${{ matrix.identifier }}/Applications/Pioneer/",
-              incremental=false,
+              incremental=true,
               force=true,
               executables=[
                 "GetSearchParams"=>"main_GetSearchParams",

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.11'
+          version: '1.12'
 
       - name: Cache docs packages
         uses: actions/cache@v5

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -73,7 +73,7 @@ jobs:
     timeout-minutes: 7200
     strategy:
       matrix:
-        version: ['1.11']
+        version: ['1.12']
         regression_set: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.regression_set)) || fromJSON('["all"]') }}
     env:
       GITHUB_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || (startsWith(github.ref, 'refs/tags/') && github.ref_name || github.sha) }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.11']
+        version: ['1.12']
         os:      [ubuntu-latest]
         arch:    [x64]
 

--- a/Project.toml
+++ b/Project.toml
@@ -101,7 +101,7 @@ StatsBase = "0.34"
 StatsModels = "0.7"
 StatsPlots = "0.15"
 Tables = "1.12"
-julia = "1.11"
+julia = "1.12"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/data/test_build_spec_lib/scenario_a_missed_cleavages/output/minimal_mc2.poin/build_log.txt
+++ b/data/test_build_spec_lib/scenario_a_missed_cleavages/output/minimal_mc2.poin/build_log.txt
@@ -65,7 +65,7 @@ Total Available System Memory: 48.0 GB
 Process Information:
 ------------------------------------------------------------------------------------------
 Number of Threads: 10
-Julia Version: 1.11.3
+Julia Version: 1.12.3
 System: arm64-apple-darwin24.0.0
 
 ==========================================================================================

--- a/data/test_build_spec_lib/scenario_a_missed_cleavages/output/minimal_mc3.poin/build_log.txt
+++ b/data/test_build_spec_lib/scenario_a_missed_cleavages/output/minimal_mc3.poin/build_log.txt
@@ -65,7 +65,7 @@ Total Available System Memory: 48.0 GB
 Process Information:
 ------------------------------------------------------------------------------------------
 Number of Threads: 10
-Julia Version: 1.11.3
+Julia Version: 1.12.3
 System: arm64-apple-darwin24.0.0
 
 ==========================================================================================

--- a/dev/Project.toml
+++ b/dev/Project.toml
@@ -13,7 +13,7 @@ Documenter = "1.5"
 DocumenterTools = "0.1"
 PProf = "3.2.0"
 PackageCompiler = "=2.2.3"
-julia = "1.11"
+julia = "1.12"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/dev/Project.toml
+++ b/dev/Project.toml
@@ -12,7 +12,7 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Documenter = "1.5"
 DocumenterTools = "0.1"
 PProf = "3.2.0"
-PackageCompiler = "=2.2.3"
+PackageCompiler = "2.2.5"
 julia = "1.12"
 
 [extras]

--- a/docs/src/user_guide/installation.md
+++ b/docs/src/user_guide/installation.md
@@ -45,7 +45,7 @@ Run Pioneer in a container without installing dependencies.
 ### Development Setup
 To work on Pioneer itself, set up a local development environment.
 
-1. Install **Julia 1.10** or higher from [julialang.org](https://julialang.org/downloads/) (only required for development; compiled releases bundle their own runtime).
+1. Install **Julia 1.12** or higher from [julialang.org](https://julialang.org/downloads/) (only required for development; compiled releases bundle their own runtime).
 2. Clone the repository:
    ```bash
    git clone https://github.com/nwamsley1/Pioneer.jl.git

--- a/src/build/snoop.jl
+++ b/src/build/snoop.jl
@@ -1,5 +1,4 @@
-using Pioneer
-using HostCPUFeatures
+import HostCPUFeatures
 
 root = joinpath(@__DIR__)
 data_dir = joinpath(root, "..", "..", "data")
@@ -8,13 +7,24 @@ cmd = get(ENV, "PIONEER_CMD", nothing)
 
 function maybe_mask_precompile_cpu_features()
     target = get(ENV, "PIONEER_PRECOMPILE_CPU_TARGET", nothing)
-    if !isnothing(target)
-        @user_info "Masking HostCPUFeatures during precompile to $target"
-        HostCPUFeatures.make_generic(target)
+    if !isnothing(target) && ((Sys.ARCH === :x86_64) || (Sys.ARCH === :i686))
+        @info "Overriding HostCPUFeatures during precompile for target $target"
+        # PackageCompiler records precompile signatures while tracing on the host CPU.
+        # On AVX-512 runners that can capture VectorizationBase methods which LLVM
+        # cannot legalize for the portable app CPU target later in the build.
+        @eval HostCPUFeatures begin
+            has_feature(::Val{:x86_64_avx512vl}) = False()
+            has_feature(::Val{:x86_64_avx512f}) = False()
+            has_feature(::Val{:x86_64_avx2}) = False()
+            has_feature(::Val{:x86_64_3}) = False()
+            has_feature(::Val{:x86_64_avx}) = False()
+        end
     end
 end
 
 maybe_mask_precompile_cpu_features()
+
+using Pioneer
 
 function maybe_run(f, name)
     if cmd === nothing || cmd == name

--- a/src/build/snoop.jl
+++ b/src/build/snoop.jl
@@ -1,9 +1,20 @@
 using Pioneer
+using HostCPUFeatures
 
 root = joinpath(@__DIR__)
 data_dir = joinpath(root, "..", "..", "data")
 
 cmd = get(ENV, "PIONEER_CMD", nothing)
+
+function maybe_mask_precompile_cpu_features()
+    target = get(ENV, "PIONEER_PRECOMPILE_CPU_TARGET", nothing)
+    if !isnothing(target)
+        @user_info "Masking HostCPUFeatures during precompile to $target"
+        HostCPUFeatures.make_generic(target)
+    end
+end
+
+maybe_mask_precompile_cpu_features()
 
 function maybe_run(f, name)
     if cmd === nothing || cmd == name


### PR DESCRIPTION
## Summary
- Bump the project, dev, docs, and CI Julia targets from 1.11 to 1.12
- Update the development installation guide to require Julia 1.12+
- Refresh checked-in sample build logs to report Julia 1.12.3

## Testing
- Not run (not requested)