### PR TITLE
Expand unit-test coverage on low-coverage modules

### DIFF
--- a/src/utils/ML/probitRegression.jl
+++ b/src/utils/ML/probitRegression.jl
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-function fillZandW!(Z::Vector{T}, W::Vector{T}, η::Vector{T}, y::Vector{Bool},data_chunks::Base.Iterators.PartitionIterator{UnitRange{Int64}}) where {T<:AbstractFloat}
+function fillZandW!(Z::Vector{T}, W::Vector{T}, η::Vector{T}, y::AbstractVector{Bool}, data_chunks::Base.Iterators.PartitionIterator{UnitRange{Int64}}) where {T<:AbstractFloat}
     tasks = map(data_chunks) do chunk
     #@inbounds @fastmath begin
     Threads.@spawn begin
@@ -139,7 +139,7 @@ end
 function loglikelihood!(tmpη::Vector{T},
                         X::DataFrame,
                         β::Vector{T},
-                        y::Vector{Bool},
+                        y::AbstractVector{Bool},
                         bounds::Tuple{T,T},
                         data_chunks::Base.Iterators.PartitionIterator{UnitRange{Int64}}) where {T<:AbstractFloat}
     fillη!(tmpη, X, β, bounds, data_chunks)
@@ -156,8 +156,8 @@ function loglikelihood!(tmpη::Vector{T},
     return sum(fetch.(tasks))
 end
 
-function ProbitRegression(β::Vector{T}, X::DataFrame, y::Vector{Bool},
-                            data_chunks::Base.Iterators.PartitionIterator{UnitRange{Int64}}; 
+function ProbitRegression(β::Vector{T}, X::DataFrame, y::AbstractVector{Bool},
+                            data_chunks::Base.Iterators.PartitionIterator{UnitRange{Int64}};
                             max_iter::Int = 30, z_score_bounds::Tuple{Float64, Float64} = (-8.0, 8.0),
                             tol::T = T(1e-2),
                             step_size::T = one(T)

--- a/test/UnitTests/test_mass_error_model.jl
+++ b/test/UnitTests/test_mass_error_model.jl
@@ -1,0 +1,247 @@
+# Tests for SimpleMassErrorModel, LinearDaMassErrorModel, and
+# LinearBiasPpmTolMassErrorModel in src/structs/MassErrorModel.jl.
+#
+# Targets the getter / corrected-mz / bounds API including:
+# - asymmetric Simple model (left ≠ right) and the reverse-swap semantics
+#   of getMzBoundsReverse
+# - degenerate zero-bias / zero-tolerance models
+# - 3-arg forwarding (intensity-aware overload that ignores intensity)
+# - getCorrectedMzAndBounds internal consistency
+# - the Linear* models' Laplace log-density fallbacks
+
+using Pioneer: SimpleMassErrorModel, LinearDaMassErrorModel,
+               LinearBiasPpmTolMassErrorModel,
+               getRightTol, getLeftTol, getMassOffset, getMassCorrection,
+               getCorrectedMz, getMzBounds, getMzBoundsReverse,
+               getCorrectedMzAndBounds, laplace_log_density,
+               get_default_top3_ll
+
+@testset "MassErrorModel" begin
+
+    @testset "SimpleMassErrorModel" begin
+        @testset "symmetric ±10 ppm, zero bias" begin
+            mem = SimpleMassErrorModel(0.0f0, (10.0f0, 10.0f0))
+            @test getLeftTol(mem) == 10.0f0
+            @test getRightTol(mem) == 10.0f0
+            @test getMassOffset(mem) == 0.0f0
+            @test getMassCorrection(mem) == 0.0f0
+            @test getCorrectedMz(mem, 1000.0f0) == 1000.0f0
+            # Zero bias → 3-arg matches 2-arg
+            @test getCorrectedMz(mem, 1000.0f0, 0.5f0) == getCorrectedMz(mem, 1000.0f0)
+
+            low, high = getMzBounds(mem, 1000.0f0)
+            @test low ≈ 1000.0f0 - 0.01f0   # 10 ppm at 1000 = 0.01
+            @test high ≈ 1000.0f0 + 0.01f0
+            # Symmetric → forward and reverse identical
+            @test getMzBoundsReverse(mem, 1000.0f0) == getMzBounds(mem, 1000.0f0)
+        end
+
+        @testset "asymmetric tolerance: reverse swaps left/right" begin
+            # left = 20 ppm (empirical can be 20 ppm BELOW theoretical)
+            # right = 5 ppm (empirical can be 5 ppm ABOVE theoretical)
+            mem = SimpleMassErrorModel(0.0f0, (20.0f0, 5.0f0))
+            @test getLeftTol(mem) == 20.0f0
+            @test getRightTol(mem) == 5.0f0
+
+            # Forward: empirical bounds for theoretical = 1000.
+            # Empirical ∈ (theoretical - left*ppm, theoretical + right*ppm)
+            low, high = getMzBounds(mem, 1000.0f0)
+            @test low  ≈ 1000.0f0 - 0.020f0   # 20 ppm
+            @test high ≈ 1000.0f0 + 0.005f0   # 5 ppm
+
+            # Reverse: theoretical bounds for empirical = 1000.
+            # Theoretical ∈ (empirical - right*ppm, empirical + left*ppm)
+            rlow, rhigh = getMzBoundsReverse(mem, 1000.0f0)
+            @test rlow  ≈ 1000.0f0 - 0.005f0   # right swap
+            @test rhigh ≈ 1000.0f0 + 0.020f0   # left swap
+
+            # If we feed the high end of the forward bound back through reverse,
+            # we should bracket the original theoretical (≤ on the lower edge —
+            # the round-trip can land exactly at 1000.0 in Float32).
+            rlow2, rhigh2 = getMzBoundsReverse(mem, high)
+            @test rlow2 ≤ 1000.0f0 ≤ rhigh2
+        end
+
+        @testset "non-zero bias correction" begin
+            # +5 ppm bias: corrected = mz - 5 * mz/1e6
+            mem = SimpleMassErrorModel(5.0f0, (10.0f0, 10.0f0))
+            @test getMassOffset(mem) == 5.0f0
+            corrected = getCorrectedMz(mem, 1000.0f0)
+            @test corrected ≈ 1000.0f0 - 0.005f0
+            @test corrected < 1000.0f0  # positive bias drags corrected down
+
+            # Negative bias: corrected drifts up
+            mem_neg = SimpleMassErrorModel(-7.5f0, (10.0f0, 10.0f0))
+            corrected_neg = getCorrectedMz(mem_neg, 1000.0f0)
+            @test corrected_neg ≈ 1000.0f0 + 0.0075f0
+            @test corrected_neg > 1000.0f0
+        end
+
+        @testset "zero-tolerance: bounds collapse to point" begin
+            mem = SimpleMassErrorModel(0.0f0, (0.0f0, 0.0f0))
+            low, high = getMzBounds(mem, 500.0f0)
+            @test low == high == 500.0f0
+            rlow, rhigh = getMzBoundsReverse(mem, 500.0f0)
+            @test rlow == rhigh == 500.0f0
+        end
+
+        @testset "very small and very large mz" begin
+            mem = SimpleMassErrorModel(0.0f0, (10.0f0, 10.0f0))
+            for mz in (Float32(50), Float32(100), Float32(2000))
+                low, high = getMzBounds(mem, mz)
+                @test low < mz < high
+                # Compare against the function's exact computation (avoid
+                # subtraction rounding near magnitudes ≫ tolerance).
+                ppm = 10.0f0 * (mz / 1f6)
+                @test high == Float32(mz + ppm)
+                @test low  == Float32(mz - ppm)
+            end
+        end
+
+        @testset "getCorrectedMzAndBounds: internal consistency" begin
+            mem = SimpleMassErrorModel(3.0f0, (15.0f0, 8.0f0))
+            corrected, low, high = getCorrectedMzAndBounds(mem, 800.0f0, 0.0f0)
+            @test corrected == getCorrectedMz(mem, 800.0f0)
+            expected_low, expected_high = getMzBoundsReverse(mem, corrected)
+            @test low == expected_low
+            @test high == expected_high
+        end
+
+        @testset "3-arg forwarding ignores intensity argument" begin
+            mem = SimpleMassErrorModel(2.5f0, (12.0f0, 9.0f0))
+            mz = 750.0f0
+            @test getCorrectedMz(mem, mz, 0.1f0) == getCorrectedMz(mem, mz, 1.0f6)
+            @test getCorrectedMz(mem, mz, 0.0f0) == getCorrectedMz(mem, mz)
+            @test getMzBoundsReverse(mem, mz, 5.0f0) == getMzBoundsReverse(mem, mz)
+        end
+    end
+
+    @testset "LinearDaMassErrorModel" begin
+        @testset "zero coefficients = identity correction" begin
+            m = LinearDaMassErrorModel(0.0f0, 0.0f0, 0.005f0)
+            @test getCorrectedMz(m, 1000.0f0) == 1000.0f0
+            @test getMassOffset(m) == 0.0f0
+            @test getMassCorrection(m) == 0.0f0
+            @test getRightTol(m) == 0.005f0
+            @test getLeftTol(m) == 0.005f0
+            low, high = getMzBounds(m, 1000.0f0)
+            @test low  == 1000.0f0 - 0.005f0
+            @test high == 1000.0f0 + 0.005f0
+            # LinearDa is symmetric → forward == reverse
+            @test getMzBoundsReverse(m, 1000.0f0) == getMzBounds(m, 1000.0f0)
+        end
+
+        @testset "intercept-only bias" begin
+            m = LinearDaMassErrorModel(0.01f0, 0.0f0, 0.001f0)
+            # corrected = mz - (0.01 + 0)
+            @test getCorrectedMz(m, 1000.0f0) ≈ 999.99f0
+        end
+
+        @testset "intercept + slope: full linear correction" begin
+            # bias_da(mz) = 0.001 + 0.000002 * mz
+            m = LinearDaMassErrorModel(0.001f0, 2.0f-6, 0.002f0)
+            mz = 500.0f0
+            expected_bias = 0.001f0 + 2.0f-6 * mz
+            @test getCorrectedMz(m, mz) ≈ mz - expected_bias
+
+            # Verify slope contribution scales with mz
+            high_mz_bias = 0.001f0 + 2.0f-6 * 2000.0f0
+            @test getCorrectedMz(m, 2000.0f0) ≈ 2000.0f0 - high_mz_bias
+            # Difference between mz=500 and mz=2000 corrected should reflect slope
+            @test (2000.0f0 - getCorrectedMz(m, 2000.0f0)) -
+                  (500.0f0 - getCorrectedMz(m, 500.0f0)) ≈ 2.0f-6 * (2000.0f0 - 500.0f0) atol=1f-5
+        end
+
+        @testset "tolerance is constant Da regardless of mz" begin
+            m = LinearDaMassErrorModel(0.0f0, 0.0f0, 0.003f0)
+            for mz in Float32[150, 500, 1000, 2000]
+                low, high = getMzBounds(m, mz)
+                # Bounds match the function's Float32 computation exactly;
+                # don't try to reconstruct the tolerance via subtraction (rounding).
+                @test high == Float32(mz + 0.003f0)
+                @test low  == Float32(mz - 0.003f0)
+            end
+        end
+
+        @testset "getCorrectedMzAndBounds: corrected propagates to bounds" begin
+            m = LinearDaMassErrorModel(0.005f0, 1.0f-6, 0.002f0)
+            corrected, low, high = getCorrectedMzAndBounds(m, 1500.0f0, 0.0f0)
+            @test corrected == getCorrectedMz(m, 1500.0f0)
+            expected_low, expected_high = getMzBoundsReverse(m, corrected)
+            @test low == expected_low
+            @test high == expected_high
+            # (Width = 2 × tolerance_da is implied by the equality checks above;
+            #  computing high - low directly loses precision in Float32 at the
+            #  ~1500 mass scale.)
+        end
+
+        @testset "Laplace log-density and top3 fallbacks return zero" begin
+            m = LinearDaMassErrorModel(0.0f0, 0.0f0, 0.001f0)
+            @test laplace_log_density(m, 1000.0f0, 0.5f0, 0.001f0) == 0.0f0
+            @test get_default_top3_ll(m) == 0.0f0
+        end
+
+        @testset "3-arg forwarding ignores intensity" begin
+            m = LinearDaMassErrorModel(0.001f0, 0.0f0, 0.002f0)
+            @test getCorrectedMz(m, 1000.0f0, 0.5f0) == getCorrectedMz(m, 1000.0f0)
+            @test getMzBoundsReverse(m, 1000.0f0, 0.5f0) == getMzBoundsReverse(m, 1000.0f0)
+        end
+    end
+
+    @testset "LinearBiasPpmTolMassErrorModel" begin
+        @testset "zero coefficients, ±10 ppm tolerance" begin
+            m = LinearBiasPpmTolMassErrorModel(0.0f0, 0.0f0, 10.0f0)
+            @test getCorrectedMz(m, 1000.0f0) == 1000.0f0
+            @test getMassOffset(m) == 0.0f0
+            @test getMassCorrection(m) == 0.0f0
+            @test getRightTol(m) == 10.0f0
+            @test getLeftTol(m) == 10.0f0
+
+            low, high = getMzBounds(m, 1000.0f0)
+            @test low  ≈ 1000.0f0 - 0.010f0
+            @test high ≈ 1000.0f0 + 0.010f0
+            # Symmetric → forward == reverse
+            @test getMzBoundsReverse(m, 1000.0f0) == getMzBounds(m, 1000.0f0)
+        end
+
+        @testset "linear bias correction with ppm tolerance" begin
+            m = LinearBiasPpmTolMassErrorModel(0.002f0, 5.0f-7, 8.0f0)
+            # Correction matches LinearDa formula
+            @test getCorrectedMz(m, 1000.0f0) ≈ 1000.0f0 - (0.002f0 + 5.0f-7 * 1000.0f0)
+            # Tolerance scales with mz (ppm semantics). Compare against the
+            # function's exact Float32 expression to avoid subtraction rounding.
+            for mz in Float32[200, 500, 1500]
+                low, high = getMzBounds(m, mz)
+                hw = 8.0f0 * (mz / 1f6)
+                @test high == Float32(mz + hw)
+                @test low  == Float32(mz - hw)
+            end
+        end
+
+        @testset "getCorrectedMzAndBounds: bounds based on corrected mass" begin
+            m = LinearBiasPpmTolMassErrorModel(0.001f0, 1.0f-6, 12.0f0)
+            corrected, low, high = getCorrectedMzAndBounds(m, 1000.0f0, 0.0f0)
+            @test corrected == getCorrectedMz(m, 1000.0f0)
+            expected_low, expected_high = getMzBoundsReverse(m, corrected)
+            @test low == expected_low
+            @test high == expected_high
+            # The bounds are ±12 ppm of CORRECTED mass, not of input.
+            hw = 12.0f0 * (corrected / 1f6)
+            @test high == Float32(corrected + hw)
+            @test low  == Float32(corrected - hw)
+        end
+
+        @testset "Laplace log-density and top3 fallbacks return zero" begin
+            m = LinearBiasPpmTolMassErrorModel(0.0f0, 0.0f0, 10.0f0)
+            @test laplace_log_density(m, 1000.0f0, 0.5f0, 0.001f0) == 0.0f0
+            @test get_default_top3_ll(m) == 0.0f0
+        end
+
+        @testset "3-arg forwarding ignores intensity" begin
+            m = LinearBiasPpmTolMassErrorModel(0.0005f0, 0.0f0, 6.0f0)
+            @test getCorrectedMz(m, 1000.0f0, 0.5f0) == getCorrectedMz(m, 1000.0f0)
+            @test getMzBoundsReverse(m, 1000.0f0, 0.5f0) == getMzBoundsReverse(m, 1000.0f0)
+        end
+    end
+
+end

--- a/test/UnitTests/test_parse_mods.jl
+++ b/test/UnitTests/test_parse_mods.jl
@@ -1,0 +1,312 @@
+# Tests for src/Routines/BuildSpecLib/utils/parse_mods.jl. The functions here
+# parse the (pos,aa,mod_name) modification strings that drive precursor and
+# fragment m/z calculation; bugs surface as wrong masses everywhere
+# downstream. Targets the difficult / edge-case paths:
+# - empty / one-mod / multi-mod strings
+# - n- and c-terminal mods (regex must accept lowercase n/c)
+# - unknown mod names (silently skipped, not crash)
+# - shared structural-mod names across iso channels
+# - reverseSequence preserves first/last positions and relocates internal mods
+# - sulfur-count modifications (positive and negative deltas)
+
+using Pioneer: get_aa_masses!, get_structural_mod_masses!, getIsoModMasses!,
+               get_sulfur_counts!, get_fragment_mz, get_precursor_mz,
+               reverseSequence
+using Pioneer: AA_to_mass, H2O, PROTON
+
+@testset "parse_mods" begin
+
+    @testset "get_aa_masses!" begin
+        @testset "all 20 standard amino acids" begin
+            seq = "ACDEFGHIKLMNPQRSTVWY"
+            buf = zeros(Float32, length(seq))
+            get_aa_masses!(buf, seq)
+            for (i, aa) in enumerate(seq)
+                @test buf[i] == Float32(AA_to_mass[aa])
+            end
+        end
+
+        @testset "buffer is reset to zero before fill" begin
+            buf = ones(Float32, 5)
+            get_aa_masses!(buf, "AAAAA")
+            @test all(buf .== Float32(AA_to_mass['A']))
+            # Now fill with shorter sequence (only 3 chars touched in iter)
+            buf2 = ones(Float32, 5)
+            get_aa_masses!(buf2, "GGG")
+            @test buf2[1] == buf2[2] == buf2[3] == Float32(AA_to_mass['G'])
+            @test buf2[4] == 0.0f0
+            @test buf2[5] == 0.0f0
+        end
+
+        @testset "accepts SubString" begin
+            full = "PEPTIDE"
+            sub = SubString(full, 1, 4)   # "PEPT"
+            buf = zeros(Float32, 4)
+            get_aa_masses!(buf, sub)
+            @test buf[1] == Float32(AA_to_mass['P'])
+            @test buf[4] == Float32(AA_to_mass['T'])
+        end
+    end
+
+    @testset "get_structural_mod_masses!" begin
+        mod_to_mass = Dict{String, Float32}(
+            "Phospho" => 79.96633f0,
+            "Acetyl"  => 42.01057f0,
+            "Carbamidomethyl" => 57.021464f0,
+            "Oxidation" => 15.99491f0,
+        )
+
+        @testset "empty mod string is a no-op" begin
+            buf = ones(Float32, 7)   # initialized to 1 to verify reset
+            get_structural_mod_masses!(buf, "", mod_to_mass)
+            @test all(buf .== 0.0f0)
+        end
+
+        @testset "single mod placed at correct index" begin
+            buf = zeros(Float32, 7)
+            get_structural_mod_masses!(buf, "(4,T,Phospho)", mod_to_mass)
+            @test buf[4] == 79.96633f0
+            @test count(==(0.0f0), buf) == 6
+        end
+
+        @testset "multiple mods including n-terminal" begin
+            buf = zeros(Float32, 7)
+            get_structural_mod_masses!(
+                buf,
+                "(1,n,Acetyl)(3,C,Carbamidomethyl)(7,M,Oxidation)",
+                mod_to_mass)
+            @test buf[1] == 42.01057f0
+            @test buf[3] == 57.021464f0
+            @test buf[7] == 15.99491f0
+            @test buf[2] == buf[4] == buf[5] == buf[6] == 0.0f0
+        end
+
+        @testset "unknown mod names are silently skipped" begin
+            buf = zeros(Float32, 5)
+            get_structural_mod_masses!(buf,
+                "(2,P,NotAMod)(4,T,Phospho)", mod_to_mass)
+            @test buf[2] == 0.0f0   # NotAMod skipped
+            @test buf[4] == 79.96633f0
+        end
+    end
+
+    @testset "getIsoModMasses!" begin
+        iso_mods_dict = Dict{String, Dict{String, Float32}}(
+            "exTag1" => Dict("d0" => 0.0f0, "d4" => 4.0f0,  "d8" => 8.0f0),
+            "exTag3" => Dict("d0" => 0.0f0, "d4" => 4.0f0),
+        )
+
+        @testset "empty structural OR isotopic string is a no-op" begin
+            buf = ones(Float32, 8)   # verify reset to zero
+            getIsoModMasses!(buf, "", "(1, d4)", iso_mods_dict)
+            @test all(buf .== 0.0f0)
+
+            buf = ones(Float32, 8)
+            getIsoModMasses!(buf, "(3,K,exTag1)", "", iso_mods_dict)
+            @test all(buf .== 0.0f0)
+        end
+
+        @testset "iso index points into structural mod sequence" begin
+            buf = zeros(Float32, 7)
+            getIsoModMasses!(buf,
+                "(1,I,exTag1)(5,L,exTag3)(7,K,exTag1)",
+                "(3, d4)",   # third mod (position 7) gets d4
+                iso_mods_dict)
+            @test buf[7] == 4.0f0
+            @test all(buf[1:6] .== 0.0f0)
+        end
+
+        @testset "n-terminal and c-terminal structural mods are indexable" begin
+            buf = zeros(Float32, 16)
+            getIsoModMasses!(buf,
+                "(1,n,exTag1)(5,L,exTag3)(16,c,exTag1)",
+                "(1, d0)(2, d4)(3, d8)",
+                iso_mods_dict)
+            @test buf[1]  == 0.0f0   # exTag1 d0 = 0
+            @test buf[5]  == 4.0f0   # exTag3 d4 = 4
+            @test buf[16] == 8.0f0   # exTag1 d8 = 8
+        end
+
+        @testset "out-of-range iso index is silently skipped" begin
+            buf = zeros(Float32, 5)
+            # Only 1 structural mod, but iso refers to index 3
+            getIsoModMasses!(buf,
+                "(2,K,exTag1)",
+                "(3, d4)",
+                iso_mods_dict)
+            @test all(buf .== 0.0f0)
+
+            # Index 0 also out of range
+            buf2 = zeros(Float32, 5)
+            getIsoModMasses!(buf2,
+                "(2,K,exTag1)",
+                "(0, d4)",
+                iso_mods_dict)
+            @test all(buf2 .== 0.0f0)
+        end
+
+        @testset "unknown channel for known mod silently skipped" begin
+            buf = zeros(Float32, 5)
+            getIsoModMasses!(buf,
+                "(2,K,exTag1)",
+                "(1, d99)",   # d99 not in iso_mods_dict["exTag1"]
+                iso_mods_dict)
+            @test all(buf .== 0.0f0)
+        end
+
+        @testset "structural mod with name not in iso dict is excluded from indexing" begin
+            # If a structural mod's name has no entry in iso_mods_dict, it should
+            # not consume an iso-index slot.
+            buf = zeros(Float32, 7)
+            # Two structural mods: first not in iso dict, second is.
+            # Iso index 1 should map to the FIRST mod that *is* in the iso dict
+            # (since the unknown one was filtered out).
+            getIsoModMasses!(buf,
+                "(2,K,Carbamidomethyl)(5,K,exTag1)",
+                "(1, d4)",
+                iso_mods_dict)
+            @test buf[5] == 4.0f0
+            @test buf[2] == 0.0f0
+        end
+    end
+
+    @testset "get_sulfur_counts!" begin
+        mods_to_sulfur = Dict{String, Int8}(
+            "Carbamidomethyl" => Int8(0),  # adds C to side chain but on existing S, net 0
+            "DiSulfide"       => Int8(2),
+            "Loss"            => Int8(-1),
+        )
+
+        @testset "sequence-only sulfurs (C and M)" begin
+            buf = zeros(Int8, 7)
+            get_sulfur_counts!(buf, "ACMSTCM", "", mods_to_sulfur)
+            @test buf == Int8[0, 1, 1, 0, 0, 1, 1]
+        end
+
+        @testset "no C/M, no mods → all zero" begin
+            buf = zeros(Int8, 5)
+            get_sulfur_counts!(buf, "GAGAG", "", mods_to_sulfur)
+            @test all(buf .== Int8(0))
+        end
+
+        @testset "modification adds sulfur" begin
+            buf = zeros(Int8, 5)
+            get_sulfur_counts!(buf, "GAGAG", "(2,A,DiSulfide)", mods_to_sulfur)
+            @test buf == Int8[0, 2, 0, 0, 0]
+        end
+
+        @testset "modification removes sulfur (negative delta)" begin
+            buf = zeros(Int8, 4)
+            # M at position 2 contributes 1; Loss subtracts 1 → net 0.
+            get_sulfur_counts!(buf, "AMAA", "(2,M,Loss)", mods_to_sulfur)
+            @test buf == Int8[0, 0, 0, 0]
+        end
+
+        @testset "buffer is reset to zero before fill" begin
+            buf = fill(Int8(99), 5)
+            get_sulfur_counts!(buf, "GAGAG", "", mods_to_sulfur)
+            @test all(buf .== Int8(0))
+        end
+    end
+
+    @testset "get_fragment_mz / get_precursor_mz" begin
+        # Use a known peptide: PEPTIDE, no mods.
+        # Sum of monoisotopic AA residue masses for PEPTIDE:
+        seq = "PEPTIDE"
+        aa_masses = zeros(Float32, length(seq))
+        get_aa_masses!(aa_masses, seq)
+        struct_mods = zeros(Float32, length(seq))
+        iso_mods = zeros(Float32, length(seq))
+        residue_sum = sum(aa_masses)
+
+        @testset "precursor mz at +1 charge" begin
+            mz = get_precursor_mz(length(seq), UInt8(1),
+                                  aa_masses, struct_mods, iso_mods)
+            expected = residue_sum + Float32(H2O) + Float32(PROTON) * 1.0f0
+            @test mz ≈ expected
+        end
+
+        @testset "precursor mz scales with charge as (M + zH) / z" begin
+            mz1 = get_precursor_mz(length(seq), UInt8(1),
+                                   aa_masses, struct_mods, iso_mods)
+            mz2 = get_precursor_mz(length(seq), UInt8(2),
+                                   aa_masses, struct_mods, iso_mods)
+            mz3 = get_precursor_mz(length(seq), UInt8(3),
+                                   aa_masses, struct_mods, iso_mods)
+            # M+H = mz1; M+2H = 2*mz2; M+3H = 3*mz3 — all should differ by H mass each
+            M = mz1 - Float32(PROTON)
+            @test 2 * mz2 - 2 * Float32(PROTON) ≈ M atol=1f-3
+            @test 3 * mz3 - 3 * Float32(PROTON) ≈ M atol=1f-3
+        end
+
+        @testset "y-ion includes H2O, b-ion does not" begin
+            # y3 covers residues 5-7 (IDE), b3 covers residues 1-3 (PEP)
+            y3 = get_fragment_mz(5, 7, 'y', UInt8(1),
+                                 aa_masses, struct_mods, iso_mods)
+            b3 = get_fragment_mz(1, 3, 'b', UInt8(1),
+                                 aa_masses, struct_mods, iso_mods)
+            ide_residue = sum(aa_masses[5:7])
+            pep_residue = sum(aa_masses[1:3])
+            @test y3 ≈ ide_residue + Float32(H2O) + Float32(PROTON)
+            @test b3 ≈ pep_residue + Float32(PROTON)
+        end
+
+        @testset "fragment charge halves the m/z difference" begin
+            y3_z1 = get_fragment_mz(5, 7, 'y', UInt8(1),
+                                    aa_masses, struct_mods, iso_mods)
+            y3_z2 = get_fragment_mz(5, 7, 'y', UInt8(2),
+                                    aa_masses, struct_mods, iso_mods)
+            # M = y3_z1 - PROTON; y3_z2 = (M + 2*PROTON) / 2
+            M = y3_z1 - Float32(PROTON)
+            @test y3_z2 ≈ (M + 2 * Float32(PROTON)) / 2
+        end
+    end
+
+    @testset "reverseSequence" begin
+        @testset "no mods: keeps last residue, reverses prefix" begin
+            rev_seq, rev_mods = reverseSequence("PEPTIDE", "")
+            @test rev_seq == "DITPEPE"
+            @test rev_mods == ""
+        end
+
+        @testset "internal mod relocates by seq_length - pos" begin
+            rev_seq, rev_mods = reverseSequence("PEPTIDE", "(4,T,Phospho)")
+            @test rev_seq == "DITPEPE"
+            # pos 4 → new pos 7-4=3; rev_seq[3] = 'T'
+            @test rev_mods == "(3,T,Phospho)"
+        end
+
+        @testset "c-terminal mod (pos == seq_length) stays put" begin
+            rev_seq, rev_mods = reverseSequence("PEPTIDE", "(7,E,Acetyl)")
+            @test rev_seq == "DITPEPE"
+            @test rev_mods == "(7,E,Acetyl)"
+        end
+
+        @testset "n-terminal mod stays at pos 1" begin
+            rev_seq, rev_mods = reverseSequence("PEPTIDE", "(1,n,Acetyl)")
+            @test rev_seq == "DITPEPE"
+            @test rev_mods == "(1,n,Acetyl)"
+        end
+
+        @testset "mix of n-terminal, internal, c-terminal mods" begin
+            rev_seq, rev_mods = reverseSequence(
+                "PEPTIDE",
+                "(1,n,nterm)(1,P,internal)(4,T,Phospho)(7,E,Acetyl)(7,c,cterm)")
+            @test rev_seq == "DITPEPE"
+            # n-terminal stays at 1; (1,P,internal) → new pos 7-1=6, rev_seq[6]='P';
+            # (4,T,Phospho) → new pos 3; (7,E,Acetyl) stays at 7; (7,c,cterm) stays at 7
+            # Sorted by new position: 1, 3, 6, 7, 7
+            @test rev_mods == "(1,n,nterm)(3,T,Phospho)(6,P,internal)(7,E,Acetyl)(7,c,cterm)"
+        end
+
+        @testset "round-trip: reverse twice over rest gives original prefix" begin
+            # Reversing the prefix twice (last AA fixed both times) returns to the
+            # original sequence.
+            seq = "ACDEFGHIK"
+            once_seq, _ = reverseSequence(seq, "")
+            twice_seq, _ = reverseSequence(once_seq, "")
+            @test twice_seq == seq
+        end
+    end
+
+end

--- a/test/UnitTests/test_protein_model_fit.jl
+++ b/test/UnitTests/test_protein_model_fit.jl
@@ -1,0 +1,110 @@
+# Tests for src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/model_fit.jl.
+#
+# Targets the pure-numerics core that everything else in protein scoring
+# depends on:
+#   - fit_probit_model(X, y)         — argument validation + linear-separable recovery
+#   - calculate_probit_scores(X, β)  — Φ(β·x) per row, in [0,1]
+#   - end-to-end: fit then predict on linearly separable synthetic data,
+#     training accuracy ≥ 0.95
+#
+# Skipped here: fit_probit_model_semisupervised (multi-iteration logic,
+# intricate fixture), assign_protein_group_cv_folds!, apply_probit_scores_multifold!
+# (DataFrame plumbing).
+
+using DataFrames
+using Random
+using LinearAlgebra
+using Distributions: Normal, cdf
+
+using Pioneer: fit_probit_model, calculate_probit_scores
+
+@testset "ProteinScoring/model_fit pure-numerics" begin
+
+    @testset "fit_probit_model rejects empty feature matrix" begin
+        X = Matrix{Float64}(undef, 5, 0)
+        y = [true, false, true, false, true]
+        @test_throws ArgumentError fit_probit_model(X, y)
+    end
+
+    @testset "fit_probit_model recovers sign on linearly separable data" begin
+        # Single feature: positives have feature > 0, negatives < 0, well-separated.
+        rng = MersenneTwister(13)
+        n = 500
+        X = zeros(Float64, n, 1)
+        y = falses(n)
+        @inbounds for i in 1:n
+            is_pos = iseven(i)
+            y[i] = is_pos
+            X[i, 1] = is_pos ? 2.0 + 0.3 * randn(rng) : -2.0 + 0.3 * randn(rng)
+        end
+        β = fit_probit_model(X, y)
+        # β is [intercept; feature_1]
+        @test length(β) == 2
+        @test β[2] > 0   # positive class has higher feature value → positive coeff
+        @test all(isfinite, β)
+    end
+
+    @testset "calculate_probit_scores returns probabilities in [0,1]" begin
+        X = randn(MersenneTwister(0), 100, 3)
+        β = [0.1, 0.5, -0.3, 0.2]   # 1 intercept + 3 feature coeffs
+        probs = calculate_probit_scores(X, β)
+        @test length(probs) == 100
+        @test all(0.0 .≤ probs .≤ 1.0)
+    end
+
+    @testset "calculate_probit_scores matches Φ(β·x) on hand-picked rows" begin
+        # Construct a small example, compute Φ(β·x) directly, compare.
+        β = [0.5, 1.0, -2.0]   # intercept + 2 features
+        X = [
+            0.0  0.0;
+            1.0  1.0;
+           -1.0 -1.0;
+            2.0  0.0;
+        ]
+        probs = calculate_probit_scores(X, β)
+
+        d = Normal(0, 1)
+        for i in 1:size(X, 1)
+            xb = β[1] + β[2] * X[i, 1] + β[3] * X[i, 2]
+            @test probs[i] ≈ cdf(d, xb) atol=1f-6
+        end
+    end
+
+    @testset "fit + predict round-trip: training accuracy ≥ 0.95 on separable data" begin
+        rng = MersenneTwister(2026)
+        n = 600
+        # 2 features: positives are clustered around (1, 1), negatives around (-1, -1)
+        X = zeros(Float64, n, 2)
+        y = falses(n)
+        for i in 1:n
+            is_pos = rand(rng) > 0.5
+            y[i] = is_pos
+            μ = is_pos ? 1.0 : -1.0
+            X[i, 1] = μ + 0.5 * randn(rng)
+            X[i, 2] = μ + 0.5 * randn(rng)
+        end
+
+        β = fit_probit_model(X, y)
+        probs = calculate_probit_scores(X, β)
+
+        # Threshold at 0.5
+        preds = probs .> 0.5
+        accuracy = sum(preds .== y) / n
+        @test accuracy ≥ 0.95
+        # Both feature coefficients should be positive (positives have larger features)
+        @test β[2] > 0
+        @test β[3] > 0
+    end
+
+    @testset "calculate_probit_scores: extreme β values saturate near 0/1" begin
+        # All-positive features × large positive β → probs near 1
+        X = ones(Float64, 5, 1) .* 5.0
+        β_pos = [0.0, 10.0]
+        @test all(calculate_probit_scores(X, β_pos) .> 0.99)
+
+        # Same features × large negative β → probs near 0
+        β_neg = [0.0, -10.0]
+        @test all(calculate_probit_scores(X, β_neg) .< 0.01)
+    end
+
+end

--- a/test/UnitTests/test_quad_models_basic.jl
+++ b/test/UnitTests/test_quad_models_basic.jl
@@ -1,0 +1,101 @@
+# Lightweight tests for the small quad transmission model files and the
+# IsotopeTraceType abstraction. These are mostly trivial getter / dispatch
+# wrappers, but they ship at 0% coverage in the develop snapshot. The tests
+# below execute every public function in each file at least once and check
+# the documented invariants (NoQuad always returns 1.0; GeneralGauss decays
+# from 1.0 at center to <1.0 outside).
+
+using Pioneer: NoQuadModel, NoQuadFunction,
+               GeneralGaussModel, GeneralGaussFunction, GeneralGaussQuadParams,
+               getQuadTransmissionFunction, getQuadTransmissionBounds,
+               getPrecMinBound, getPrecMaxBound,
+               CombineTraces, SeperateTraces, seperateTraces, getPsmGroupbyCols
+
+@testset "Quad models — basic dispatch coverage" begin
+
+    @testset "NoQuadModel" begin
+        m = NoQuadModel(1.0f0)   # 1 Da overhang on each side
+        center = 500.0f0
+        width  = 4.0f0
+
+        bounds_low, bounds_high = getQuadTransmissionBounds(m, center, width)
+        @test bounds_low  ≈ 498.0f0
+        @test bounds_high ≈ 502.0f0
+        # Bounds are NOT influenced by overhang
+        @test (bounds_high - bounds_low) ≈ width
+
+        f = getQuadTransmissionFunction(m, center, width)
+        # The transmission FUNCTION incorporates the overhang on its mz limits
+        @test getPrecMinBound(f) ≈ 497.0f0   # 498 - 1
+        @test getPrecMaxBound(f) ≈ 503.0f0   # 502 + 1
+        # NoQuadFunction returns 1.0 for any input mz, regardless of position
+        for mz in (300.0f0, center, 700.0f0, -10.0f0)
+            @test f(mz) === one(typeof(mz))
+        end
+
+        @testset "Float64 type stability" begin
+            m64 = NoQuadModel(1.0)
+            f64 = getQuadTransmissionFunction(m64, 500.0, 4.0)
+            @test f64(500.0) === 1.0
+            @test getPrecMinBound(f64) ≈ 497.0
+        end
+    end
+
+    @testset "GeneralGaussModel" begin
+        m = GeneralGaussModel(2.0f0, 0.0f0)   # b=2, no overhang
+        center = 500.0f0
+        width  = 4.0f0
+
+        bounds_low, bounds_high = getQuadTransmissionBounds(m, center, width)
+        @test bounds_low  ≈ 498.0f0
+        @test bounds_high ≈ 502.0f0
+
+        f = getQuadTransmissionFunction(m, center, width)
+        @test getPrecMinBound(f) ≈ 498.0f0   # GG does NOT add overhang to bounds
+        @test getPrecMaxBound(f) ≈ 502.0f0
+
+        @testset "transmission peaks at center, decays outward" begin
+            t_center = f(center)
+            @test t_center ≈ 1.0f0
+            t_off1   = f(center + 0.5f0)
+            t_off2   = f(center + 1.5f0)
+            t_far    = f(center + 5.0f0)
+            # Strictly monotonic decay with |Δmz|
+            @test 1.0f0 ≥ t_center > t_off1 > t_off2 > t_far ≥ 0.0f0
+            # Mirror symmetry about center
+            @test f(center - 1.5f0) ≈ f(center + 1.5f0)
+        end
+
+        @testset "overhang shifts the transmission curve outward" begin
+            m_oh = GeneralGaussModel(2.0f0, 1.0f0)   # 1 Da overhang
+            f_oh = getQuadTransmissionFunction(m_oh, center, width)
+            # At the same off-center mz, more overhang → higher transmission
+            for delta in (1.0f0, 2.0f0, 3.0f0)
+                @test f_oh(center + delta) > f(center + delta)
+            end
+        end
+
+        @testset "GeneralGaussQuadParams direct call (covers the abs path)" begin
+            params = GeneralGaussQuadParams(2.0f0, 2.0f0, 0.0f0)
+            # Symmetric: same value for ±x
+            @test params(1.5f0) ≈ params(-1.5f0)
+            @test params(0.0f0) ≈ 1.0f0
+        end
+    end
+
+    @testset "IsotopeTraceType" begin
+        @testset "CombineTraces" begin
+            ct = CombineTraces(0.25f0)
+            @test seperateTraces(ct) == false
+            @test getPsmGroupbyCols(ct) == [:precursor_idx]
+            @test ct.min_ft == 0.25f0
+        end
+
+        @testset "SeperateTraces" begin
+            st = SeperateTraces()
+            @test seperateTraces(st) == true
+            @test getPsmGroupbyCols(st) == [:precursor_idx, :isotopes_captured]
+        end
+    end
+
+end

--- a/test/UnitTests/test_rt_alignment_utils.jl
+++ b/test/UnitTests/test_rt_alignment_utils.jl
@@ -1,0 +1,140 @@
+# Tests for src/Routines/SearchDIA/CommonSearchUtils/rt_alignment_utils.jl.
+#
+# Targets the three exported functions:
+# - fit_linear_irt_model: robust (Tukey-bisquare) linear regression for RT→iRT
+# - make_spline_monotonic: enforces monotonicity on a fitted spline via
+#   bidirectional cumulative-max from the median
+# - fit_irt_model: dispatches identity / linear / spline based on PSM count
+
+using DataFrames
+using Random
+
+using Pioneer: fit_linear_irt_model, make_spline_monotonic, fit_irt_model
+using Pioneer: LinearRtConversionModel, IdentityModel,
+               InterpolationRtConversionModel, RtConversionModel
+using Pioneer: UniformSpline
+
+@testset "rt_alignment_utils" begin
+
+    @testset "fit_linear_irt_model: clean linear recovers slope/intercept" begin
+        rt = Float32.(collect(1.0:0.5:50.0))
+        # iRT = 1.5 * RT + 10 (clean, no noise)
+        irt = Float32.(1.5f0 .* rt .+ 10.0f0)
+        psms = DataFrame(rt = rt, irt_predicted = irt)
+        model, residual_std, n_params = fit_linear_irt_model(psms)
+        @test model isa LinearRtConversionModel
+        @test n_params == 2
+        # Apply model — should match irt at sample points within tight tolerance
+        for r in rt[1:5:end]
+            @test model(r) ≈ 1.5f0 * r + 10.0f0 atol=1f-2
+        end
+        # Clean data → near-zero residual std
+        @test residual_std < 1f-2
+    end
+
+    @testset "fit_linear_irt_model: degenerate (all RTs identical)" begin
+        rt = fill(20.0f0, 10)
+        irt = Float32.(rand(MersenneTwister(7), 10) .* 100)
+        psms = DataFrame(rt = rt, irt_predicted = irt)
+        model, residual_std, n_params = fit_linear_irt_model(psms)
+        @test model isa LinearRtConversionModel
+        @test n_params == 2
+        # Slope must be 0 in the degenerate path; intercept ≈ mean(irt)
+        @test model(0.0f0) ≈ Float32(mean(irt)) atol=1f-3
+        # Residual std equals std(irt) per the degenerate-branch contract
+        @test residual_std ≈ Float32(std(irt)) atol=1f-3
+    end
+
+    @testset "fit_linear_irt_model: robust to outliers (5%)" begin
+        rng = MersenneTwister(2026)
+        rt = Float32.(collect(LinRange(1.0, 50.0, 200)))
+        irt = Float32.(2.0f0 .* rt .+ 5.0f0 .+ 0.5f0 .* randn(rng, length(rt)))
+        # Inject ~5% wild outliers
+        outlier_idx = sort!(randperm(rng, length(rt))[1:10])
+        irt[outlier_idx] .+= Float32.(rand(rng, [-200.0, 200.0], length(outlier_idx)))
+        psms = DataFrame(rt = rt, irt_predicted = irt)
+
+        model, residual_std, _ = fit_linear_irt_model(psms)
+        @test model isa LinearRtConversionModel
+        # Robust slope should still be close to 2.0 despite outliers; OLS would
+        # be pulled noticeably off.
+        # Recover slope from two well-spaced predictions.
+        slope_est = (model(40.0f0) - model(10.0f0)) / 30.0f0
+        @test slope_est ≈ 2.0f0 atol=0.1f0
+    end
+
+    @testset "make_spline_monotonic: enforces monotonicity on non-monotonic input" begin
+        # Build a spline whose raw output is non-monotonic by design (sinusoid
+        # over [0, 2π]).
+        rt = Float32.(collect(LinRange(0.0, 2π, 60)))
+        irt = Float32.(sin.(rt))
+        spline = UniformSpline(irt, rt, 3, 10)
+        @test minimum(diff(Float32[spline(r) for r in rt])) < 0   # confirm non-monotonic
+
+        mono = make_spline_monotonic(spline, rt, irt)
+        # Sample on the same grid; monotonic non-decreasing
+        sampled = Float32[mono(r) for r in rt]
+        @test all(diff(sampled) .≥ -1f-6)
+    end
+
+    @testset "make_spline_monotonic: already-monotonic spline preserved" begin
+        rt = Float32.(collect(LinRange(1.0, 50.0, 80)))
+        irt = Float32.(0.5f0 .* rt .+ 2.0f0)   # linear, already monotonic
+        spline = UniformSpline(irt, rt, 3, 8)
+
+        mono = make_spline_monotonic(spline, rt, irt)
+        sampled = Float32[mono(r) for r in rt]
+        @test all(diff(sampled) .≥ -1f-6)
+        # Output close to the original linear function on the interior
+        for r in rt[10:10:end-10]
+            @test mono(r) ≈ 0.5f0 * r + 2.0f0 atol=0.5f0
+        end
+    end
+
+    @testset "fit_irt_model: insufficient data → IdentityModel" begin
+        # min_psms default is 30; supply 10
+        rt = Float32.(collect(1.0:1.0:10.0))
+        irt = Float32.(rt .+ 1.0)
+        psms = DataFrame(rt = rt, irt_predicted = irt)
+        model, rt_out, irt_out, mad_out = fit_irt_model(psms; min_psms = 30)
+        @test model isa IdentityModel
+        @test isempty(rt_out)
+        @test isempty(irt_out)
+        @test mad_out == 0.0f0
+    end
+
+    @testset "fit_irt_model: small-dataset linear branch" begin
+        # 20 PSMs (≥min_psms=10 but <30) → linear branch
+        rt = Float32.(collect(1.0:1.0:20.0))
+        irt = Float32.(2.0f0 .* rt .+ 3.0f0)
+        psms = DataFrame(rt = rt, irt_predicted = irt)
+        model, rt_out, irt_out, mad_out = fit_irt_model(psms; min_psms = 10)
+        @test model isa LinearRtConversionModel
+        @test length(rt_out)  == 20
+        @test length(irt_out) == 20
+        @test mad_out ≥ 0.0f0
+        # Linear model should recover the slope on clean data
+        @test (model(15.0f0) - model(5.0f0)) / 10.0f0 ≈ 2.0f0 atol=0.1f0
+    end
+
+    @testset "fit_irt_model: many-PSM branch returns a callable RtConversionModel" begin
+        rng = MersenneTwister(99)
+        rt = Float32.(collect(LinRange(1.0, 60.0, 200)))
+        irt = Float32.(0.8f0 .* rt .+ 4.0f0 .+ 0.2f0 .* randn(rng, length(rt)))
+        psms = DataFrame(rt = rt, irt_predicted = irt)
+        model, rt_out, irt_out, mad_out = fit_irt_model(psms;
+            min_psms = 30, ransac_threshold = 1000)
+
+        @test model isa RtConversionModel
+        # rt_out and irt_out should match the input length (after outlier removal,
+        # most points retained for clean data); test for non-empty.
+        @test length(rt_out) > 50
+        @test length(irt_out) == length(rt_out)
+        @test mad_out ≥ 0.0f0
+        # Sanity: applying the model recovers the linear trend within ~5 iRT units
+        for r in rt[20:30:180]
+            @test abs(model(r) - (0.8f0 * r + 4.0f0)) ≤ 5.0f0
+        end
+    end
+
+end

--- a/test/UnitTests/test_scoring_workspace_coverage.jl
+++ b/test/UnitTests/test_scoring_workspace_coverage.jl
@@ -1,0 +1,353 @@
+# Coverage tests for src/utils/ML/PSMScoring/workspace.jl.
+#
+# Targets the in-memory + Arrow-file scoring workspaces:
+# - InMemoryScoringWorkspace fold / train index pre-computation
+# - prepare_training_data! sorts in-place and initializes scoring columns
+# - phase-dispatched accessors (Training vs Prediction)
+# - store_final_predictions! writes view results back into the global array
+# - ArrowFile path: _create_combined_dataframe schema + missing-typed columns
+# - ArrowFile path: _sample_psms proportional reservoir sampling
+# - ArrowFile prepare_training_data! / _finalize_scoring_arrow! round-trip
+
+using DataFrames
+using Arrow, Tables
+using Random
+
+using Pioneer: DataFramePSMContainer,
+               InMemoryScoringWorkspace, ArrowFileScoringWorkspace,
+               ArrowFilePSMContainer, ArrowFileGroup,
+               setup_scoring_workspace, prepare_training_data!,
+               get_cv_folds, get_train_indices, get_test_indices,
+               get_test_view, get_training_view,
+               get_train_output, get_test_output,
+               get_phase_view, get_phase_indices, get_phase_output,
+               init_fold_models, commit_fold!,
+               store_fold_models!, get_fold_models, get_all_models,
+               get_psms, store_final_predictions!,
+               TrainingPhase, PredictionPhase,
+               probit_scoring_config
+
+# Pioneer-namespaced (underscore-prefixed internal helpers)
+const _create_combined_dataframe = Pioneer._create_combined_dataframe
+const _sample_psms                = Pioneer._sample_psms
+const _finalize_scoring_arrow!    = Pioneer._finalize_scoring_arrow!
+const writeArrow                  = Pioneer.writeArrow
+
+function _make_synthetic_psm_df(n_per_fold::Int = 6)
+    # 2 folds × n_per_fold rows, alphabet-mixed for sort verification.
+    n = 2 * n_per_fold
+    rng = MersenneTwister(42)
+    df = DataFrame(
+        target            = rand(rng, Bool, n),
+        cv_fold           = repeat(UInt8[0, 1], inner = n_per_fold),
+        precursor_idx     = shuffle!(rng, UInt32.(1:n)),
+        ms_file_idx       = UInt32.(rand(rng, 1:3, n)),
+        irt_pred          = Float32.(randn(rng, n) .* 5.0 .+ 30.0),
+        isotopes_captured = [(Int8(0), Int8(2)) for _ in 1:n],
+    )
+    return DataFramePSMContainer(df)
+end
+
+@testset "workspace.jl" begin
+
+    @testset "InMemoryScoringWorkspace setup + accessors" begin
+        psms = _make_synthetic_psm_df(5)
+        config = probit_scoring_config(features = Symbol[])
+
+        ws = setup_scoring_workspace(psms, config)
+        @test ws isa InMemoryScoringWorkspace
+
+        # Folds discovered correctly
+        @test sort(get_cv_folds(ws)) == sort(get_cv_folds(psms))
+        @test length(get_cv_folds(ws)) == 2
+
+        # Output arrays pre-allocated to nrow(psms)
+        @test length(get_train_output(ws)) == 10
+        @test length(get_test_output(ws)) == 10
+        @test all(get_train_output(ws) .== 0.0f0)
+        @test all(get_test_output(ws) .== 0.0f0)
+
+        # Per-fold splits
+        for fold in get_cv_folds(ws)
+            test_idx = get_test_indices(ws, fold)
+            train_idx = get_train_indices(ws, fold)
+            @test isdisjoint(test_idx, train_idx)
+            @test length(test_idx) + length(train_idx) == 10
+            # All test rows have cv_fold == fold
+            cv = get_psms(ws).data.cv_fold
+            @test all(cv[test_idx] .== fold)
+            @test all(cv[train_idx] .!= fold)
+        end
+
+        # get_test_view / get_training_view are non-empty subsets
+        for fold in get_cv_folds(ws)
+            tv = get_test_view(ws, fold)
+            trv = get_training_view(ws, fold)
+            @test Pioneer.nrows(tv) == length(get_test_indices(ws, fold))
+            @test Pioneer.nrows(trv) == length(get_train_indices(ws, fold))
+        end
+
+        # get_psms returns the original container
+        @test get_psms(ws) === psms
+    end
+
+    @testset "prepare_training_data! sorts + initializes columns" begin
+        psms = _make_synthetic_psm_df(5)
+        config = probit_scoring_config(features = Symbol[])
+
+        # Pre-sort state: precursor_idx is shuffled
+        before = copy(psms.data.precursor_idx)
+        prepare_training_data!(psms, config)
+
+        # Sort key is (isotopes_captured, precursor_idx, ms_file_idx). All rows
+        # share the same isotopes, so precursor_idx should now be ascending
+        # within each ms_file_idx group.
+        df = psms.data
+        @test issorted(df, [:isotopes_captured, :precursor_idx, :ms_file_idx])
+
+        # Initialized scoring columns
+        @test :trace_prob in propertynames(df)
+        @test :q_value   in propertynames(df)
+        @test eltype(df.trace_prob) == Float32
+        @test eltype(df.q_value)    == Float64
+        @test all(df.trace_prob .== 0.0f0)
+        @test all(df.q_value   .== 0.0)
+        @test length(df.trace_prob) == 10
+    end
+
+    @testset "phase-dispatched accessors (Training vs Prediction)" begin
+        psms = _make_synthetic_psm_df(4)
+        config = probit_scoring_config(features = Symbol[])
+        ws = setup_scoring_workspace(psms, config)
+
+        for fold in get_cv_folds(ws)
+            train_phase_view = get_phase_view(ws, TrainingPhase(), fold)
+            pred_phase_view  = get_phase_view(ws, PredictionPhase(), fold)
+            @test Pioneer.nrows(train_phase_view) == length(get_train_indices(ws, fold))
+            @test Pioneer.nrows(pred_phase_view)  == length(get_test_indices(ws, fold))
+
+            @test get_phase_indices(ws, TrainingPhase(), fold) ==
+                  get_train_indices(ws, fold)
+            @test get_phase_indices(ws, PredictionPhase(), fold) ==
+                  get_test_indices(ws, fold)
+        end
+
+        # Phase output arrays — separate buffers
+        @test get_phase_output(ws, TrainingPhase())   === get_train_output(ws)
+        @test get_phase_output(ws, PredictionPhase()) === get_test_output(ws)
+
+        # init_fold_models creates a fresh Vector{Any} of the right length for
+        # training, and returns the stored models for prediction.
+        models_in = Any[1, 2, 3]
+        commit_fold!(ws, TrainingPhase(), UInt8(0), models_in)
+        @test get_all_models(ws)[UInt8(0)] === models_in
+        @test get_fold_models(ws, UInt8(0)) === models_in
+
+        # init_fold_models for TrainingPhase allocates n slots
+        slots = init_fold_models(ws, TrainingPhase(), UInt8(0), 4)
+        @test length(slots) == 4
+        @test eltype(slots) === Any
+
+        # init_fold_models for PredictionPhase returns the stored models
+        @test init_fold_models(ws, PredictionPhase(), UInt8(0), 0) === models_in
+    end
+
+    @testset "store_fold_models! / get_fold_models / get_all_models" begin
+        psms = _make_synthetic_psm_df(3)
+        config = probit_scoring_config(features = Symbol[])
+        ws = setup_scoring_workspace(psms, config)
+
+        store_fold_models!(ws, UInt8(0), Any["model_a"])
+        store_fold_models!(ws, UInt8(1), Any["model_b1", "model_b2"])
+        @test get_fold_models(ws, UInt8(0)) == ["model_a"]
+        @test get_fold_models(ws, UInt8(1)) == ["model_b1", "model_b2"]
+        all_models = get_all_models(ws)
+        @test sort(collect(keys(all_models))) == [UInt8(0), UInt8(1)]
+    end
+
+    @testset "store_final_predictions! writes view results back to global array" begin
+        psms = _make_synthetic_psm_df(4)
+        config = probit_scoring_config(features = Symbol[])
+        prepare_training_data!(psms, config)   # adds :trace_prob
+        ws = setup_scoring_workspace(psms, config)
+
+        # Inject distinguishable trace_prob values for fold 0's test rows only,
+        # via the view's set_column!.
+        fold = UInt8(0)
+        test_idx = get_test_indices(ws, fold)
+        view = get_test_view(ws, fold)
+        n_test = Pioneer.nrows(view)
+        injected = Float32[Float32(i) * 0.1f0 for i in 1:n_test]
+        Pioneer.set_column!(view, :trace_prob, injected)
+
+        store_final_predictions!(ws, fold)
+        # Workspace's prob_test array should now hold injected values at test_idx
+        out = get_test_output(ws)
+        for (i, idx) in enumerate(test_idx)
+            @test out[idx] ≈ injected[i]
+        end
+        # Other (non-fold-0) indices still zero
+        non_fold0 = setdiff(1:length(out), test_idx)
+        @test all(out[non_fold0] .== 0.0f0)
+    end
+
+    # ────────────────────────────────────────────────────────────────────
+    # ArrowFile path
+    # ────────────────────────────────────────────────────────────────────
+    @testset "_create_combined_dataframe schema (Missing-typed columns)" begin
+        # Build two Arrow tables in memory, with one column declared as
+        # Union{Missing,Float64}, another as plain UInt32, and verify the
+        # resulting DataFrame preserves those types.
+        data_df = DataFrame(
+            precursor_idx = UInt32[1, 2, 3],
+            score = Union{Missing, Float64}[0.5, missing, 0.7],
+        )
+        scores_df = DataFrame(
+            trace_prob = Float32[0.0, 0.0, 0.0],
+            q_value    = Float64[0.0, 0.0, 0.0],
+        )
+        mktempdir() do dir
+            data_path = joinpath(dir, "d.arrow")
+            scores_path = joinpath(dir, "s.arrow")
+            Arrow.write(data_path, data_df)
+            Arrow.write(scores_path, scores_df)
+
+            data_tbl = Arrow.Table(data_path)
+            scores_tbl = Arrow.Table(scores_path)
+
+            combined = _create_combined_dataframe(data_tbl, scores_tbl, 5)
+            @test nrow(combined) == 5
+            @test eltype(combined.precursor_idx) == UInt32
+            @test eltype(combined.score) == Union{Missing, Float64}
+            @test eltype(combined.trace_prob) == Float32
+            @test eltype(combined.q_value)    == Float64
+            # All columns from both inputs present
+            for name in (:precursor_idx, :score, :trace_prob, :q_value)
+                @test name in propertynames(combined)
+            end
+        end
+    end
+
+    @testset "_sample_psms: proportional, deterministic, count == budget" begin
+        # Build two Arrow files (file_fold0 with 30 rows, file_fold1 with 70).
+        # max=20 → expect ~20 rows total (rounding may shave by 0–1).
+        rng = MersenneTwister(11)
+        function _make_data_df(n)
+            DataFrame(
+                target            = rand(rng, Bool, n),
+                cv_fold           = fill(UInt8(0), n),
+                precursor_idx     = UInt32.(1:n),
+                ms_file_idx       = UInt32.(fill(1, n)),
+                irt_pred          = Float32.(rand(rng, n) .* 50.0),
+                isotopes_captured = [(Int8(0), Int8(2)) for _ in 1:n],
+            )
+        end
+
+        mktempdir() do dir
+            f0_path = joinpath(dir, "f_fold0.arrow")
+            f1_path = joinpath(dir, "f_fold1.arrow")
+            Arrow.write(f0_path, _make_data_df(30))
+            Arrow.write(f1_path, _make_data_df(70))
+
+            scores0 = DataFrame(trace_prob = zeros(Float32, 30), q_value = zeros(Float64, 30))
+            scores1 = DataFrame(trace_prob = zeros(Float32, 70), q_value = zeros(Float64, 70))
+            s0_path = joinpath(dir, "f_fold0_scores.arrow")
+            s1_path = joinpath(dir, "f_fold1_scores.arrow")
+            Arrow.write(s0_path, scores0)
+            Arrow.write(s1_path, scores1)
+
+            container = ArrowFilePSMContainer([f0_path, f1_path]; max_training_psms = 20)
+
+            sampled = _sample_psms(container, 20)
+            n_sampled = Pioneer.nrows(sampled)
+            # Allow rounding: each per-file count uses round(Int, n*frac); total
+            # is within one row of the budget.
+            @test 18 ≤ n_sampled ≤ 22
+            # Determinism: same seed, same input → same row count
+            sampled2 = _sample_psms(container, 20)
+            @test Pioneer.nrows(sampled2) == n_sampled
+            # And the sampled rows should be a subset of the original union
+            all_pidx = vcat(_make_data_df(30).precursor_idx, _make_data_df(70).precursor_idx)
+            sampled_pidx = sampled.data.precursor_idx
+            @test all(p -> p in Set(all_pidx), sampled_pidx)
+        end
+    end
+
+    @testset "ArrowFile prepare_training_data! + _finalize_scoring_arrow! round-trip" begin
+        rng = MersenneTwister(7)
+        function _data_df(n)
+            DataFrame(
+                target            = rand(rng, Bool, n),
+                cv_fold           = fill(UInt8(0), n),
+                precursor_idx     = shuffle!(rng, UInt32.(1:n)),
+                ms_file_idx       = UInt32.(fill(2, n)),
+                irt_pred          = Float32.(rand(rng, n) .* 30.0),
+                isotopes_captured = [(Int8(0), Int8(2)) for _ in 1:n],
+            )
+        end
+
+        mktempdir() do dir
+            data_path = joinpath(dir, "x_fold0.arrow")
+            Arrow.write(data_path, _data_df(8))
+            container = ArrowFilePSMContainer([data_path])
+
+            config = probit_scoring_config(features = Symbol[])
+            prepare_training_data!(container, config)
+
+            # After prepare_training_data!, scores sidecar should exist with
+            # zeros and main file should be sorted.
+            scores_tbl = Arrow.Table(container.file_groups[1].scores_path)
+            @test length(scores_tbl[:trace_prob]) == 8
+            @test all(Tables.getcolumn(scores_tbl, :trace_prob) .== 0.0f0)
+            @test all(Tables.getcolumn(scores_tbl, :q_value)    .== 0.0)
+            data_tbl = Arrow.Table(container.file_groups[1].data_path)
+            @test issorted(Tables.getcolumn(data_tbl, :precursor_idx))
+
+            # Now write nontrivial trace_prob into the scores sidecar and
+            # verify _finalize_scoring_arrow! copies it into the main data file.
+            preds = Float32[i * 0.05f0 for i in 1:8]
+            scores_df = DataFrame(
+                trace_prob = preds,
+                q_value    = zeros(Float64, 8),
+            )
+            writeArrow(container.file_groups[1].scores_path, scores_df)
+
+            _finalize_scoring_arrow!(container)
+            data_after = Arrow.Table(container.file_groups[1].data_path)
+            @test :trace_prob in Tables.columnnames(data_after)
+            @test all(Tables.getcolumn(data_after, :trace_prob) .≈ preds)
+        end
+    end
+
+    @testset "setup_scoring_workspace dispatches on ArrowFile container" begin
+        mktempdir() do dir
+            df = DataFrame(
+                target            = rand(Bool, 4),
+                cv_fold           = fill(UInt8(0), 4),
+                precursor_idx     = UInt32.(1:4),
+                ms_file_idx       = UInt32.(fill(1, 4)),
+                irt_pred          = Float32.(rand(4) .* 30.0),
+                isotopes_captured = [(Int8(0), Int8(2)) for _ in 1:4],
+            )
+            data_path = joinpath(dir, "y_fold0.arrow")
+            Arrow.write(data_path, df)
+            scores_df = DataFrame(trace_prob = zeros(Float32, 4),
+                                  q_value    = zeros(Float64, 4))
+            Arrow.write(joinpath(dir, "y_fold0_scores.arrow"), scores_df)
+
+            container = ArrowFilePSMContainer([data_path]; max_training_psms = 10)
+            config = probit_scoring_config(features = Symbol[])
+            ws = setup_scoring_workspace(container, config)
+
+            @test ws isa ArrowFileScoringWorkspace
+            # Delegates to inner
+            @test ws.container === container
+            @test ws.inner isa InMemoryScoringWorkspace
+            # ArrowFile workspace's store_final_predictions! is a no-op (returns nothing)
+            @test store_final_predictions!(ws, UInt8(0)) === nothing
+            # Delegated cv_folds (only fold 0 in this fixture)
+            @test get_cv_folds(ws) == [UInt8(0)]
+        end
+    end
+
+end

--- a/test/UnitTests/test_solve_poisson_mm.jl
+++ b/test/UnitTests/test_solve_poisson_mm.jl
@@ -1,0 +1,311 @@
+# Unit tests for src/utils/SpectralDeconvolution/solvePoissonMM.jl.
+#
+# The solver maximizes the Poisson log-likelihood   max Σ y_i log μ_i - μ_i
+# under the model μ = A x and the constraint x_j ≥ 0. Most numerical
+# packages (GLM.jl, NMF.jl) don't ship a non-negativity-constrained
+# Poisson regression with an OLS-style API, so we build ground truth
+# directly from KKT conditions and from closed-form solutions on
+# diagonal A.
+#
+# At the optimum (with the loss-gradient sign convention used by
+# `solvePoissonMM_fast!`,  L1_j = Σ_i a_ij (1 - y_i / μ_i) ):
+#   x_j > 0  →  L1_j ≈ 0          (interior: gradient zero)
+#   x_j = 0  →  L1_j ≥ 0          (boundary: increasing x_j wouldn't
+#                                  decrease loss)
+
+using Pioneer: SparseArrayFused, solvePoissonMM_fast!, initMu!,
+               initObserved!, updateMu!, solve_deconvolution!,
+               OLSSolver, PoissonMMSolver
+
+# ────────────────────────────────────────────────────────────────────
+# Helper: build a SparseArrayFused from row-indexed (col, row, val) triples.
+# Triples must be grouped by column ascending. m is the number of rows.
+function _make_sparse_fused(triples::Vector{<:Tuple{<:Integer,<:Integer,<:Real}},
+                            n_rows::Integer, n_cols::Integer)
+    n_vals = length(triples)
+    sa = SparseArrayFused(Int64(max(n_vals, 1)))
+    sa.m = Int64(n_rows)
+    sa.n = Int64(n_cols)
+    sa.n_vals = Int64(n_vals)
+    if length(sa.colptr) < n_cols + 1
+        append!(sa.colptr, zeros(Int64, n_cols + 1 - length(sa.colptr)))
+    end
+    @inbounds for c in 1:(n_cols + 1)
+        sa.colptr[c] = Int64(0)
+    end
+    @inbounds for c in 1:n_cols
+        sa.colptr[c] = Int64(0)
+    end
+    # Fill colptr by counting per-column entries.
+    counts = zeros(Int64, n_cols)
+    for (col, _row, _val) in triples
+        counts[col] += 1
+    end
+    sa.colptr[1] = Int64(1)
+    for c in 1:n_cols
+        sa.colptr[c + 1] = sa.colptr[c] + counts[c]
+    end
+    # Place entries column-by-column following triples order
+    cursor = zeros(Int64, n_cols)
+    for c in 1:n_cols
+        cursor[c] = sa.colptr[c]
+    end
+    @inbounds for (col, row, val) in triples
+        idx = cursor[col]
+        sa.rowval[idx] = Int64(row)
+        sa.nzval[idx]  = Float32(val)
+        cursor[col] += 1
+    end
+    return sa
+end
+
+# Loss gradient L1_j = Σ_i a_ij (1 - y_i / μ_i)
+function _loss_gradient(sa, μ::Vector{Float32}, y::Vector{Float32}, j::Int)
+    g = 0.0
+    for i in sa.colptr[j]:(sa.colptr[j + 1] - 1)
+        row = sa.rowval[i]
+        a   = Float64(sa.nzval[i])
+        μ_i = max(Float64(μ[row]), 1e-6)
+        y_i = Float64(y[row])
+        g += a * (1.0 - y_i / μ_i)
+    end
+    return g
+end
+
+@testset "solvePoissonMM" begin
+
+    @testset "initMu!: μ = A * w with floor clamp" begin
+        # 2 cols × 3 rows, dense block:
+        #   col 1: row 1=2.0, row 2=1.0
+        #   col 2: row 2=3.0, row 3=4.0
+        sa = _make_sparse_fused([(1,1,2.0), (1,2,1.0), (2,2,3.0), (2,3,4.0)], 3, 2)
+        w = Float32[2.0, 0.5]
+        μ = zeros(Float32, 4)
+        initMu!(μ, sa, w)
+        # μ = [2*2, 1*2 + 3*0.5, 4*0.5] = [4.0, 3.5, 2.0]
+        @test μ[1] ≈ 4.0f0
+        @test μ[2] ≈ 3.5f0
+        @test μ[3] ≈ 2.0f0
+        # Floor clamp: μ unaffected here (all > 1e-6)
+        @test all(μ[1:3] .≥ 1f-6)
+    end
+
+    @testset "initMu!: zero-weight rows clamped to POISSON_MU_FLOOR" begin
+        sa = _make_sparse_fused([(1,1,2.0)], 2, 1)
+        w = Float32[1.0]
+        μ = zeros(Float32, 3)
+        initMu!(μ, sa, w)
+        @test μ[1] ≈ 2.0f0
+        # Row 2 has no entries → unclamped μ would be 0; floor pushes to 1e-6
+        @test μ[2] == 1f-6
+    end
+
+    @testset "initMu! grows μ if too short" begin
+        sa = _make_sparse_fused([(1,1,2.0), (1,5,3.0)], 5, 1)
+        w = Float32[1.0]
+        μ = Float32[]   # empty; initMu! must grow it to length 5
+        initMu!(μ, sa, w)
+        @test length(μ) ≥ 5
+        @test μ[1] ≈ 2.0f0
+        @test μ[5] ≈ 3.0f0
+    end
+
+    @testset "initObserved!: extracts sa.x into y" begin
+        sa = _make_sparse_fused([(1,1,2.0), (1,2,1.0), (2,3,4.0)], 3, 2)
+        sa.x[1] = 7.0f0   # row 1 observation
+        sa.x[2] = 5.0f0   # row 2 observation
+        sa.x[3] = 9.0f0   # row 3 observation
+        y = zeros(Float32, 3)
+        initObserved!(y, sa)
+        @test y[1] ≈ 7.0f0
+        @test y[2] ≈ 5.0f0
+        @test y[3] ≈ 9.0f0
+    end
+
+    @testset "updateMu!: μ updated by Δ × column entries" begin
+        sa = _make_sparse_fused([(1,1,2.0), (1,2,1.0)], 3, 1)
+        w = Float32[1.0]
+        μ = zeros(Float32, 3)
+        initMu!(μ, sa, w)
+        μ_before = copy(μ)
+        # Bump column 1 weight from 1.0 → 3.0 (Δ = +2.0)
+        updateMu!(sa, μ, 1, 3.0f0, 1.0f0)
+        @test μ[1] ≈ μ_before[1] + 2.0f0 * 2.0f0   # row 1 a=2 → +4
+        @test μ[2] ≈ μ_before[2] + 2.0f0 * 1.0f0   # row 2 a=1 → +2
+    end
+
+    @testset "single-column closed form: x = Σy / Σa" begin
+        # 4 rows, 1 col, all matching: a = [1, 1, 2, 4], y = [3, 1, 6, 4]
+        # Poisson MLE for x: x = (Σ y_i) / (Σ a_i) = 14/8 = 1.75
+        sa = _make_sparse_fused(
+            [(1,1,1.0), (1,2,1.0), (1,3,2.0), (1,4,4.0)], 4, 1)
+        y = Float32[3.0, 1.0, 6.0, 4.0]
+        X = Float32[0.5]   # warm start
+        μ = zeros(Float32, 4)
+        initMu!(μ, sa, X)
+        converged, iters = solvePoissonMM_fast!(sa, μ, y, X, Int64(50), 1f-5)
+        @test converged
+        @test X[1] ≈ 1.75f0 atol=5f-3
+        @test X[1] ≥ 0
+    end
+
+    @testset "diagonal A: independent columns, closed form per column" begin
+        # 3 cols, 6 rows. Each col has 2 rows. Expect:
+        #   x_j = (y_{2j-1} + y_{2j}) / (a + b) for col j with values a, b
+        sa = _make_sparse_fused([
+            (1,1,2.0), (1,2,3.0),
+            (2,3,1.0), (2,4,1.0),
+            (3,5,4.0), (3,6,2.0),
+        ], 6, 3)
+        y = Float32[10.0, 5.0,   2.0, 8.0,   4.0, 4.0]
+        X = ones(Float32, 3)
+        μ = zeros(Float32, 6)
+        initMu!(μ, sa, X)
+        converged, _ = solvePoissonMM_fast!(sa, μ, y, X, Int64(50), 1f-5)
+        @test converged
+        # x_1 = (10 + 5)  / (2 + 3) = 3.0
+        # x_2 = (2 + 8)   / (1 + 1) = 5.0
+        # x_3 = (4 + 4)   / (4 + 2) = 8/6 ≈ 1.333
+        @test X[1] ≈ 3.0f0    atol=5f-3
+        @test X[2] ≈ 5.0f0    atol=5f-3
+        @test X[3] ≈ 1.3333f0 atol=5f-3
+        @test all(X .≥ 0)
+    end
+
+    @testset "y = 0 drives x → 0 (no observations to support)" begin
+        sa = _make_sparse_fused([(1,1,2.0), (1,2,1.0), (2,2,3.0)], 2, 2)
+        y = zeros(Float32, 2)
+        X = Float32[1.0, 1.0]
+        μ = zeros(Float32, 2)
+        initMu!(μ, sa, X)
+        # Poisson loss with y=0 is just Σ μ; minimum is at x=0.
+        converged, _ = solvePoissonMM_fast!(sa, μ, y, X, Int64(100), 1f-6)
+        @test converged
+        # Tolerance: with relative threshold 1e-6 the solver may stop above 0
+        @test X[1] ≤ 1f-3
+        @test X[2] ≤ 1f-3
+        @test all(X .≥ 0)
+    end
+
+    @testset "non-negativity active: column with no support pinned at 0" begin
+        # 3 rows, 2 cols. Col 1 covers rows 1,2; col 2 covers row 3.
+        # y has support only on rows 1,2 (y_3 = 0). The MLE wants x_2 → 0
+        # since col 2 contributes nothing to the likelihood except cost.
+        sa = _make_sparse_fused([
+            (1,1,1.0), (1,2,1.0),
+            (2,3,1.0),
+        ], 3, 2)
+        y = Float32[2.0, 4.0, 0.0]
+        X = Float32[1.0, 1.0]   # warm start col 2 at 1.0
+        μ = zeros(Float32, 3)
+        initMu!(μ, sa, X)
+        converged, _ = solvePoissonMM_fast!(sa, μ, y, X, Int64(100), 1f-6)
+        @test converged
+        # x_1 → (2 + 4) / (1 + 1) = 3.0
+        @test X[1] ≈ 3.0f0 atol=5f-3
+        @test X[2] ≤ 1f-3
+        @test X[2] ≥ 0
+    end
+
+    @testset "KKT conditions hold at convergence (mixed-coupling problem)" begin
+        # 4 rows, 3 cols, every col touches multiple rows. Ground truth not
+        # closed-form; verify KKT instead.
+        sa = _make_sparse_fused([
+            (1,1,1.0), (1,2,2.0), (1,3,1.0),
+            (2,1,2.0), (2,2,1.0), (2,4,1.0),
+            (3,3,3.0), (3,4,2.0),
+        ], 4, 3)
+        y = Float32[3.0, 4.0, 6.0, 2.0]
+        X = Float32[0.5, 0.5, 0.5]
+        μ = zeros(Float32, 4)
+        initMu!(μ, sa, X)
+        converged, _ = solvePoissonMM_fast!(sa, μ, y, X, Int64(200), 1f-7)
+        @test converged
+
+        # Recompute μ from scratch with the converged X, then check KKT.
+        μ_check = zeros(Float32, 4)
+        initMu!(μ_check, sa, X)
+        for j in 1:3
+            grad = _loss_gradient(sa, μ_check, y, j)
+            if X[j] > 1f-3
+                # Interior: gradient ≈ 0
+                @test abs(grad) ≤ 5f-2
+            else
+                # Boundary: gradient ≥ 0 (loss can only go up by increasing x_j)
+                @test grad ≥ -5f-2
+            end
+        end
+        @test all(X .≥ 0)
+    end
+
+    @testset "y-scaling kicks in for large counts and is restored on exit" begin
+        # max(y) = 1000 → y_scale = 1000; y is divided then multiplied back.
+        sa = _make_sparse_fused([(1,1,1.0), (1,2,1.0)], 2, 1)
+        y = Float32[400.0, 600.0]
+        y_orig = copy(y)
+        X = Float32[1.0]
+        μ = zeros(Float32, 2)
+        initMu!(μ, sa, X)
+        converged, _ = solvePoissonMM_fast!(sa, μ, y, X, Int64(50), 1f-5)
+        @test converged
+        # y must be restored to original after exit
+        @test y ≈ y_orig
+        # Closed-form: x = (400 + 600) / (1 + 1) = 500
+        @test X[1] ≈ 500.0f0 atol=2.0f0
+    end
+
+    @testset "warm-start at optimum: converges in 1 outer iter" begin
+        # Same single-column problem, but start at the closed-form optimum.
+        sa = _make_sparse_fused([(1,1,2.0), (1,2,3.0)], 2, 1)
+        y = Float32[6.0, 9.0]   # x_opt = 15 / 5 = 3.0
+        X = Float32[3.0]
+        μ = zeros(Float32, 2)
+        initMu!(μ, sa, X)
+        converged, iters = solvePoissonMM_fast!(sa, μ, y, X, Int64(20), 1f-5)
+        @test converged
+        @test iters ≤ 1
+        @test X[1] ≈ 3.0f0 atol=1f-3
+    end
+
+    @testset "solve_deconvolution! dispatch" begin
+        # Single-column problem, observations stored in sa.x (the dispatch path
+        # initializes y from sa.x via initObserved!). r and colnorm2 are needed
+        # to satisfy the OLS interface but unused by PoissonMMSolver beyond
+        # the initial allocation check.
+        sa = _make_sparse_fused([(1,1,1.0), (1,2,1.0), (1,3,2.0)], 3, 1)
+        sa.x[1] = 2.0f0
+        sa.x[2] = 4.0f0
+        sa.x[3] = 6.0f0   # observations: y = [2, 4, 6/2] but initObserved
+                          # uses sa.x[n] for the row, so for col 1 row 3 with
+                          # value 2, sa.x[3] = 6 → y[3] = 6.
+
+        w = Float32[1.0]
+        r = zeros(Float32, 3)
+        colnorm2 = Float32[1.0]
+        μ = zeros(Float32, 3)
+        y = zeros(Float32, 3)
+
+        @testset "PoissonMMSolver path" begin
+            X = copy(w)
+            converged, _ = solve_deconvolution!(
+                PoissonMMSolver(), sa, copy(r), X, copy(colnorm2),
+                copy(μ), copy(y), Int64(50), 1f-5)
+            @test converged
+            # x = (Σ y) / (Σ a) = (2 + 4 + 6) / (1 + 1 + 2) = 3.0
+            @test X[1] ≈ 3.0f0 atol=5f-3
+            @test X[1] ≥ 0
+        end
+
+        @testset "OLSSolver path runs without error" begin
+            # Verifies dispatch works; we don't assert OLS optimality here
+            # because OLS treats the problem differently and isn't the
+            # subject under test.
+            X = copy(w)
+            solve_deconvolution!(
+                OLSSolver(), sa, copy(r), X, copy(colnorm2),
+                copy(μ), copy(y), Int64(50), 1f-5)
+            @test all(isfinite, X)
+        end
+    end
+
+end

--- a/test/runtests_part2_units.jl
+++ b/test/runtests_part2_units.jl
@@ -44,6 +44,15 @@ include("./UnitTests/LogTruncationTests.jl")
 
 include("./UnitTests/test_counter.jl")
 
+# Coverage: small modules with previously-poor unit coverage.
+include("./UnitTests/test_mass_error_model.jl")
+include("./UnitTests/test_parse_mods.jl")
+include("./UnitTests/test_quad_models_basic.jl")
+include("./UnitTests/test_solve_poisson_mm.jl")
+include("./UnitTests/test_scoring_workspace_coverage.jl")
+include("./UnitTests/test_rt_alignment_utils.jl")
+include("./UnitTests/test_protein_model_fit.jl")
+
 # ParameterTuningSearch — Lipschitz step cap regression
 include("./Routines/SearchDIA/SearchMethods/ParameterTuningSearch/test_intensity_spline_lipschitz.jl")
 


### PR DESCRIPTION
## Summary

Adds **378 unit-test assertions** across 7 files targeting modules that ranked at 0–43% coverage on the latest develop snapshot. One production-code interface inconsistency surfaced and was fixed.

## Tests added (6 coverage files + 1 driving the probit fix)

| File | Tests | Target |
|---|---|---|
| `test_mass_error_model.jl` | 89 | `MassErrorModel.jl` — Simple/LinearDa/LinearBiasPpmTol models, asymmetric-tolerance reverse-swap, 3-arg forwarding, `getCorrectedMzAndBounds` consistency |
| `test_parse_mods.jl` | 69 | `parse_mods.jl` — `get_aa_masses!`, `get_structural_mod_masses!`, `getIsoModMasses!`, `get_sulfur_counts!`, `get_fragment_mz`, `get_precursor_mz`, `reverseSequence` |
| `test_quad_models_basic.jl` | 28 | `noQuadModel.jl`, `generalGaussModel.jl`, `IsotopeTraceType.jl` |
| `test_solve_poisson_mm.jl` | 45 | `solvePoissonMM.jl` — closed-form solutions on 1- and N-col problems, KKT conditions, `y=0 → x=0`, non-negativity active set, y-scaling round-trip, `solve_deconvolution!` dispatch |
| `test_scoring_workspace_coverage.jl` | 74 | `workspace.jl` — `InMemoryScoringWorkspace` accessors, `store_final_predictions!` round-trip, ArrowFile path `_create_combined_dataframe` / `_sample_psms` / `_finalize_scoring_arrow!` |
| `test_rt_alignment_utils.jl` | 58 | `rt_alignment_utils.jl` — robust linear regression, monotonic-spline enforcement, RT-model dispatch branches |
| `test_protein_model_fit.jl` | 15 | `model_fit.jl` (pure-numerics) — `fit_probit_model` + `calculate_probit_scores` end-to-end |

All tests wired into `runtests_part2_units.jl`. Local Pkg.test() pass on develop+this branch.

## Production-code change

`src/utils/ML/probitRegression.jl`: loosened three signatures from `y::Vector{Bool}` to `y::AbstractVector{Bool}` (`ProbitRegression`, `fillZandW!`, `loglikelihood!`). The outer `fit_probit_model` already declared `AbstractVector{Bool}` but forwarded to internals that only accepted concrete `Vector{Bool}` — a `BitVector` (e.g. `falses(n)`) would type-check at the boundary and then `MethodError` from inside. Bodies only do read-only `y[i]` and `length(y)`, so the relaxation is safe; integration test unchanged (2331 prec / 1266 pg).

## Test plan
- [x] Each new test file passes locally on its own.
- [x] Full `runtests_part2_units.jl` passes (all prior tests + new files).
- [x] Integration test (`SearchDIA(test/integration/search_ecoli.json)`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)