### PR TITLE
Keep decoys through protein scoring; suppress only at output

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
@@ -52,7 +52,6 @@ struct IntegrateChromatogramSearchParameters{P<:PrecEstimation, I<:IsotopeTraceT
 
     # Chromatogram parameters
     wh_smoothing_strength::Float32
-    write_decoys::Bool
 
     # Deconvolution parameters (MS2)
     lambda::Float32
@@ -68,7 +67,6 @@ struct IntegrateChromatogramSearchParameters{P<:PrecEstimation, I<:IsotopeTraceT
     function IntegrateChromatogramSearchParameters(params::PioneerParameters)
         # Extract relevant parameter groups
         search_params = params.search
-        output_params = params.output
 
         # Hardcoded — formerly read from global.isotope_settings (removed from
         # the public schema; values shipped at defaults in every config).
@@ -92,7 +90,6 @@ struct IntegrateChromatogramSearchParameters{P<:PrecEstimation, I<:IsotopeTraceT
             Set{Int64}([2]),
 
             Float32(1e-6),    # wh_smoothing_strength
-            Bool(output_params.write_decoys),
 
             Float32(0.0),     # lambda (no regularization)
             NoNorm(),         # reg_type
@@ -145,13 +142,11 @@ function process_file!(
         DataFrame(Arrow.Table(rt_index_path)),
         bin_rt_size = 0.1)
 
-    # Load PSMs that passed previous filtering steps
+    # Load PSMs that passed previous filtering steps. Decoys are intentionally
+    # kept here — ProteinInferenceSearch and ProteinScoringSearch need them
+    # for protein-level FDR / PEP calibration. Final decoy suppression for
+    # output happens later in MaxLFQSearch when output.write_decoys=false.
     passing_psms = DataFrame(Tables.columntable(Arrow.Table(passing_psms_path)))
-
-    # Keep only target (non-decoy) PSMs
-    if !params.write_decoys
-        filter!(row -> row.target, passing_psms)
-    end
 
     # If there are no PSMs to integrate (e.g. sparse / empty file), skip
     # chromatogram extraction entirely. Downstream steps treat an empty


### PR DESCRIPTION
## Summary

- IntegrateChromatogramsSearch was filtering decoy PSMs when \`output.write_decoys=false\`, but that step runs **before** ProteinInferenceSearch and ProteinScoringSearch — so protein-level FDR/PEP calibration was left with zero decoy proteins, producing the symptom \`"PEP interpolation: only 1 unique score points — using flat default"\`.
- The correct late-stage decoy filter already lives in MaxLFQSearch (\`MaxLFQSearch.jl:183-187\`). Removing the early filter is the entire fix — decoys now flow through chromatogram integration and protein scoring, then get suppressed for final output writing.
- Drops the now-unused \`write_decoys\` field on \`IntegrateChromatogramSearchParameters\` and the orphaned \`output_params\` binding.

## Test plan
- [x] Integration test (\`SearchDIA(test/integration/search_ecoli.json)\`) still produces 2331 precursors / 1266 protein groups end-to-end with no new warnings — and crucially no PEP-interpolation warning.
- [ ] Re-run on the full Eclipse / Astral / yeast configs to confirm the warning is gone there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)