### PR TITLE
Lipschitz step cap for spline fits + remove dead rank_to_score

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Regression Reports](https://img.shields.io/badge/regression-reports-orange)](https://nwamsley1.github.io/Pioneer.jl/reports/)
 [![Main branch tests](https://img.shields.io/github/actions/workflow/status/nwamsley1/Pioneer.jl/tests.yml?branch=main&label=Main%20tests)](https://github.com/nwamsley1/Pioneer.jl/actions/workflows/tests.yml?query=branch%3Amain)
 [![Develop branch tests](https://img.shields.io/github/actions/workflow/status/nwamsley1/Pioneer.jl/tests.yml?branch=develop&label=Develop%20tests)](https://github.com/nwamsley1/Pioneer.jl/actions/workflows/tests.yml?query=branch%3Adevelop)
-[![Coverage](https://codecov.io/gh/nwamsley1/Pioneer.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/nwamsley1/Pioneer.jl)
+[![Coverage](https://codecov.io/gh/nwamsley1/Pioneer.jl/branch/develop/graph/badge.svg)](https://codecov.io/gh/nwamsley1/Pioneer.jl/branch/develop)
 [![bioRxiv](https://img.shields.io/badge/bioRxiv-2026.02.16.706201v2-B31B1B)](https://www.biorxiv.org/content/10.64898/2026.02.16.706201v2)
 
 Pioneer and its companion tool, Altimeter, are an open-source and performant solution for analysis of protein MS data acquired by data-independent acquisition (DIA). Pioneer includes routines for searching DIA experiments from Thermo and Sciex instruments and for building spectral libraries using the [Koina](https://koina.wilhelmlab.org/) interface. Given a spectral library of precursor fragment ion intensities and retention time estimates, Pioneer identifies and quantifies peptides and protein groups from the library in the data.

--- a/data/precompile/build_ecoli_altimeter.json
+++ b/data/precompile/build_ecoli_altimeter.json
@@ -16,7 +16,6 @@
     "library_params": {
         "rt_bin_tol": 1.0,
         "frag_bin_tol_ppm": 10.0,
-        "rank_to_score": [8,4,4,2,2,1,1],
         "y_start_index": 4,
         "b_start_index": 3,
         "y_start": 3,

--- a/data/test_build_spec_lib/scenario_a_missed_cleavages/params_0mc.json
+++ b/data/test_build_spec_lib/scenario_a_missed_cleavages/params_0mc.json
@@ -16,15 +16,6 @@
     "library_params": {
         "rt_bin_tol": 1.0,
         "frag_bin_tol_ppm": 10.0,
-        "rank_to_score": [
-            8,
-            4,
-            4,
-            2,
-            2,
-            1,
-            1
-        ],
         "y_start_index": 4,
         "b_start_index": 3,
         "y_start": 3,

--- a/data/test_build_spec_lib/scenario_a_missed_cleavages/params_2mc.json
+++ b/data/test_build_spec_lib/scenario_a_missed_cleavages/params_2mc.json
@@ -61,15 +61,6 @@
     "library_params": {
         "rt_bin_tol": 1.0,
         "frag_bin_tol_ppm": 10.0,
-        "rank_to_score": [
-            8,
-            4,
-            4,
-            2,
-            2,
-            1,
-            1
-        ],
         "y_start_index": 4,
         "b_start_index": 3,
         "y_start": 3,

--- a/data/test_build_spec_lib/scenario_a_missed_cleavages/params_3mc.json
+++ b/data/test_build_spec_lib/scenario_a_missed_cleavages/params_3mc.json
@@ -61,15 +61,6 @@
     "library_params": {
         "rt_bin_tol": 1.0,
         "frag_bin_tol_ppm": 10.0,
-        "rank_to_score": [
-            8,
-            4,
-            4,
-            2,
-            2,
-            1,
-            1
-        ],
         "y_start_index": 4,
         "b_start_index": 3,
         "y_start": 3,

--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -363,7 +363,6 @@ function BuildSpecLib(params_path::String)
                 const_max_frag_rank,
                 const_length_to_frag_count_multiple,
                 const_min_frag_intensity,
-                haskey(params, "rank_to_score") ? UInt8.(params["rank_to_score"]) : UInt8[8, 4, 4, 2, 2, 1, 1],  # rank_to_score
                 frag_bounds,
                 Float32(get(_params.library_params, "frag_bin_tol_ppm", 0.0)),  # frag_bin_tol_ppm (0 = use mDa mode)
                 3.0f0,          # rt_bin_tol

--- a/src/Routines/BuildSpecLib/build/build_poin_lib.jl
+++ b/src/Routines/BuildSpecLib/build/build_poin_lib.jl
@@ -64,7 +64,6 @@ end
                 max_frag_charge::UInt8,
                 max_frag_rank::UInt8,
                 min_frag_intensity::Float32,
-                rank_to_score::Vector{UInt8},
                 frag_bounds::FragBoundModel,
                 frag_bin_tol_ppm::Float32,
                 rt_bin_tol_ppm::Float32,
@@ -80,14 +79,13 @@ Build a Pioneer spectral library from preprocessed fragment and precursor data.
 - `b_start`: Minimum index for b-ions to include in detailed fragments
 - `include_p_index`: Whether to include precursor ions in the fragment index
 - `include_p`: Whether to include precursor ions in detailed fragments
-- `include_isotope`: Whether to include isotope peaks 
+- `include_isotope`: Whether to include isotope peaks
 - `include_immonium`: Whether to include immonium ions
 - `include_internal`: Whether to include internal fragment ions
 - `include_neutral_diff`: Whether to include fragments with neutral losses
 - `max_frag_charge`: Maximum fragment charge state to include
 - `max_frag_rank`: Maximum number of fragments per precursor (ranked by intensity)
 - `min_frag_intensity`: Minimum relative intensity threshold for fragments
-- `rank_to_score`: Vector mapping intensity rank to scoring value
 - `frag_bounds`: Model defining minimum and maximum fragment m/z bounds
 - `frag_bin_tol_ppm`: Fragment binning tolerance in parts per million
 - `rt_bin_tol_ppm`: Retention time binning tolerance in parts per million
@@ -128,7 +126,6 @@ function buildPionLib(spec_lib_path::String,
                       max_frag_rank::UInt8,
                       length_to_frag_count_multiple::AbstractFloat,
                       min_frag_intensity::Float32,
-                      rank_to_score::Vector{UInt8},
                       frag_bounds::FragBoundModel,
                       frag_bin_tol_ppm::Float32,
                       rt_bin_tol_ppm::Float32,
@@ -205,13 +202,13 @@ function buildPionLib(spec_lib_path::String,
 
     partitioned_index = build_partitioned_index_from_lib(temp_lib;
         partition_width=5.0f0, frag_bin_tol_ppm=frag_bin_tol_ppm, frag_bin_tol_mda=frag_bin_tol_mda,
-        rt_bin_tol=rt_bin_tol_ppm, rank_to_score=rank_to_score,
+        rt_bin_tol=rt_bin_tol_ppm,
         y_start_index=y_start_index, b_start_index=b_start_index,
         include_p_index=include_p_index)
 
     presearch_partitioned_index = build_partitioned_index_from_lib(temp_lib;
         partition_width=5.0f0, frag_bin_tol_ppm=frag_bin_tol_ppm, frag_bin_tol_mda=frag_bin_tol_mda,
-        rt_bin_tol=typemax(Float32), rank_to_score=rank_to_score,
+        rt_bin_tol=typemax(Float32),
         y_start_index=y_start_index, b_start_index=b_start_index,
         include_p_index=include_p_index)
 
@@ -419,7 +416,6 @@ end
         include_neutral_diff::Bool,
         max_frag_charge::UInt8,
         frag_bounds::FragBoundModel,
-        rank_to_score::Vector{UInt8}
     )::Vector{SimpleFrag{Float32}}
 
 Extract fragments for the fragment index from raw fragment data.
@@ -448,7 +444,6 @@ Extract fragments for the fragment index from raw fragment data.
 - `include_neutral_diff`: Whether to include fragments with neutral losses
 - `max_frag_charge`: Maximum fragment charge state to include
 - `frag_bounds`: Model defining valid m/z range based on precursor m/z
-- `rank_to_score`: Vector mapping intensity rank to scoring value
 
 # Returns
 - Vector of SimpleFrag objects, containing filtered fragments for the index
@@ -477,14 +472,13 @@ function getSimpleFrags(
     include_neutral_diff::Bool,
     max_frag_charge::UInt8,
     frag_bounds::FragBoundModel,
-    rank_to_score::Vector{UInt8},
     )
     if (length(prec_to_frag_idx) - 1) != (length(precursor_mz))
         #println("mistake")
     end
-    #Maximum ranked fragment that can be included in the fragment index
-    max_rank_index = length(rank_to_score)
-    #Number of precursors 
+    # Score is a per-rank bitmask packed into a UInt8 — 8 ranks max.
+    max_rank_index = 8
+    #Number of precursors
     n_precursors = UInt32(length(precursor_mz))
     simple_frags = Vector{SimpleFrag{Float32}}(undef, n_precursors*max_rank_index)
     simple_frag_idx = 0
@@ -526,7 +520,7 @@ function getSimpleFrags(
                 UInt8(1) << UInt8(rank - 1)  # bitmask: rank 1→bit0, rank 2→bit1, ...
             )
             rank += 1
-            if rank > min(max_rank_index, 8)  # cap at 8 bits
+            if rank > max_rank_index  # cap at 8 bits
                 break
             end
         end

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/fit_intensity_mass_error.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/fit_intensity_mass_error.jl
@@ -126,10 +126,17 @@ function fit_convex_bias_spline(x::Vector{Float64}, y::Vector{Float64};
         c = H \ Xty
         project!(c)
 
+        # Lipschitz-safe step cap: opnorm(H) is the gradient Lipschitz
+        # constant of this convex quadratic, so any lr ≤ 2/L is stable.
+        # Without this cap, fixed lr diverges once n_pts is large enough
+        # that L grows past 1/lr (LU factorization at the next IRLS
+        # iteration then throws on the resulting Inf/NaN coefficients).
+        lr_eff = min(lr, 1.8 / opnorm(H))
+
         prev_obj = Inf
         for iter in 1:max_iter
             grad = H * c - Xty
-            c .-= lr .* grad
+            c .-= lr_eff .* grad
             project!(c)
             if iter % 200 == 0
                 obj = 0.5 * (c' * H * c) - (Xty' * c)
@@ -236,10 +243,13 @@ function fit_monotone_bias_spline(x::Vector{Float64}, y::Vector{Float64};
         c = H \ Xty
         project!(c)
 
+        # See fit_convex_bias_spline for rationale.
+        lr_eff = min(lr, 1.8 / opnorm(H))
+
         prev_obj = Inf
         for iter in 1:max_iter
             grad = H * c - Xty
-            c .-= lr .* grad
+            c .-= lr_eff .* grad
             project!(c)
             if iter % 200 == 0
                 obj = 0.5 * (c' * H * c) - (Xty' * c)
@@ -366,10 +376,12 @@ function fit_monotone_convex_spread_spline(
     end
 
     project!(c)
+    # See fit_convex_bias_spline for rationale.
+    lr_eff = min(lr, 1.8 / opnorm(H))
     prev_obj = Inf
     for iter in 1:max_iter
         grad = H * c - Xty
-        c .-= lr .* grad
+        c .-= lr_eff .* grad
         project!(c)
         if iter % 100 == 0
             obj = 0.5 * (c' * H * c) - (Xty' * c)

--- a/src/structs/SpectralLibrary/PartitionedFragmentIndex/build.jl
+++ b/src/structs/SpectralLibrary/PartitionedFragmentIndex/build.jl
@@ -18,13 +18,14 @@
 """
     build_partitioned_index_from_lib(spec_lib; partition_width=5.0f0,
         frag_bin_tol_ppm=2.5f0, rt_bin_tol=3.0f0,
-        rank_to_score=UInt8[8,4,4,2,2,1,1],
         y_start_index=UInt8(4), b_start_index=UInt8(3),
         include_p_index=false)
 
 Build a LocalPartitionedFragmentIndex from scratch using the spectral library's
 DetailedFrag data. Each partition gets its own independently-constructed index
 with LocalFragment entries (UInt16 local_id + UInt8 score = 4 bytes).
+
+Per-fragment score is a bitmask `1 << (rank-1)`, capped at 8 ranks (UInt8).
 
 Precursor IDs are remapped to partition-local UInt16 values (1..N, N ≤ 65535).
 Partitions that would exceed 65535 unique precursors are automatically split.
@@ -35,7 +36,6 @@ function build_partitioned_index_from_lib(
     frag_bin_tol_ppm::Float32 = 0.0f0,
     frag_bin_tol_mda::Float32 = 2.0f0,
     rt_bin_tol::Float32 = 3.0f0,
-    rank_to_score::Vector{UInt8} = UInt8[8, 4, 4, 2, 2, 1, 1],
     y_start_index::UInt8 = UInt8(4),
     b_start_index::UInt8 = UInt8(3),
     include_p_index::Bool = false,
@@ -46,7 +46,7 @@ function build_partitioned_index_from_lib(
     prec_mzs = getMz(precursors)
     prec_irts = getIrt(precursors)
     n_precursors = length(prec_mzs)
-    max_rank = length(rank_to_score)
+    max_rank = 8
 
     # ── Step 1: Assign precursors to initial partitions by prec_mz ───────────
     min_prec_mz = Float32(Inf)

--- a/test/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/test_intensity_spline_lipschitz.jl
+++ b/test/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/test_intensity_spline_lipschitz.jl
@@ -1,0 +1,54 @@
+# Regression test for the Lipschitz step cap in
+# fit_intensity_mass_error.jl. The projected gradient descent loops
+# inside fit_convex_bias_spline / fit_monotone_bias_spline /
+# fit_monotone_convex_spread_spline used a fixed lr=1e-4. opnorm(H)
+# scales with the row count of the design matrix, so once n_pts pushes
+# L = opnorm(H) past 1/lr the optimizer diverges, IRLS reweights to
+# non-finite values, and the next H \ Xty throws
+# `ArgumentError: matrix contains Infs or NaNs` from LAPACK.
+#
+# These tests build large-N synthetic inputs (300k points) that would
+# trip the original divergence and assert the fit returns a finite
+# UniformSpline.
+
+using Pioneer: fit_convex_bias_spline, fit_monotone_bias_spline,
+               fit_monotone_convex_spread_spline
+
+@testset "Intensity spline Lipschitz step cap" begin
+    rng = MersenneTwister(0x5eedfa11)
+    n = 300_000
+
+    @testset "fit_convex_bias_spline (n=$n)" begin
+        x = collect(range(100.0, 1500.0; length=n))
+        y = 1e-3 .* (x ./ 1000.0 .- 0.7).^2 .+ 5e-4 .* randn(rng, n)
+        spline = fit_convex_bias_spline(x, y; convex_up=true,
+                                         n_knots=10, λ=1.0,
+                                         max_iter=1000, lr=1e-4)
+        @test spline !== nothing
+        @test all(isfinite, spline.coeffs)
+    end
+
+    @testset "fit_monotone_bias_spline (n=$n)" begin
+        x = collect(range(0.0, 30.0; length=n))
+        y = 1e-3 .* (x .- 15.0) .+ 5e-4 .* randn(rng, n)
+        spline = fit_monotone_bias_spline(x, y; increasing=true,
+                                           n_knots=10, λ=1.0,
+                                           max_iter=1000, lr=1e-4)
+        @test spline !== nothing
+        @test all(isfinite, spline.coeffs)
+    end
+
+    @testset "fit_monotone_convex_spread_spline" begin
+        # The spread fit consumes pre-binned (centers, scales) so its
+        # design matrix is small; the Lipschitz cap still has to be
+        # finite. This guards against regression of the same code path.
+        centers = collect(range(10.0, 30.0; length=200))
+        scales = max.(0.5 .+ 5.0 .* exp.(-(centers .- 10.0) ./ 5.0)
+                       .+ 0.05 .* randn(rng, length(centers)), 0.05)
+        spline = fit_monotone_convex_spread_spline(centers, scales;
+                                                    n_knots=10, λ=0.01,
+                                                    max_iter=1000, lr=1e-3)
+        @test spline !== nothing
+        @test all(isfinite, spline.coeffs)
+    end
+end

--- a/test/UnitTests/BuildPionLibTest.jl
+++ b/test/UnitTests/BuildPionLibTest.jl
@@ -220,7 +220,6 @@ end
         max_frag_rank = UInt8(10)
         length_to_frag_count_multiple = Float32(10)
         min_frag_intensity = Float32(0.1)
-        rank_to_score = UInt8[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
 
         # Create a simple fragment bounds model for testing
         frag_bounds = FragBoundModel(
@@ -290,7 +289,6 @@ end
             max_frag_rank,
             length_to_frag_count_multiple,
             min_frag_intensity,
-            rank_to_score,
             frag_bounds,
             frag_bin_tol_ppm,
             rt_bin_tol_ppm,
@@ -705,9 +703,6 @@ end
             ImmutablePolynomial([1000.0f0, 0.0f0])  # max_frag_mz = 1000
         )
         
-        # Rank to score mapping
-        rank_to_score = UInt8[10, 9, 8, 7, 6]
-        
         # Call function with parameters that should allow all fragments to pass
         simple_frags = getSimpleFrags(
             frag_mz,
@@ -733,7 +728,6 @@ end
             include_neutral_diff,
             max_frag_charge,
             frag_bounds,
-            rank_to_score
         )
         
         # All fragments should pass our filters
@@ -745,8 +739,7 @@ end
         @test getPrecMZ(simple_frags[1]) ≈ 500.0
         @test getIRT(simple_frags[1]) ≈ 10.0
         @test getPrecCharge(simple_frags[1]) == 2
-        # Score is a bitmask of 1 << (rank-1) (since commit f472cd06 replaced
-        # the additive rank_to_score lookup with bitmask scoring). Rank 1 → 1.
+        # Score is a per-rank bitmask: rank N → UInt8(1) << (N-1), capped at 8.
         @test getScore(simple_frags[1]) == UInt8(1)  # rank 1 → bit 0
         
         # Check properties of second fragment
@@ -791,7 +784,6 @@ end
             include_neutral_diff,
             max_frag_charge,
             frag_bounds,
-            rank_to_score
         )
         
         # Only fragment #3 should pass (y-ion with index 3)
@@ -799,8 +791,9 @@ end
         @test getMZ(restrictive_simple_frags[1]) ≈ 400.0
         @test getPrecID(restrictive_simple_frags[1]) == 2
         
-        # Test with rank limits
-        # Create a large number of identical fragments
+        # Rank cap: getSimpleFrags hardcodes max_rank=8 (UInt8 bitmask).
+        # Feed 10 candidate fragments and confirm only the first 8 are emitted
+        # with bitmask scores 1<<0 .. 1<<7.
         n_test_frags = 10
         large_frag_mz = repeat(Float32[100.0], n_test_frags)
         large_frag_is_y = repeat([true], n_test_frags)
@@ -812,13 +805,10 @@ end
         large_frag_internal = repeat([false], n_test_frags)
         large_frag_immonium = repeat([false], n_test_frags)
         large_frag_neutral_diff = repeat([false], n_test_frags)
-        
+
         # All fragments belong to same precursor
         large_prec_to_frag_idx = UInt64[1, n_test_frags+1]
-        
-        # Small rank_to_score array to test rank limiting
-        small_rank_to_score = UInt8[10, 9, 8]
-        
+
         rank_limited_frags = getSimpleFrags(
             large_frag_mz,
             large_frag_is_y,
@@ -843,16 +833,13 @@ end
             include_neutral_diff,
             max_frag_charge,
             frag_bounds,
-            small_rank_to_score     # Only allow 3 ranks
         )
-        
-        # Should only return 3 fragments due to rank limit
-        @test length(rank_limited_frags) == 3
-        
-        # Bitmask scores: rank N → 1 << (N-1)
-        @test getScore(rank_limited_frags[1]) == UInt8(1)  # 1 << 0
-        @test getScore(rank_limited_frags[2]) == UInt8(2)  # 1 << 1
-        @test getScore(rank_limited_frags[3]) == UInt8(4)  # 1 << 2
+
+        # 8-rank cap (one bit per rank in the UInt8 score)
+        @test length(rank_limited_frags) == 8
+        for r in 1:8
+            @test getScore(rank_limited_frags[r]) == UInt8(1) << UInt8(r - 1)
+        end
     end
     
     #==========================================================================

--- a/test/integration/build_ecoli.json
+++ b/test/integration/build_ecoli.json
@@ -16,7 +16,6 @@
     "library_params": {
         "rt_bin_tol": 1.0,
         "frag_bin_tol_ppm": 10.0,
-        "rank_to_score": [8, 4, 4, 2, 2, 1, 1],
         "y_start_index": 4,
         "b_start_index": 3,
         "y_start": 3,

--- a/test/integration/build_keap1.json
+++ b/test/integration/build_keap1.json
@@ -50,7 +50,6 @@
     "include_internal": false,
     "include_immonium": false,
     "include_neutral_diff": true,
-    "rank_to_score": [8, 4, 4, 2, 2, 1, 1],
     "y_start_index": 4,
     "b_start_index": 3,
     "y_start": 3,

--- a/test/runtests_part2_units.jl
+++ b/test/runtests_part2_units.jl
@@ -43,6 +43,9 @@ include("./UnitTests/LogTruncationTests.jl")
 
 include("./UnitTests/test_counter.jl")
 
+# ParameterTuningSearch — Lipschitz step cap regression
+include("./Routines/SearchDIA/SearchMethods/ParameterTuningSearch/test_intensity_spline_lipschitz.jl")
+
 # Coverage data is normally flushed to .cov files by an atexit hook
 # that `_exit` skips. Flush it explicitly before terminating, otherwise
 # `--code-coverage=...` produces zero output and codecov reports 0%.


### PR DESCRIPTION
## Summary

- Cap projected-gradient-descent step size by `min(lr, 1.8/opnorm(H))` in the three spline fits inside `ParameterTuningSearch/fit_intensity_mass_error.jl` (convex bias, monotone bias, monotone-convex spread). Fixes Dennis's `ArgumentError: matrix contains Infs or NaNs` from LAPACK `getrf!` on large training sets — fixed `lr=1e-4` exceeded `2/L` past ~220k points, so the optimizer diverged and the next IRLS iteration's LU factorization tripped on Inf/NaN coefficients.
- Remove `rank_to_score` everywhere. The fragment-index builders score each fragment as `1 << (rank-1)` (a per-rank bitmask) and the search-time accumulator is bitwise OR; values in `rank_to_score` were never consulted past `length()`, so `[8,4,4,2,2,1,1]` and `[1,1,1,1,1,1,1,1]` differed only by 7 vs 8 indexed ranks. Cap is now hardcoded to 8 (the UInt8 width).
- README codecov badge now tracks `develop`.

## Test plan
- [x] New regression test (`test_intensity_spline_lipschitz.jl`) exercises 300k synthetic points and asserts finite spline coefficients; wired into `runtests_part2_units.jl`. Local run: 6/6 pass.
- [x] `BuildPionLibTest.jl` updated for the new `getSimpleFrags`/`buildPionLib` signatures and the hardcoded 8-rank cap. Local run: 67/67 pass.
- [ ] CI: full test suite on develop branch.
- [ ] Smoke test on Dennis's 3P-Astral and yeast datasets to confirm parameter tuning no longer throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)