### PR TITLE
Fix chromatogram integration trace ordering

### DIFF
--- a/.github/workflows/validate_installers.yml
+++ b/.github/workflows/validate_installers.yml
@@ -164,7 +164,7 @@ jobs:
           test -f "$SMOKE_DIR/build_template.json"
 
           "$PIONEER" params-search \
-            "$GITHUB_WORKSPACE/data/ecoli_test/Prosit_ECOLI_500_600mz_062625.poin" \
+            "$GITHUB_WORKSPACE/test/integration/ecoli_lib.poin" \
             "$GITHUB_WORKSPACE/data/ecoli_test/raw" \
             "$SMOKE_DIR/search_results_from_cli" \
             --params-path "$SMOKE_DIR/search_template.json"
@@ -288,7 +288,7 @@ jobs:
           }
 
           & $pioneer params-search `
-            (Join-Path $env:GITHUB_WORKSPACE 'data\ecoli_test\Prosit_ECOLI_500_600mz_062625.poin') `
+            (Join-Path $env:GITHUB_WORKSPACE 'test\integration\ecoli_lib.poin') `
             (Join-Path $env:GITHUB_WORKSPACE 'data\ecoli_test\raw') `
             (Join-Path $smokeDir 'search_results_from_cli') `
             --params-path (Join-Path $smokeDir 'search_template.json')
@@ -403,7 +403,7 @@ jobs:
           test -f "$SMOKE_DIR/build_template.json"
 
           "$PIONEER" params-search \
-            "$GITHUB_WORKSPACE/data/ecoli_test/Prosit_ECOLI_500_600mz_062625.poin" \
+            "$GITHUB_WORKSPACE/test/integration/ecoli_lib.poin" \
             "$GITHUB_WORKSPACE/data/ecoli_test/raw" \
             "$SMOKE_DIR/search_results_from_cli" \
             --params-path "$SMOKE_DIR/search_template.json"
@@ -509,7 +509,7 @@ jobs:
           test -f "$SMOKE_DIR/build_template.json"
 
           "$PIONEER" params-search \
-            "$GITHUB_WORKSPACE/data/ecoli_test/Prosit_ECOLI_500_600mz_062625.poin" \
+            "$GITHUB_WORKSPACE/test/integration/ecoli_lib.poin" \
             "$GITHUB_WORKSPACE/data/ecoli_test/raw" \
             "$SMOKE_DIR/search_results_from_cli" \
             --params-path "$SMOKE_DIR/search_template.json"

--- a/assets/example_config/defaultSearchParams.json
+++ b/assets/example_config/defaultSearchParams.json
@@ -13,6 +13,9 @@
         "nce": 26
     },
     "optimization": {
+        "chromatogram_integration": {
+            "trace_mode": "combined"
+        },
         "machine_learning": {
             "max_psm_memory_mb": 2000,
             "pep_bin_size": 10

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pioneer</title>
+    <style>
+      :root {
+        --pioneer-blue: #193b54;
+      }
+
+      body {
+        font-family: "Helvetica Neue", Arial, sans-serif;
+        margin: 0;
+        color: #1f2933;
+        background-color: #f8fafc;
+      }
+
+      header {
+        background: var(--pioneer-blue);
+        color: #ffffff;
+        padding: 48px 24px;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: 40px;
+        letter-spacing: 0.5px;
+      }
+
+      header p {
+        margin: 12px 0 0;
+        font-size: 18px;
+        opacity: 0.9;
+      }
+
+      main {
+        max-width: 900px;
+        margin: 32px auto;
+        padding: 0 24px 48px;
+        line-height: 1.6;
+      }
+
+      h2 {
+        color: var(--pioneer-blue);
+        margin-top: 32px;
+      }
+
+      .card {
+        background: #ffffff;
+        border-radius: 12px;
+        padding: 24px;
+        margin: 20px;
+        box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+      }
+
+      .logo {
+        display: block;
+        width: 300px;
+        max-width: 100%;
+        margin: 0 auto 16px;
+      }
+
+      .cta-link {
+        color: var(--pioneer-blue);
+        font-weight: 600;
+        text-decoration: none;
+      }
+
+      .cta-link:hover {
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <header></header>
+    <main>
+      <section class="card">
+        <img class="logo" src="assets/pioneer-logo.svg" alt="Pioneer logo" />
+        <p>
+          Pioneer is an open-source and high-performance toolkit for analyzing
+          data-independent acquisition (DIA) proteomics experiments. It delivers
+          rapid spectral library search, quantification, and scalable
+          workflows across large experiments.
+        </p>
+        <p>
+          <a class="cta-link" href="https://github.com/nwamsley1/Pioneer.jl"
+            >Visit the Pioneer GitHub repository →</a
+          >
+        </p>
+      </section>
+
+      <section class="card">
+        <h2>Documentation</h2>
+        <p>
+          Explore the Pioneer documentation, including guides, API references,
+          and tutorials.
+        </p>
+        <p>
+          <a class="cta-link" href="docs/stable/">Read the docs →</a>
+        </p>
+      </section>
+
+      <section class="card">
+        <h2>Regression Reports</h2>
+        <p>
+          View the history of regression tests for Pioneer.
+        </p>
+        <p>
+          <a class="cta-link" href="reports/">Browse regression reports →</a>
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/scripts/prepare_release_smoke_inputs.py
+++ b/scripts/prepare_release_smoke_inputs.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Prepare absolute-path config files for pre-release smoke validation."
+    )
+    parser.add_argument("--repo-root", required=True, help="Path to the repository root")
+    parser.add_argument("--output-dir", required=True, help="Directory where smoke inputs should be written")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    predict_config = json.loads((repo_root / "data" / "precompile" / "build_ecoli_altimeter.json").read_text(encoding="utf-8"))
+    predict_config["library_path"] = str(output_dir / "predicted_library")
+    predict_config["out_dir"] = str(output_dir)
+    predict_config["lib_name"] = "predicted_library"
+    predict_config["new_lib_name"] = "predicted_library"
+    predict_config["out_name"] = "predicted_library.tsv"
+    predict_config["max_koina_requests"] = 4
+    predict_config["max_koina_batch"] = 250
+    predict_config["fasta_paths"] = [str((repo_root / "data" / "precompile" / "ecoli.fasta").resolve())]
+    calibration_raw_file = str((repo_root / "data" / "ecoli_test" / "raw" / "ecoli_filtered_01.arrow").resolve())
+    predict_config["calibration_raw_file"] = calibration_raw_file
+    predict_config["library_params"]["calibration_raw_file"] = calibration_raw_file
+    write_json(output_dir / "build_predict.json", predict_config)
+
+    search_config = json.loads((repo_root / "test" / "integration" / "search_ecoli.json").read_text(encoding="utf-8"))
+    search_config["paths"]["library"] = str((repo_root / "test" / "integration" / "ecoli_lib.poin").resolve())
+    search_config["paths"]["ms_data"] = str((repo_root / "data" / "ecoli_test" / "raw").resolve())
+    search_config["paths"]["results"] = str((output_dir / "search_results").resolve())
+    search_config["output"]["write_csv"] = False
+    search_config["output"]["write_decoys"] = False
+    write_json(output_dir / "search.json", search_config)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_gh_pages_site.py
+++ b/scripts/update_gh_pages_site.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import html
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - Python < 3.9 fallback
+    ZoneInfo = None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Publish a regression report to gh-pages and prune stale plot assets."
+    )
+    parser.add_argument("--run-dir", required=True)
+    parser.add_argument("--report-path", required=True)
+    parser.add_argument("--report-subdir", required=True)
+    parser.add_argument("--history-branch", default="gh-pages")
+    parser.add_argument("--github-repository")
+    parser.add_argument("--github-token")
+    parser.add_argument("--repo-url")
+    parser.add_argument("--retention-days", type=int, default=30)
+    parser.add_argument("--current-timestamp")
+    return parser.parse_args()
+
+
+def run_command(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, check=check, text=True, capture_output=True)
+
+
+def ensure_success(result: subprocess.CompletedProcess[str], context: str) -> None:
+    if result.returncode == 0:
+        return
+    output = (result.stdout or "") + (result.stderr or "")
+    raise RuntimeError(f"{context} failed:\n{output}".rstrip())
+
+
+def iso_utc_now(current_timestamp: str | None) -> str:
+    if current_timestamp:
+        return current_timestamp
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_timestamp(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        parsed = dt.datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def load_json(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+
+
+def derive_repo_url(args: argparse.Namespace) -> str:
+    if args.repo_url:
+        return args.repo_url
+    if not args.github_repository or not args.github_token:
+        raise ValueError("Either --repo-url or both --github-repository and --github-token are required.")
+    return f"https://x-access-token:{args.github_token}@github.com/{args.github_repository}.git"
+
+
+def ensure_checkout(repo_dir: Path, repo_url: str, history_branch: str) -> None:
+    if (repo_dir / ".git").is_dir():
+        fetch_result = run_command(
+            ["git", "-C", str(repo_dir), "fetch", "origin", history_branch],
+            check=False,
+        )
+        if fetch_result.returncode != 0:
+            combined = (fetch_result.stdout or "") + (fetch_result.stderr or "")
+            print(f"warning: fetch failed for {history_branch}: {combined.strip()}", file=sys.stderr)
+
+        checkout_result = run_command(
+            ["git", "-C", str(repo_dir), "checkout", history_branch],
+            check=False,
+        )
+        if checkout_result.returncode != 0:
+            ensure_success(
+                run_command(["git", "-C", str(repo_dir), "checkout", "-b", history_branch]),
+                f"checkout branch {history_branch}",
+            )
+
+        remote_exists = run_command(
+            ["git", "-C", str(repo_dir), "rev-parse", "--verify", f"origin/{history_branch}"],
+            check=False,
+        )
+        if remote_exists.returncode == 0:
+            ensure_success(
+                run_command(
+                    ["git", "-C", str(repo_dir), "reset", "--hard", f"origin/{history_branch}"]
+                ),
+                f"reset branch {history_branch}",
+            )
+        return
+
+    if repo_dir.exists():
+        shutil.rmtree(repo_dir)
+
+    clone_result = run_command(
+        [
+            "git",
+            "clone",
+            "--branch",
+            history_branch,
+            "--depth",
+            "1",
+            "--filter=blob:none",
+            repo_url,
+            str(repo_dir),
+        ],
+        check=False,
+    )
+    if clone_result.returncode == 0:
+        return
+
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    ensure_success(run_command(["git", "init", str(repo_dir)]), "initialize git repository")
+    ensure_success(
+        run_command(["git", "-C", str(repo_dir), "checkout", "-b", history_branch]),
+        f"create branch {history_branch}",
+    )
+    ensure_success(
+        run_command(["git", "-C", str(repo_dir), "remote", "add", "origin", repo_url]),
+        "add origin remote",
+    )
+
+
+def publish_report(
+    repo_dir: Path,
+    report_path: Path,
+    report_subdir: Path,
+    report_timestamp: str,
+    retention_days: int,
+) -> Path:
+    report_dir = repo_dir / report_subdir
+    report_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(report_path, report_dir / "index.html")
+
+    plots_source = report_path.parent / "fdr_plots"
+    plots_dest = report_dir / "fdr_plots"
+    if plots_dest.exists():
+        shutil.rmtree(plots_dest)
+    plots_available = plots_source.is_dir()
+    if plots_available:
+        shutil.copytree(plots_source, plots_dest)
+
+    write_json(
+        report_dir / "meta.json",
+        {
+            "plots_available": plots_available,
+            "plots_pruned": False,
+            "plots_retention_days": retention_days,
+            "timestamp": report_timestamp,
+        },
+    )
+    return report_dir
+
+
+def sync_landing_page(run_dir: Path, repo_dir: Path) -> None:
+    landing_source = run_dir / "pioneer" / "pages" / "index.html"
+    logo_source = run_dir / "pioneer" / "figures" / "PIONEER_LOGO.svg"
+    if not landing_source.is_file():
+        raise FileNotFoundError(f"Missing landing page at {landing_source}")
+    if not logo_source.is_file():
+        raise FileNotFoundError(f"Missing logo at {logo_source}")
+
+    assets_dir = repo_dir / "assets"
+    assets_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(landing_source, repo_dir / "index.html")
+    shutil.copy2(logo_source, assets_dir / "pioneer-logo.svg")
+
+
+def prune_stale_plots(
+    repo_dir: Path,
+    current_report_dir: Path,
+    report_timestamp: str,
+    retention_days: int,
+) -> list[Path]:
+    reports_root = repo_dir / "reports"
+    if not reports_root.is_dir():
+        return []
+
+    cutoff = parse_timestamp(report_timestamp)
+    if cutoff is None:
+        raise ValueError(f"Invalid current timestamp: {report_timestamp}")
+    cutoff -= dt.timedelta(days=retention_days)
+
+    pruned: list[Path] = []
+    for meta_file in sorted(reports_root.rglob("meta.json")):
+        report_dir = meta_file.parent
+        if report_dir == current_report_dir:
+            continue
+
+        metadata = load_json(meta_file)
+        report_time = parse_timestamp(str(metadata.get("timestamp", "")))
+        if report_time is None:
+            continue
+
+        plots_dir = report_dir / "fdr_plots"
+        metadata_changed = False
+        if plots_dir.is_dir() and report_time < cutoff:
+            shutil.rmtree(plots_dir)
+            metadata["plots_available"] = False
+            metadata["plots_pruned"] = True
+            metadata["plots_pruned_at"] = report_timestamp
+            metadata["plots_retention_days"] = retention_days
+            write_json(meta_file, metadata)
+            pruned.append(report_dir)
+            continue
+
+        plots_available = plots_dir.is_dir()
+        if metadata.get("plots_available") != plots_available:
+            metadata["plots_available"] = plots_available
+            metadata_changed = True
+        if metadata_changed:
+            write_json(meta_file, metadata)
+
+    return pruned
+
+
+def chicago_timestamp(value: dt.datetime | None) -> str:
+    if value is None:
+        return ""
+    if ZoneInfo is None:
+        return value.strftime("%Y-%m-%dT%H:%M:%S")
+    try:
+        local_value = value.astimezone(ZoneInfo("America/Chicago"))
+    except Exception:
+        local_value = value
+    return local_value.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def render_reports_index(repo_dir: Path) -> None:
+    reports_root = repo_dir / "reports"
+    reports_root.mkdir(parents=True, exist_ok=True)
+
+    entries: list[dict[str, object]] = []
+    for meta_file in reports_root.rglob("meta.json"):
+        report_dir = meta_file.parent
+        relative_dir = report_dir.relative_to(reports_root)
+        parts = relative_dir.parts
+        if len(parts) < 4:
+            continue
+
+        metadata = load_json(meta_file)
+        report_time = parse_timestamp(str(metadata.get("timestamp", "")))
+        plots_dir = report_dir / "fdr_plots"
+        if plots_dir.is_dir():
+            plots_status = "Available"
+        elif metadata.get("plots_pruned"):
+            plots_status = "Archived"
+        else:
+            plots_status = "Unavailable"
+
+        entries.append(
+            {
+                "branch": parts[0],
+                "sha": parts[1],
+                "regression_set": parts[2],
+                "run": parts[3],
+                "date_cst": chicago_timestamp(report_time),
+                "href": relative_dir.as_posix() + "/",
+                "plots_status": plots_status,
+                "sort_key": report_time or dt.datetime.min.replace(tzinfo=dt.timezone.utc),
+            }
+        )
+
+    entries.sort(key=lambda entry: entry["sort_key"], reverse=True)
+
+    rows: list[str] = []
+    for entry in entries:
+        rows.extend(
+            [
+                "<tr>",
+                f"<td>{html.escape(str(entry['date_cst']))}</td>",
+                f"<td>{html.escape(str(entry['branch']))}</td>",
+                f"<td>{html.escape(str(entry['sha']))}</td>",
+                f"<td>{html.escape(str(entry['regression_set']))}</td>",
+                f"<td>{html.escape(str(entry['run']))}</td>",
+                f"<td>{html.escape(str(entry['plots_status']))}</td>",
+                f"<td><a href=\"{html.escape(str(entry['href']))}\">Open report</a></td>",
+                "</tr>",
+            ]
+        )
+
+    html_output = "\n".join(
+        [
+            "<!DOCTYPE html>",
+            "<html lang=\"en\">",
+            "<head>",
+            "<meta charset=\"UTF-8\">",
+            "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">",
+            "<title>Regression Report Index</title>",
+            "<style>",
+            "body { font-family: Arial, sans-serif; margin: 24px; }",
+            "table { border-collapse: collapse; width: 100%; }",
+            "th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }",
+            "th { background-color: #f4f4f4; }",
+            "tr:nth-child(even) { background-color: #fafafa; }",
+            "</style>",
+            "</head>",
+            "<body>",
+            "<h1>Regression Reports</h1>",
+            "<table>",
+            "<thead><tr><th>Date (CST)</th><th>Branch</th><th>Commit</th><th>Regression Set</th><th>Run</th><th>Plots</th><th>Report</th></tr></thead>",
+            "<tbody>",
+            *rows,
+            "</tbody>",
+            "</table>",
+            "</body>",
+            "</html>",
+        ]
+    )
+    (reports_root / "index.html").write_text(html_output + "\n", encoding="utf-8")
+
+
+def commit_and_push(repo_dir: Path, history_branch: str, run_dir: Path) -> bool:
+    ensure_success(run_command(["git", "-C", str(repo_dir), "add", "-A"]), "stage gh-pages updates")
+    diff_result = run_command(
+        ["git", "-C", str(repo_dir), "diff", "--cached", "--quiet"],
+        check=False,
+    )
+    if diff_result.returncode == 0:
+        return False
+    if diff_result.returncode not in (0, 1):
+        ensure_success(diff_result, "check for staged changes")
+
+    ensure_success(
+        run_command(
+            [
+                "git",
+                "-C",
+                str(repo_dir),
+                "-c",
+                "user.name=github-actions[bot]",
+                "-c",
+                "user.email=github-actions[bot]@users.noreply.github.com",
+                "commit",
+                "-m",
+                f"Update Pages history from {run_dir.name}",
+            ]
+        ),
+        "commit gh-pages updates",
+    )
+    ensure_success(
+        run_command(["git", "-C", str(repo_dir), "push", "origin", history_branch]),
+        "push gh-pages updates",
+    )
+    return True
+
+
+def main() -> int:
+    args = parse_args()
+    run_dir = Path(args.run_dir).resolve()
+    report_path = Path(args.report_path).resolve()
+    if not report_path.is_file():
+        raise FileNotFoundError(f"Missing report HTML at {report_path}")
+    if args.retention_days < 0:
+        raise ValueError("--retention-days must be non-negative")
+
+    repo_url = derive_repo_url(args)
+    repo_dir = run_dir / "gh-pages-site"
+    history_branch = args.history_branch
+    report_subdir = Path(args.report_subdir)
+    report_timestamp = iso_utc_now(args.current_timestamp)
+
+    ensure_checkout(repo_dir, repo_url, history_branch)
+    report_dir = publish_report(repo_dir, report_path, report_subdir, report_timestamp, args.retention_days)
+    sync_landing_page(run_dir, repo_dir)
+    pruned = prune_stale_plots(repo_dir, report_dir, report_timestamp, args.retention_days)
+    render_reports_index(repo_dir)
+    pushed = commit_and_push(repo_dir, history_branch, run_dir)
+
+    print(f"Published report: {report_subdir.as_posix()}")
+    print(f"Pruned plot directories: {len(pruned)}")
+    for report_dir in pruned:
+        print(f"  - {report_dir.relative_to(repo_dir).as_posix()}")
+    print(f"Changes pushed: {'yes' if pushed else 'no'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/Routines/SearchDIA/ParseInputs/paramsChecks.jl
+++ b/src/Routines/SearchDIA/ParseInputs/paramsChecks.jl
@@ -88,6 +88,16 @@ function checkParams(json_path::String)
     check_param(ml_params, "max_psm_memory_mb", Real)
     check_param(ml_params, "pep_bin_size", Integer)
 
+    check_param(opt_params, "chromatogram_integration", Dict)
+    chrom_params = opt_params["chromatogram_integration"]
+    check_param(chrom_params, "trace_mode", String)
+    if !(chrom_params["trace_mode"] in ("combined", "separate"))
+        throw(InvalidParametersError(
+            "Invalid parameter optimization.chromatogram_integration.trace_mode: expected \"combined\" or \"separate\"",
+            chrom_params,
+        ))
+    end
+
     # Validate protein scoring parameters
     protein_scoring = params["proteinScoring"]
     check_param(protein_scoring, "min_peptides", Integer)

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
@@ -39,6 +39,24 @@ struct IntegrateChromatogramSearchResults <: SearchResults
     psms::Base.Ref{DataFrame}  # Chromatogram data per file
 end
 
+function _resolve_chromatogram_trace_type(
+    params::PioneerParameters,
+    min_fraction_transmitted::Float32,
+)
+    trace_mode = params.optimization.chromatogram_integration.trace_mode
+
+    if trace_mode == "combined"
+        return CombineTraces(min_fraction_transmitted)
+    elseif trace_mode == "separate"
+        return SeperateTraces()
+    end
+
+    throw(ArgumentError(
+        "Invalid optimization.chromatogram_integration.trace_mode=$(repr(trace_mode)); " *
+        "expected \"combined\" or \"separate\"",
+    ))
+end
+
 """
 Parameters for chromatogram integration search.
 """
@@ -68,10 +86,11 @@ struct IntegrateChromatogramSearchParameters{P<:PrecEstimation, I<:IsotopeTraceT
         # Extract relevant parameter groups
         search_params = params.search
 
-        # Hardcoded — formerly read from global.isotope_settings (removed from
-        # the public schema; values shipped at defaults in every config).
-        isotope_trace_type = SeperateTraces()
         min_fraction_transmitted = 0.25f0
+        isotope_trace_type = _resolve_chromatogram_trace_type(
+            params,
+            Float32(min_fraction_transmitted),
+        )
         prec_estimation = PartialPrecCapture()
 
         # max_rank hardcoded to typemax(UInt8); the library already enforces
@@ -196,16 +215,9 @@ function process_file!(
             getCenterMzs(spectra),
             getIsolationWidthMzs(spectra)
         )
-    end
-
-    if seperateTraces(params.isotope_tracetype)
-        fast_df_sort!(chromatograms, [:precursor_idx, :isotopes_captured, :rt])
     else
-        fast_df_sort!(chromatograms, [:precursor_idx, :rt])
-    end
-
-    # CombineTraces: compute fraction_transmitted AFTER sort (order-independent per-row calc)
-    if !seperateTraces(params.isotope_tracetype)
+        # Combined-trace integration needs the per-row transmission fraction, but
+        # must not group or sort points by isotope-capture state before integration.
         get_isotopes_captured!(
             chromatograms,
             getQuadTransmissionModel(search_context, ms_file_idx),
@@ -219,17 +231,28 @@ function process_file!(
             compute_isotope_set=false
         )
     end
+    sort_chromatograms_for_integration!(chromatograms, params.isotope_tracetype)
 
     # Integrate chromatographic peaks for each precursor (skip if no chromatograms extracted)
     if nrow(chromatograms) > 0
+        psm_isotopes_captured = nothing
+        if seperateTraces(params.isotope_tracetype)
+            apply_quant_trace_selection!(
+                passing_psms,
+                select_quant_trace_by_transmission(chromatograms),
+            )
+            psm_isotopes_captured = passing_psms[!, :isotopes_captured]
+        end
         integrate_precursors(
             chromatograms,
+            params.isotope_tracetype,
             params.min_fraction_transmitted,
             passing_psms[!, :precursor_idx],
             passing_psms[!, :scan_idx],
             passing_psms[!, :peak_area],
             passing_psms[!, :new_best_scan],
             passing_psms[!, :points_integrated],
+            isotopes_captured = psm_isotopes_captured,
             λ = params.wh_smoothing_strength
         )
     end

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
@@ -49,6 +49,39 @@ function build_chrom_index(prec_col::AbstractVector{UInt32}, n_rows::Int)
     return chrom_index, max_len
 end
 
+function build_chrom_index(chromatograms::DataFrame, ::CombineTraces)
+    return build_chrom_index(
+        chromatograms[!, :precursor_idx]::AbstractVector{UInt32},
+        nrow(chromatograms),
+    )
+end
+
+function build_chrom_index(chromatograms::DataFrame, ::SeperateTraces)
+    n_rows = nrow(chromatograms)
+    if n_rows == 0
+        return Dict{Tuple{UInt32, Tuple{Int8, Int8}}, UnitRange{Int}}(), 0
+    end
+
+    prec_col = chromatograms[!, :precursor_idx]::AbstractVector{UInt32}
+    iso_col = chromatograms[!, :isotopes_captured]::AbstractVector{Tuple{Int8, Int8}}
+    max_len = 0
+    chrom_index = Dict{Tuple{UInt32, Tuple{Int8, Int8}}, UnitRange{Int}}()
+    start_idx = 1
+    current_key = (prec_col[1], iso_col[1])
+    for row_idx in 2:n_rows
+        next_key = (prec_col[row_idx], iso_col[row_idx])
+        if next_key != current_key
+            chrom_index[current_key] = start_idx:(row_idx - 1)
+            max_len = max(max_len, row_idx - start_idx)
+            start_idx = row_idx
+            current_key = next_key
+        end
+    end
+    chrom_index[current_key] = start_idx:n_rows
+    max_len = max(max_len, n_rows - start_idx + 1)
+    return chrom_index, max_len
+end
+
 """
     find_nearest_scan(scan_indices::AbstractVector{UInt32}, target_scan::UInt32)
 
@@ -69,10 +102,78 @@ function find_nearest_scan(scan_indices::AbstractVector{UInt32}, target_scan::UI
     return nearest_idx
 end
 
+function sort_chromatograms_for_integration!(chromatograms::DataFrame, ::CombineTraces)
+    nrow(chromatograms) == 0 && return chromatograms
+    fast_df_sort!(chromatograms, [:precursor_idx, :rt])
+    return chromatograms
+end
+
+function sort_chromatograms_for_integration!(chromatograms::DataFrame, ::SeperateTraces)
+    nrow(chromatograms) == 0 && return chromatograms
+    fast_df_sort!(chromatograms, [:precursor_idx, :isotopes_captured, :rt])
+    return chromatograms
+end
+
+function sort_chromatograms_for_integration!(chromatograms::DataFrame)
+    return sort_chromatograms_for_integration!(chromatograms, CombineTraces(0.25f0))
+end
+
+function select_quant_trace_by_transmission(chromatograms::DataFrame)
+    prec_col = chromatograms[!, :precursor_idx]::AbstractVector{UInt32}
+    iso_col = chromatograms[!, :isotopes_captured]::AbstractVector{Tuple{Int8, Int8}}
+    fraction_col = chromatograms[!, :precursor_fraction_transmitted]::AbstractVector{Float32}
+    selected = Dict{UInt32, Tuple{Tuple{Int8, Int8}, Float32}}()
+
+    for i in eachindex(prec_col)
+        pid = prec_col[i]
+        iso = iso_col[i]
+        fraction = fraction_col[i]
+        if !haskey(selected, pid) || fraction > selected[pid][2] ||
+           (fraction == selected[pid][2] && iso < selected[pid][1])
+            selected[pid] = (iso, fraction)
+        end
+    end
+
+    return selected
+end
+
+function apply_quant_trace_selection!(psms::DataFrame, selected_quant_trace::Dict{UInt32, Tuple{Tuple{Int8, Int8}, Float32}})
+    prec_col = psms[!, :precursor_idx]::AbstractVector{UInt32}
+    iso_col = psms[!, :isotopes_captured]::AbstractVector{Tuple{Int8, Int8}}
+    fraction_col = psms[!, :precursor_fraction_transmitted]::AbstractVector{Float32}
+
+    for i in eachindex(prec_col)
+        selected = get(selected_quant_trace, prec_col[i], nothing)
+        selected === nothing && continue
+        iso_col[i] = selected[1]
+        fraction_col[i] = selected[2]
+    end
+
+    return psms
+end
+
+@inline function chromatogram_index_key(
+    ::CombineTraces,
+    precursor_idx::AbstractVector{UInt32},
+    isotopes_captured,
+    row_idx::Integer,
+)
+    return precursor_idx[row_idx]
+end
+
+@inline function chromatogram_index_key(
+    ::SeperateTraces,
+    precursor_idx::AbstractVector{UInt32},
+    isotopes_captured::AbstractVector{Tuple{Int8, Int8}},
+    row_idx::Integer,
+)
+    return (precursor_idx[row_idx], isotopes_captured[row_idx])
+end
+
 """
     integrate_precursors(chromatograms, min_fraction_transmitted, precursor_idx,
                          apex_scan_idx, peak_area, new_best_scan, points_integrated;
-                         λ=1.0f0)
+                         isotopes_captured=nothing, λ=1.0f0)
 
 Integrate chromatographic peaks for multiple precursors in parallel.
 
@@ -83,22 +184,23 @@ detection → trapezoidal integration). Results are written into the output vect
 `peak_area`, `new_best_scan`, and `points_integrated`.
 """
 function integrate_precursors(chromatograms::DataFrame,
+                             isotope_trace_type::IsotopeTraceType,
                              min_fraction_transmitted::Float32,
                              precursor_idx::AbstractVector{UInt32},
                              apex_scan_idx::AbstractVector{UInt32},
                              peak_area::AbstractVector{Float32},
                              new_best_scan::AbstractVector{UInt32},
                              points_integrated::AbstractVector{UInt32};
+                             isotopes_captured = nothing,
                              λ::Float32 = 1.0f0
                              )
     n_pad = Int64(0)
-    prec_col = chromatograms[!, :precursor_idx]::AbstractVector{UInt32}
     rt_all = chromatograms[!, :rt]::AbstractVector{Float32}
     scan_idx_all = chromatograms[!, :scan_idx]::AbstractVector{UInt32}
     intensity_all = chromatograms[!, :intensity]::AbstractVector{Float32}
     fraction_all = chromatograms[!, :precursor_fraction_transmitted]::AbstractVector{Float32}
 
-    chrom_index, max_chrom_len = build_chrom_index(prec_col, nrow(chromatograms))
+    chrom_index, max_chrom_len = build_chrom_index(chromatograms, isotope_trace_type)
     N = max_chrom_len + (2*n_pad)
 
     # Partition work into chunks, then distribute chunks to exactly nthreads() tasks
@@ -120,13 +222,18 @@ function integrate_precursors(chromatograms::DataFrame,
         for chunk_idx in task_ranges[batch_id]
             chunk = all_chunks[chunk_idx]
             for i in chunk
-                prec_id = precursor_idx[i]
                 apex_scan = apex_scan_idx[i]
+                chrom_key = chromatogram_index_key(
+                    isotope_trace_type,
+                    precursor_idx,
+                    isotopes_captured,
+                    i,
+                )
 
-                if !haskey(chrom_index, prec_id)
+                if !haskey(chrom_index, chrom_key)
                     continue
                 end
-                chrom_range = chrom_index[prec_id]
+                chrom_range = chrom_index[chrom_key]
 
                 avg_cycle_time = (rt_all[last(chrom_range)] - rt_all[first(chrom_range)]) / length(chrom_range)
 
@@ -172,6 +279,28 @@ function integrate_precursors(chromatograms::DataFrame,
     end
 
     return nothing
+end
+
+function integrate_precursors(chromatograms::DataFrame,
+                             min_fraction_transmitted::Float32,
+                             precursor_idx::AbstractVector{UInt32},
+                             apex_scan_idx::AbstractVector{UInt32},
+                             peak_area::AbstractVector{Float32},
+                             new_best_scan::AbstractVector{UInt32},
+                             points_integrated::AbstractVector{UInt32};
+                             λ::Float32 = 1.0f0
+                             )
+    return integrate_precursors(
+        chromatograms,
+        CombineTraces(Float32(min_fraction_transmitted)),
+        min_fraction_transmitted,
+        precursor_idx,
+        apex_scan_idx,
+        peak_area,
+        new_best_scan,
+        points_integrated;
+        λ = λ,
+    )
 end
 
 #==========================================================
@@ -873,4 +1002,3 @@ function process_final_psms!(
     
     return nothing
 end
-

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/mbr_ftr.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/mbr_ftr.jl
@@ -482,7 +482,7 @@ function apply_mbr_filter_paired!(
     #    Selectable via ENV var PIONEER_FTR_MODE = "qval" (default) or "pep".
     qvals_top = qvals_double[1:n_cand]
     pep_top   = pep_double[1:n_cand]
-    ftr_mode  = get(ENV, "PIONEER_FTR_MODE", "qval")
+    ftr_mode  = get(ENV, "PIONEER_FTR_MODE", "pep")
     # PIONEER_FTR_ALPHA env var overrides the default `alpha` kwarg so users
     # can sweep without recompiling.
     α_use = parse(Float32, get(ENV, "PIONEER_FTR_ALPHA", string(alpha)))

--- a/src/utils/maxLFQ.jl
+++ b/src/utils/maxLFQ.jl
@@ -36,7 +36,16 @@ was not seen in the i'th experiment, then S[i, j] == missing.
 ### Examples 
 
 """
-function getS(peptides::AbstractVector{UInt32}, peptides_dict::Dict{UInt32, Int64}, experiments::AbstractVector{UInt16}, experiments_dict::Dict{UInt16, Int64}, abundance::AbstractVector{Union{T, Missing}}, M::Int, N::Int) where {T<:Real}
+function getS(
+    peptides::AbstractVector{UInt32},
+    peptides_dict::Dict{UInt32, Int64},
+    experiments::AbstractVector{<:Integer},
+    experiments_dict::Dict{E, Int64},
+    abundance::AbstractVector{<:Union{Missing, Real}},
+    M::Int,
+    N::Int
+) where {E<:Integer}
+    T = Base.nonmissingtype(eltype(abundance))
     S = Matrix{Union{Missing, T}}(missing, M, N)
     for i in eachindex(peptides)
         if !ismissing(abundance[i])
@@ -453,14 +462,14 @@ function getProtAbundance(protein::String,
                             entrap_id::UInt8,
                             species::String,
                             peptides::AbstractVector{UInt32}, 
-                            experiments::AbstractVector{UInt16}, 
+                            experiments::AbstractVector{<:Integer},
                             use_for_quant::AbstractVector{Bool},
-                            abundance::AbstractVector{Union{T, Missing}},
-                            global_qvals::AbstractVector{Union{F,Missing}},
-                            qvals::AbstractVector{Union{F,Missing}},
-                            peps::AbstractVector{Union{F,Missing}},
-                            pg_scores::AbstractVector{Union{F,Missing}},
-                            global_pg_scores::AbstractVector{Union{F,Missing}},
+                            abundance::AbstractVector{<:Union{Missing, Real}},
+                            global_qvals::AbstractVector{<:Union{Missing, Real}},
+                            qvals::AbstractVector{<:Union{Missing, Real}},
+                            peps::AbstractVector{<:Union{Missing, Real}},
+                            pg_scores::AbstractVector{<:Union{Missing, Real}},
+                            global_pg_scores::AbstractVector{<:Union{Missing, Real}},
                             target_out::Vector{Union{Missing, Bool}},
                             entrap_id_out::Vector{Union{Missing, UInt8}},
                             species_out::Vector{Union{Missing, String}},
@@ -473,7 +482,7 @@ function getProtAbundance(protein::String,
                             pep_out::Vector{Union{Missing, Float32}},
                             pg_score_out::Vector{Union{Missing, Float32}},
                             global_pg_score_out::Vector{Union{Missing, Float32}},
-                            total_peak_area_out::Vector{Union{Missing, Float32}}) where {T <: Real, F <: Real}
+                            total_peak_area_out::Vector{Union{Missing, Float32}})
 
     unique_experiments = unique(experiments)
     unique_peptides = unique(peptides)
@@ -510,12 +519,12 @@ function getProtAbundance(protein::String,
                             species::String,
                             protein::String,
                             unique_peptides::Vector{UInt32}, 
-                            log2_abundances::AbstractVector{Union{Missing, T}},
-                            global_qvals::AbstractVector{Union{Float32,Missing}},
-                            qvals::AbstractVector{Union{Float32,Missing}},
-                            peps::AbstractVector{Union{Float32,Missing}},
-                            pg_scores::AbstractVector{Union{Float32,Missing}},
-                            global_pg_scores::AbstractVector{Union{Float32,Missing}},
+                            log2_abundances::AbstractVector{Union{Missing, A}},
+                            global_qvals::AbstractVector{<:Union{Missing, Real}},
+                            qvals::AbstractVector{<:Union{Missing, Real}},
+                            peps::AbstractVector{<:Union{Missing, Real}},
+                            pg_scores::AbstractVector{<:Union{Missing, Real}},
+                            global_pg_scores::AbstractVector{<:Union{Missing, Real}},
                             target_out::Vector{Union{Missing, Bool}},
                             entrap_id_out::Vector{Union{Missing, UInt8}},
                             species_out::Vector{Union{Missing, String}}, 
@@ -529,13 +538,13 @@ function getProtAbundance(protein::String,
                             global_pg_score_out::Vector{Union{Missing, Float32}},
                             total_peak_area_out::Vector{Union{Missing, Float32}},
                             experiments_out::Vector{Union{Missing, I}}, 
-                            S::Matrix{Union{Missing, T}},
-                            total_peak_area::AbstractVector{Union{Missing, Float32}}) where {T<:Real,I<:Integer}
+                            S::Matrix{Union{Missing, S_T}},
+                            total_peak_area::AbstractVector{Union{Missing, Float32}}) where {A<:Real,S_T<:Real,I<:Integer}
         
         function appendPeptides!(peptides_out::Vector{Union{Missing, Vector{Union{Missing, UInt32}}}}, 
                                 row_idx::Int64,
                                 unique_peptides::Vector{UInt32}, 
-                                S::Matrix{Union{Missing,T}})
+                                S::Matrix{Union{Missing,S_T}})
             #Each column of S corresponds to and experiment and each row corresponds to a peptide
             #Need to get each non-missing peptide for each experiment. Concatenate the non-missing peptides
             #For and experiment with a semi-colon. See example in the getProtAbundance docstring 

--- a/test/UnitTests/test_chromatogram_integration_trace_order.jl
+++ b/test/UnitTests/test_chromatogram_integration_trace_order.jl
@@ -1,0 +1,148 @@
+function _trace_order_test_chromatograms()
+    return DataFrame(
+        precursor_idx = UInt32[10, 10, 10, 10, 11],
+        isotopes_captured = [(Int8(0), Int8(1)), (Int8(0), Int8(1)),
+                             (Int8(1), Int8(2)), (Int8(1), Int8(2)),
+                             (Int8(0), Int8(1))],
+        rt = Float32[2.0, 4.0, 1.0, 3.0, 1.5],
+        scan_idx = UInt32[20, 40, 10, 30, 15],
+        intensity = Float32[2.0, 4.0, 1.0, 3.0, 5.0],
+        precursor_fraction_transmitted = Float32[0.7, 0.7, 0.35, 0.35, 0.8],
+    )
+end
+
+@testset "combined chromatogram integration trace ordering" begin
+    chromatograms = _trace_order_test_chromatograms()
+
+    Pioneer.sort_chromatograms_for_integration!(chromatograms, Pioneer.CombineTraces(0.25f0))
+
+    target_rows = findall(==(UInt32(10)), chromatograms.precursor_idx)
+    @test chromatograms.rt[target_rows] == Float32[1.0, 2.0, 3.0, 4.0]
+    @test chromatograms.scan_idx[target_rows] == UInt32[10, 20, 30, 40]
+    @test chromatograms.isotopes_captured[target_rows] == [
+        (Int8(1), Int8(2)),
+        (Int8(0), Int8(1)),
+        (Int8(1), Int8(2)),
+        (Int8(0), Int8(1)),
+    ]
+
+    chrom_index, max_chrom_len = Pioneer.build_chrom_index(
+        chromatograms,
+        Pioneer.CombineTraces(0.25f0),
+    )
+    @test max_chrom_len == 4
+    @test chrom_index[UInt32(10)] == 1:4
+end
+
+@testset "separate chromatogram integration trace ordering" begin
+    chromatograms = _trace_order_test_chromatograms()
+
+    Pioneer.sort_chromatograms_for_integration!(chromatograms, Pioneer.SeperateTraces())
+
+    target_rows = findall(==(UInt32(10)), chromatograms.precursor_idx)
+    @test chromatograms.rt[target_rows] == Float32[2.0, 4.0, 1.0, 3.0]
+    @test chromatograms.isotopes_captured[target_rows] == [
+        (Int8(0), Int8(1)),
+        (Int8(0), Int8(1)),
+        (Int8(1), Int8(2)),
+        (Int8(1), Int8(2)),
+    ]
+
+    chrom_index, max_chrom_len = Pioneer.build_chrom_index(
+        chromatograms,
+        Pioneer.SeperateTraces(),
+    )
+    @test max_chrom_len == 2
+    @test chrom_index[(UInt32(10), (Int8(0), Int8(1)))] == 1:2
+    @test chrom_index[(UInt32(10), (Int8(1), Int8(2)))] == 3:4
+end
+
+@testset "separate trace quantification uses highest transmission trace" begin
+    chromatograms = DataFrame(
+        precursor_idx = UInt32[10, 10, 10, 10, 20],
+        isotopes_captured = [(Int8(1), Int8(2)), (Int8(0), Int8(1)),
+                             (Int8(1), Int8(2)), (Int8(0), Int8(1)),
+                             (Int8(0), Int8(1))],
+        rt = Float32[1.0, 1.0, 2.0, 2.0, 1.0],
+        scan_idx = UInt32[10, 10, 20, 20, 10],
+        intensity = Float32[1.0, 10.0, 2.0, 20.0, 3.0],
+        precursor_fraction_transmitted = Float32[0.35, 0.82, 0.40, 0.80, 0.55],
+    )
+    passing_psms = DataFrame(
+        precursor_idx = UInt32[10, 20],
+        isotopes_captured = [(Int8(1), Int8(2)), (Int8(1), Int8(2))],
+        precursor_fraction_transmitted = Float32[0.35, 0.1],
+    )
+
+    selected = Pioneer.select_quant_trace_by_transmission(chromatograms)
+    Pioneer.apply_quant_trace_selection!(passing_psms, selected)
+
+    @test passing_psms.isotopes_captured == [(Int8(0), Int8(1)), (Int8(0), Int8(1))]
+    @test passing_psms.precursor_fraction_transmitted == Float32[0.82, 0.55]
+end
+
+@testset "legacy chromatogram integration sort defaults to combined" begin
+    chromatograms = DataFrame(
+        precursor_idx = UInt32[10, 10, 10, 10, 11],
+        isotopes_captured = [(Int8(0), Int8(1)), (Int8(0), Int8(1)),
+                             (Int8(1), Int8(2)), (Int8(1), Int8(2)),
+                             (Int8(0), Int8(1))],
+        rt = Float32[2.0, 4.0, 1.0, 3.0, 1.5],
+        scan_idx = UInt32[20, 40, 10, 30, 15],
+        intensity = Float32[2.0, 4.0, 1.0, 3.0, 5.0],
+        precursor_fraction_transmitted = Float32[0.7, 0.7, 0.35, 0.35, 0.8],
+    )
+
+    Pioneer.sort_chromatograms_for_integration!(chromatograms)
+
+    target_rows = findall(==(UInt32(10)), chromatograms.precursor_idx)
+    @test chromatograms.rt[target_rows] == Float32[1.0, 2.0, 3.0, 4.0]
+    @test chromatograms.scan_idx[target_rows] == UInt32[10, 20, 30, 40]
+    @test chromatograms.isotopes_captured[target_rows] == [
+        (Int8(1), Int8(2)),
+        (Int8(0), Int8(1)),
+        (Int8(1), Int8(2)),
+        (Int8(0), Int8(1)),
+    ]
+end
+
+function _write_trace_mode_params(path::AbstractString; trace_mode = nothing)
+    trace_mode_json = trace_mode === nothing ? "" : """
+        ,
+        "optimization": {
+            "chromatogram_integration": {
+                "trace_mode": "$(trace_mode)"
+            }
+        }
+    """
+
+    write(path, """
+    {
+        "paths": {
+            "ms_data": "/tmp/pioneer-ms-data",
+            "library": "/tmp/pioneer-lib.poin",
+            "results": "/tmp/pioneer-results"
+        }
+        $(trace_mode_json)
+    }
+    """)
+end
+
+@testset "chromatogram integration trace mode config" begin
+    tmp = mktempdir()
+
+    default_path = joinpath(tmp, "default.json")
+    _write_trace_mode_params(default_path)
+    default_params = Pioneer.parse_pioneer_parameters(default_path)
+    default_integration = Pioneer.IntegrateChromatogramSearchParameters(default_params)
+    @test default_integration.isotope_tracetype isa Pioneer.CombineTraces
+
+    separate_path = joinpath(tmp, "separate.json")
+    _write_trace_mode_params(separate_path; trace_mode = "separate")
+    checked = Pioneer.checkParams(separate_path)
+    @test checked["optimization"]["chromatogram_integration"]["trace_mode"] == "separate"
+
+    separate_params = Pioneer.parse_pioneer_parameters(separate_path)
+    separate_integration = Pioneer.IntegrateChromatogramSearchParameters(separate_params)
+    @test separate_integration.isotope_tracetype isa Pioneer.SeperateTraces
+end

--- a/test/UnitTests/test_maxLFQ.jl
+++ b/test/UnitTests/test_maxLFQ.jl
@@ -223,6 +223,47 @@ end
     end
 end
 
+@testset "getProtAbundance accepts non-nullable normalized quant values" begin
+    peptides  = UInt32[1, 1, 1, 2, 2, 2]
+    exps      = UInt16[1, 2, 3, 1, 2, 3]
+    use_quant = Bool[true, true, true, true, true, true]
+    abundance = Float64[10.0, 20.0, 40.0, 5.0, 10.0, 20.0]
+    qvals     = Float32[0.01f0, 0.01f0, 0.01f0, 0.02f0, 0.02f0, 0.02f0]
+    gqvals    = Float32[0.005f0, 0.005f0, 0.005f0, 0.01f0, 0.01f0, 0.01f0]
+    peps      = Float32[0.05f0, 0.05f0, 0.05f0, 0.1f0, 0.1f0, 0.1f0]
+    scores    = Float32[5.0f0, 5.0f0, 5.0f0, 3.0f0, 3.0f0, 3.0f0]
+    gscores   = Float32[4.0f0, 4.0f0, 4.0f0, 2.0f0, 2.0f0, 2.0f0]
+
+    n_experiments = 3
+    target_out       = Vector{Union{Missing, Bool}}(missing, n_experiments)
+    entrap_out       = Vector{Union{Missing, UInt8}}(missing, n_experiments)
+    species_out      = Vector{Union{Missing, String}}(missing, n_experiments)
+    protein_out      = Vector{Union{Missing, String}}(missing, n_experiments)
+    peptides_out     = Vector{Union{Missing, Vector{Union{Missing, UInt32}}}}(missing, n_experiments)
+    experiments_out  = Vector{Union{Missing, UInt32}}(missing, n_experiments)
+    log2_abund_out   = Vector{Union{Missing, Float32}}(missing, n_experiments)
+    gqval_out        = Vector{Union{Missing, Float32}}(missing, n_experiments)
+    qval_out         = Vector{Union{Missing, Float32}}(missing, n_experiments)
+    pep_out          = Vector{Union{Missing, Float32}}(missing, n_experiments)
+    score_out        = Vector{Union{Missing, Float32}}(missing, n_experiments)
+    gscore_out       = Vector{Union{Missing, Float32}}(missing, n_experiments)
+    peak_area_out    = Vector{Union{Missing, Float32}}(missing, n_experiments)
+
+    Pioneer.getProtAbundance(
+        "ProteinA", 1, true, UInt8(0), "HUMAN",
+        peptides, exps, use_quant, abundance,
+        gqvals, qvals, peps, scores, gscores,
+        target_out, entrap_out, species_out, protein_out,
+        peptides_out, experiments_out, log2_abund_out,
+        gqval_out, qval_out, pep_out, score_out, gscore_out,
+        peak_area_out,
+    )
+
+    @test all(!ismissing, log2_abund_out)
+    @test all(!ismissing, peak_area_out)
+    @test all(x -> x == "ProteinA", protein_out)
+end
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # getProtAbundance — missing data handling
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/test/runtests_part3_units.jl
+++ b/test/runtests_part3_units.jl
@@ -35,6 +35,7 @@ include("./UnitTests/test_fused_prec_filters.jl")
 include("./UnitTests/test_run_fused.jl")
 include("./UnitTests/test_sort_detailed_fragments.jl")
 include("./UnitTests/test_feature_finiteness.jl")
+include("./UnitTests/test_chromatogram_integration_trace_order.jl")
 
 # FileOperations focused tests
 include("./utils/FileOperations/io/test_arrow_operations_basic.jl")


### PR DESCRIPTION
## Summary

- Add `optimization.chromatogram_integration.trace_mode`, defaulting to `"combined"`.
- Fix chromatogram integration ordering so combined traces are sorted/indexed by precursor, while separate traces are sorted/indexed by precursor and isotope-capture state.
- In separate-trace mode, select the isotope-capture trace with the highest precursor fraction transmitted for each precursor before quantification.
- Add regression coverage for combined/separate trace ordering, quant trace selection, config parsing, and default behavior.

## Notes

Default behavior remains combined traces. To use separate traces:

```json
{
  "optimization": {
    "chromatogram_integration": {
      "trace_mode": "separate"
    }
  }
}