### PR TITLE
Quiet safeRm retry logging (demote per-try message to @debug)

### DIFF
--- a/src/utils/FileOperations/io/safeFileOps.jl
+++ b/src/utils/FileOperations/io/safeFileOps.jl
@@ -53,7 +53,10 @@ function safeRm(fpath::String, file_handle; force::Bool=false)
                 run(`cmd /c del /f /q "$fpath"`)
                 return nothing
             catch
-                @user_info "safe_rm failed on try i=$i"
+                # Transient on Windows: the file is briefly still memory-mapped.
+                # We retry (and ultimately succeed), so keep this at debug level
+                # rather than spamming the user log on every retry.
+                @debug "safe_rm retry $i for $fpath"
                 if i == max_retries
                     # If all retries failed, try Windows-specific deletion
                     try


### PR DESCRIPTION
## Problem
On Windows, `safeRm` deletes Arrow temp files that are briefly still memory-mapped. The first `cmd del` attempts fail (file lock), so it retries and a later attempt succeeds — but every failed attempt logs `safe_rm failed on try i=N` at user/INFO level. During the OOM precursor-scoring / MBR path this produces dozens-to-hundreds of noise lines per search.

## Fix
Demote the per-retry message to `@debug`. Behavior is unchanged (still retries, still succeeds); genuine give-up cases still surface via the existing `@user_warn` rename-fallback path.

## Notes
Follow-up to #402. Verified on Windows: searches complete and `temp_data` is fully removed; this only removes log spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)