### PR TITLE
[codex] Fix quantitation transmission scaling and relax prescore filter

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/integrate_chrom.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/integrate_chrom.jl
@@ -131,7 +131,7 @@ function integrate_chrom(rt_col::AbstractVector{<:AbstractFloat},
         @inbounds for i in range(1, m)
             frac = fraction_col[i]
             if frac >= min_fraction_transmitted
-                b[i + n_pad] = intensity_col[i] / frac
+                b[i + n_pad] = intensity_col[i]
                 max_isolation = max(max_isolation, frac)
             else
                 b[i + n_pad] = 0.0f0

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/prescore_aggregation.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/prescore_aggregation.jl
@@ -91,9 +91,8 @@ end
 
 # Hardcoded prescore q-value threshold. The active filter cutoff between
 # MainSearch's per-file LightGBM and ScoringSearch's experiment-wide LightGBM.
-# Tuned via per-file ID sweep (see commit 5a24ccdf): Astral peaks at 1.5%,
-# Eclipse near-tied with 1%; 0.015 is the cross-dataset compromise.
-const PRESCORE_QVALUE_THRESHOLD = 0.015f0
+# Temporarily relaxed to 10% for quantitation evaluation on MTAC standard.
+const PRESCORE_QVALUE_THRESHOLD = 0.10f0
 
 # Floor for the per-file logit clamp inside _logodds_combine. Caps the
 # negative contribution of a single bad file (worst-case single-file logit


### PR DESCRIPTION
## Summary

- Removes the second division by `precursor_fraction_transmitted` before Whittaker-Henderson smoothing in chromatogram integration.
- Keeps the current low-transmission gate for smoothing input, but passes the deconvolved intensity through unscaled for retained scans.
- Temporarily relaxes the hardcoded global prescore q-value threshold to `0.10f0` for quantitation evaluation.

## Rationale

The deconvolution design matrix already incorporates precursor isotope transmission, so the fitted chromatogram intensity is already a full-transmission-equivalent abundance. Dividing by `precursor_fraction_transmitted` again over-corrects partially transmitted precursors and inflates peak areas by roughly `1 / T`.

The relaxed prescore filter matches the MTAC standard q010 experiment we evaluated while comparing current develop, Change 1, and the HUPO v0.6.6 output.

## Validation

- Instantiated and precompiled the clean PR worktree with `julia --project=/private/tmp/pioneer-quant-change1-q010 -e 'using Pkg; Pkg.instantiate(); Pkg.status()'`.
- Previously ran the equivalent Change 1 + q010 MTAC standard SearchDIA cell sequentially with 10 Julia threads: `05_change1_q010`, producing `504757` precursor rows and `60945` protein-group rows.
- Regenerated MTAC comparison analysis and CV plot in `dev/robust_solver_dev_rebuild/results/mtac_3p_std_3way/` using the q010 result.