### PR TITLE
Hardcode PoissonMMSolver across all deconvolution sites

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
@@ -93,8 +93,7 @@ struct IntegrateChromatogramSearchParameters{P<:PrecEstimation, I<:IsotopeTraceT
 
             Float32(0.0),     # lambda (no regularization)
             NoNorm(),         # reg_type
-            (haskey(search_params, :deconvolution_solver) &&
-             search_params.deconvolution_solver == "pmm") ? PoissonMMSolver() : OLSSolver(),
+            PoissonMMSolver(),  # hardcoded: PMM is the production solver
             DECONV_MAX_ITER,          # max_iter_outer
             DECONV_CONVERGENCE_TOL,   # max_diff
 

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/types.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/types.jl
@@ -114,8 +114,7 @@ struct MainSearchParameters{P<:PrecEstimation, I<:IsotopeTraceType} <: FragmentI
 
             Float32(0.0),     # lambda (no regularization)
             NoNorm(),         # reg_type
-            (haskey(quant_params, :deconvolution_solver) &&
-             quant_params.deconvolution_solver == "pmm") ? PoissonMMSolver() : OLSSolver(),
+            PoissonMMSolver(),  # hardcoded: PMM is the production solver
             DECONV_MAX_ITER,          # max_iter_outer
             DECONV_CONVERGENCE_TOL,   # max_diff
 

--- a/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/QuadTuningSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/QuadTuningSearch.jl
@@ -120,8 +120,7 @@ struct QuadTuningSearchParameters{P<:PrecEstimation} <: FragmentIndexSearchParam
             typemax(Float32),                                              # irt_tol
             Set{Int64}([2]),                                               # spec_order
             TUNING_RELATIVE_IMPROVEMENT_THRESHOLD,                         # relative_improvement_threshold
-            (haskey(params.search, :deconvolution_solver) &&
-             params.search.deconvolution_solver == "pmm") ? PoissonMMSolver() : OLSSolver(), # deconvolution_solver
+            PoissonMMSolver(),                                             # deconvolution_solver — hardcoded
             DECONV_MAX_ITER,                                               # max_iter_outer
             DECONV_CONVERGENCE_TOL,                                        # max_diff
             QUAD_TUNING_MIN_FRAGMENTS,                                     # min_quad_tuning_fragments


### PR DESCRIPTION
## Summary

Hardcode \`PoissonMMSolver()\` in all three deconvolution call sites (MainSearch, QuadTuning, IntegrateChromatograms). Removes the JSON-driven \`deconvolution_solver\` dispatch — there is no longer a runtime knob to switch to OLS.

## Empirical justification (Olsen Astral 30-min + Mtac alternating 5-min)

Across two datasets covering the four (main_solver / chrom_solver) corners:

| metric | direction | scale |
|---|---|---|
| precursor IDs | pmm-main > ols-main | +0.3% (Astral 30-min) → +2.6% (Mtac 5-min) |
| protein-group IDs | pmm-main > ols-main | +0.8% → +2.5% |
| HUMAN %CV across replicates | unaffected by main solver | — |
| HUMAN %CV across replicates | pmm-chrom slightly worse | +1.2pp on Astral, +3% std on Mtac |
| ECOLI/YEAST FC compression | pmm-chrom compresses | 0.42 toward 0 on 9× ratio (Astral); 0.01 on 3× ratio (Mtac) |
| Main Search wall time | pmm slower | ~5–6% |
| Chromatogram Integration wall time | pmm slower | ~7–10% |

PMM-in-main is a clear win on IDs at modest time cost. PMM-in-chrom-integration is a marginal quant trade-off (consistently in OLS's favor on width/compression metrics) but small in magnitude on real fold changes.

Decision: ship PMM everywhere for solver consistency. Eliminates the four-corner combinatorics and the surface area of two runtime knobs.

## Code change

3 lines per site, 3 sites:

\`\`\`julia
- (haskey(quant_params, :deconvolution_solver) &&
-  quant_params.deconvolution_solver == \"pmm\") ? PoissonMMSolver() : OLSSolver(),
+ PoissonMMSolver(),  # hardcoded
\`\`\`

\`OLSSolver\` is retained as a type — it still dispatches \`solve_deconvolution!\` to \`solveOLS!\` and is exercised by \`test/UnitTests/test_solve_poisson_mm.jl\`. No other production caller.

## Test plan
- [x] Integration test (\`SearchDIA(test/integration/search_ecoli.json)\`) runs to completion. Counts shift (2331 → 2226 prec, 1266 → 1311 pg) because PMM was previously the implicit OLS default at the test fixture; the test only asserts \`=== nothing\`, no count regression.
- [x] Empirical four-corner comparison on Olsen Astral E5/E45 and Mtac alternating Sample-A/B (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)