### PR TITLE
fix: allow probit fallback in low-data MainSearch model selection

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/scoring.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/scoring.jl
@@ -284,8 +284,18 @@ function train_psm_classifier_with_fallback(
         n_lgbm_default = _oof_count(lgbm_scores)
         adaptive = n_lgbm_default < ADAPTIVE_HP_TARGET_THRESHOLD
     end
-    candidates = [(name="lgbm_default", scores=lgbm_scores, infold=lgbm_infold_scores,
-                   last=last_classifier, predictors=lgbm_predictors, oof=n_lgbm_default)]
+    candidate_type = @NamedTuple{
+        name::String,
+        scores::Vector{Vector{Float64}},
+        infold::Union{Nothing, Vector{Vector{Float64}}},
+        last::Union{Nothing, LightGBM.LGBMClassification},
+        predictors::Vector{Any},
+        oof::Int64,
+    }
+    candidates = candidate_type[
+        (name="lgbm_default", scores=lgbm_scores, infold=lgbm_infold_scores,
+         last=last_classifier, predictors=lgbm_predictors, oof=n_lgbm_default)
+    ]
 
     if adaptive
         for (variant_name, hp_over) in pairs(ADAPTIVE_HP_OVERRIDES)

--- a/test/UnitTests/test_mainsearch_irt_refinement.jl
+++ b/test/UnitTests/test_mainsearch_irt_refinement.jl
@@ -5,12 +5,62 @@ using Pioneer
 using Pioneer: MainSearchIrtCorrectionModel, MainSearchIrtRefinement, _compute_phase2_columns!
 using Pioneer: _passing_precursor_targets, refine_mainsearch_irt_predictions!
 using Pioneer: reapply_psm_classifier_and_select_best!, train_lgbm_and_select_best
+using Pioneer: train_psm_classifier_with_fallback
 
 struct MainSearchMockPrecursors <: Pioneer.LibraryPrecursors
     sequence::Vector{String}
     structural_mods::Vector{Union{Missing, String}}
     mz::Vector{Float32}
     irt::Vector{Float32}
+end
+
+@testset "MainSearch classifier fallback" begin
+    @testset "low-data model selection accepts non-LightGBM candidates" begin
+        psms = DataFrame(
+            target = Bool[
+                true, false, false, true,
+                true, false, false, true,
+                true, false, false, true,
+            ],
+            cv_fold = UInt8[
+                1, 0, 1, 0,
+                1, 0, 1, 0,
+                1, 0, 1, 0,
+            ],
+            discriminant = Float32[
+                0.9, 0.1, 0.2, 0.8,
+                0.85, 0.15, 0.25, 0.75,
+                0.88, 0.12, 0.22, 0.78,
+            ],
+        )
+
+        tiny_lgbm_hp = (
+            num_iterations = 3,
+            learning_rate = 0.2,
+            max_depth = 2,
+            num_leaves = 3,
+            min_data_in_leaf = 1,
+            feature_fraction = 1.0,
+            bagging_fraction = 1.0,
+            bagging_freq = 0,
+            is_unbalance = false,
+            max_bin = 16,
+            lambda_l1 = 0.0,
+            lambda_l2 = 0.0,
+        )
+
+        scores, infold_scores, _last_classifier, info = train_psm_classifier_with_fallback(
+            psms;
+            features = [:discriminant],
+            lgbm_hp = tiny_lgbm_hp,
+        )
+
+        @test length(scores) == nrow(psms)
+        @test infold_scores === nothing
+        @test info.low_data
+        @test haskey(info.candidate_oof, "probit")
+        @test all(isfinite, scores)
+    end
 end
 
 Pioneer.getSequence(p::MainSearchMockPrecursors) = p.sequence


### PR DESCRIPTION
## Summary
- Fixes a `MethodError` in MainSearch low-data classifier selection when LightGBM and probit candidates are evaluated together. It happens when we have complex runs and simple runs mixed together (like the APMS dataset that had some blanks).
- Explicitly types the candidate list so the selected model can carry either a `LightGBM.LGBMClassification` or `nothing`.
- Adds a regression test covering low-data model selection with a non-LightGBM candidate.