### PR TITLE
Fix Windows EACCES on MBR sidecar cleanup in PrecursorScoringSearch

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/mbr_streaming.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/mbr_streaming.jl
@@ -578,7 +578,14 @@ function merge_mbr_sidecars_into_main!(file_paths::Vector{String}; cleanup::Bool
         writeArrow(new_sidecar_path, side_df)
 
         if cleanup
-            rm(pass1_path); rm(mbr_path); rm(rec_path)
+            # Release the Arrow mmap handles before deleting: on Windows a raw
+            # rm() of a memory-mapped file throws EACCES until the mapping is
+            # released. Mirror the safeRm pattern used elsewhere in this module.
+            main = nothing; pass1 = nothing; mbr = nothing; rec = nothing
+            GC.gc(false)
+            safeRm(pass1_path, nothing; force=true)
+            safeRm(mbr_path, nothing; force=true)
+            safeRm(rec_path, nothing; force=true)
         end
         n_merged += 1
     end


### PR DESCRIPTION
## Problem
On Windows, `SearchDIA` crashes during the OOM MBR streaming path with:
```
IOError: unlink(".../temp_data/main_search_psms/1_fold0.arrow.pass1_sidecar.arrow"): permission denied (EACCES)
```
`merge_mbr_sidecars_into_main!` (`PrecursorScoringSearch/mbr_streaming.jl`) deletes the pass1/mbr/recovery sidecars with raw `rm()` while their `Arrow.Table` memory-maps are still open. A memory-mapped file cannot be unlinked on Windows, so every search that runs this path fails.

## Fix
Release the mmap handles (set to `nothing` + `GC.gc(false)`), then delete via `safeRm(...; force=true)` — the same pattern already used throughout this module and the rest of the SearchDIA pipeline.

## Testing
Ran a full `SearchDIA` on Windows (SingleCell, human Altimeter library): completed cleanly (7,248 precursor rows, 2,504 protein-group rows), `delete_temp` cleanup succeeded, and no `EACCES`/`IOError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)