### PR TITLE
[codex] Use C13 isotope mass spacing

### DIFF
--- a/src/Pioneer.jl
+++ b/src/Pioneer.jl
@@ -701,7 +701,7 @@ files_loaded = importScripts()
 #include(joinpath(@__DIR__, "Routines","LibrarySearch","method"s,"loadSpectralLibrary.jl"))
 const methods_path = joinpath(@__DIR__, "Routines","LibrarySearch")
 
-# H2O, PROTON, NEUTRON constants are defined in get_mz.jl and available via importScripts()
+# H2O, PROTON, and isotope-spacing constants are defined in get_mz.jl and available via importScripts()
 
 # Spectral deconvolution solver defaults (Huber / OLS / Poisson MM coordinate descent)
 const DECONV_MAX_ITER::Int64 = Int64(1000)

--- a/src/Routines/BuildSpecLib/utils/get_mz.jl
+++ b/src/Routines/BuildSpecLib/utils/get_mz.jl
@@ -20,7 +20,8 @@
 ##########
 const H2O::Float64 = Float64(18.010565)
 const PROTON::Float64 = Float64(1.0072764)
-const NEUTRON::Float64 = Float64(1.00335)
+const C13_C12_MASS_DIFF::Float64 = Float64(13.00335483507 - 12.0)
+const C13_C12_MASS_DIFF_F32::Float32 = Float32(C13_C12_MASS_DIFF)
 
 const default_mods::Dict{String, Float64} = Dict{String, Float64}(
     "Carb" => Float64(57.021464))

--- a/src/Routines/SearchDIA/CommonSearchUtils/fusedMatch.jl
+++ b/src/Routines/SearchDIA/CommonSearchUtils/fusedMatch.jl
@@ -467,9 +467,6 @@ function prepare_scan_peaks!(corrected::Vector{Float32},
     return n
 end
 
-const NEUTRON_F32 = Float32(1.00335)
-
-
 """
     scan_for_nearest_in_window(corrected_mz, obs_low, obs_high,
                                 start_idx, n_peaks, iso_mz, conservative_high)
@@ -576,16 +573,16 @@ True iff `|prec_irt - scan_irt| <= irt_tol`. Boundary inclusive.
     quad_window_with_iso_bounds(qfunc, prec_charge, iso_err_bounds) -> (low, high)
 
 Returns the precursor-m/z acceptance window: the quadrupole bounds widened
-by ±NEUTRON/charge × isotope-error bounds (so a precursor whose monoisotopic
+by ±C13_C12_MASS_DIFF/charge × isotope-error bounds (so a precursor whose monoisotopic
 m/z sits outside the literal quad window can still be admitted via an
 allowed isotope offset).
 """
 @inline function quad_window_with_iso_bounds(qfunc::QuadTransmissionFunction,
         prec_charge::Integer, iso_err_bounds::Tuple{<:Integer, <:Integer})
     low  = getPrecMinBound(qfunc) -
-           Float32(NEUTRON * first(iso_err_bounds) / prec_charge)
+           Float32(C13_C12_MASS_DIFF * first(iso_err_bounds) / prec_charge)
     high = getPrecMaxBound(qfunc) +
-           Float32(NEUTRON * last(iso_err_bounds)  / prec_charge)
+           Float32(C13_C12_MASS_DIFF * last(iso_err_bounds)  / prec_charge)
     return low, high
 end
 
@@ -605,7 +602,7 @@ and `frag_charge_inv = 1 / frag_charge`. iso_idx=0 returns the monoisotopic
 m/z. Caller hoists the reciprocal so this stays an FMA per call.
 """
 @inline iso_mz_for(frag_mz::Float32, iso_idx::Integer, frag_charge_inv::Float32) =
-    Float32(frag_mz + Float32(iso_idx) * NEUTRON_F32 * frag_charge_inv)
+    Float32(frag_mz + Float32(iso_idx) * C13_C12_MASS_DIFF_F32 * frag_charge_inv)
 
 """
     in_frag_mz_window(iso_mz, lo, hi) -> Bool

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
@@ -542,9 +542,9 @@ function getPrecursorWindowRange(
     isotope_err_bounds::Tuple{I, I}
 ) where {I<:Integer}
     start = searchsortedfirst(precs, by = x->last(x),
-        min_prec_mz - first(isotope_err_bounds)*NEUTRON/2)
+        min_prec_mz - first(isotope_err_bounds)*C13_C12_MASS_DIFF/2)
     stop = searchsortedlast(precs, by = x->last(x),
-        max_prec_mz + last(isotope_err_bounds)*NEUTRON/2)
+        max_prec_mz + last(isotope_err_bounds)*C13_C12_MASS_DIFF/2)
     return start, stop
 end
 
@@ -553,8 +553,8 @@ function withinQuadrupoleBounds(
     min_prec_mz::Float32, max_prec_mz::Float32,
     isotope_err_bounds::Tuple{I, I}
 ) where {I<:Integer}
-    mz_low = min_prec_mz - first(isotope_err_bounds)*NEUTRON/prec_charge
-    mz_high = max_prec_mz + last(isotope_err_bounds)*NEUTRON/prec_charge
+    mz_low = min_prec_mz - first(isotope_err_bounds)*C13_C12_MASS_DIFF/prec_charge
+    mz_high = max_prec_mz + last(isotope_err_bounds)*C13_C12_MASS_DIFF/prec_charge
     return mz_low ≤ prec_mz ≤ mz_high
 end
 

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
@@ -289,7 +289,8 @@ end
 function _ms1_lookup_chunk!(psms, spectra,
                              prec_mzs, prec_charges, prec_sulfurs, iso_splines,
                              scan_to_ms1::Vector{Int32},
-                             ms1_ppm_tol::Float32, ms1_ppm_offset::Float32, NEUTRON::Float32,
+                             ms1_ppm_tol::Float32, ms1_ppm_offset::Float32,
+                             c13_c12_mass_diff::Float32,
                              chunk_start::Int, chunk_end::Int)
     # Per-task scratch buffers; reused (resize-only) across cache misses
     # within this chunk. Type-stable Vector{Float32}.
@@ -317,7 +318,7 @@ function _ms1_lookup_chunk!(psms, spectra,
         # ms1_m0_mass_err_ppm is computed against the shifted (bias-corrected)
         # target so its zero point matches the calibration.
         target_m0 = prec_mz * (1f0 + ms1_ppm_offset * 1f-6)
-        target_m1 = target_m0 + NEUTRON / Float32(prec_chg)
+        target_m1 = target_m0 + c13_c12_mass_diff / Float32(prec_chg)
 
         m0_hit, m0_int, m0_mz = _ms1_find_peak(cached_mz, cached_int, target_m0, ms1_ppm_tol)
         m1_hit, m1_int, _    = _ms1_find_peak(cached_mz, cached_int, target_m1, ms1_ppm_tol)
@@ -423,8 +424,6 @@ function add_ms1_lookup_features!(psms::DataFrame,
     prec_sulfurs   = getSulfurCount(precursors)
     iso_splines    = getIsoSplines(getSearchData(search_context)[1])
 
-    NEUTRON = Float32(1.00335)
-
     # Parallel per-PSM lookup. Each PSM writes to disjoint indices in the output
     # columns (ms1_m0_intensity[i], etc.) so no synchronization needed. We use
     # Threads.@spawn per chunk so each task keeps its own ms1-spectrum cache.
@@ -440,7 +439,8 @@ function add_ms1_lookup_features!(psms::DataFrame,
             psms, spectra,
             prec_mzs, prec_charges, prec_sulfurs, iso_splines,
             scan_to_ms1,
-            Float32(ms1_ppm_tol), Float32(ms1_ppm_offset), NEUTRON,
+            Float32(ms1_ppm_tol), Float32(ms1_ppm_offset),
+            C13_C12_MASS_DIFF_F32,
             chunk_start, chunk_end
         )
     end

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ms1_diagnostic.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ms1_diagnostic.jl
@@ -8,7 +8,6 @@
 
 const MS1_DIAG_WINDOW_PPM = 100.0f0
 const MS1_DIAG_TOL_K_MAD  = 5.0f0
-const MS1_DIAG_NEUTRON    = Float32(1.00335)
 
 # Inlined minimal nearest-peak finder. Uses Julia's searchsortedfirst rather
 # than the perf-tuned bsearch_hybrid since this only runs once per file on a
@@ -109,7 +108,7 @@ function collect_ms1_residuals(spectra, psms::DataFrame, search_context, ms_file
         prec_chg = Int(prec_charges[pid]); prec_chg == 0 && (prec_chg = 1)
 
         for iso in 0:2
-            target = prec_mz + Float32(iso) * MS1_DIAG_NEUTRON / Float32(prec_chg)
+            target = prec_mz + Float32(iso) * C13_C12_MASS_DIFF_F32 / Float32(prec_chg)
             hit, obs_mz = _ms1_diag_find_peak(cached_mz, target, MS1_DIAG_WINDOW_PPM)
             if hit
                 push!(residuals, (obs_mz - target) / target * 1f6)

--- a/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/utils.jl
@@ -206,7 +206,7 @@ function add_columns!(
     prec_charge = [lib_prec_charge[pid] for pid in precursor_idx]
     sulfur_count = [lib_sulfur_count[pid] for pid in precursor_idx]
     #The iso_idx is 1 indexed. So the M0 has an index of 1, the M+1 had an index of 2, etc.
-    iso_mz = Float32.(mono_mz .+ NEUTRON.*(iso_idx.-1.0f0)./prec_charge)
+    iso_mz = Float32.(mono_mz .+ C13_C12_MASS_DIFF.*(iso_idx.-1.0f0)./prec_charge)
     mz_offset = iso_mz .- center_mz
     δ = zeros(Float32, length(precursor_idx))
     for i in range(1, length(precursor_idx))
@@ -565,7 +565,7 @@ function summarize_precursor(
     #If we only got the M0
     if (length(iso_idx) == 1) && (iso_idx[1] == 1)
         m0_idx = 1
-        m1_mz = iso_mz[m0_idx] + (NEUTRON/prec_charge[m0_idx])
+        m1_mz = iso_mz[m0_idx] + (C13_C12_MASS_DIFF/prec_charge[m0_idx])
 
         return (center_mz = center_mz[m0_idx], 
             δ = δ[m0_idx], 
@@ -578,7 +578,7 @@ function summarize_precursor(
     #If we only got the M1
     if (length(iso_idx) == 1) && (iso_idx[1] == 2)
         m1_idx = 1
-        mo_mz = iso_mz[m1_idx] - (NEUTRON/prec_charge[m1_idx])
+        mo_mz = iso_mz[m1_idx] - (C13_C12_MASS_DIFF/prec_charge[m1_idx])
 
         return (center_mz = center_mz[m1_idx], 
                δ = δ[m1_idx], 
@@ -1254,11 +1254,11 @@ function process_quad_pipeline(
         x0 = processed_psms[i,:x0]::Float32
         hw = processed_psms[i,:half_width_mz]::Float32
         if x0 > zero(Float32)
-            if (x0 - hw) < (NEUTRON/4 + 0.1)
+            if (x0 - hw) < (C13_C12_MASS_DIFF/4 + 0.1)
                 keep_data[i] = true
             end
         else
-            if (abs(x0) - hw) < (NEUTRON/2 + 0.1)
+            if (abs(x0) - hw) < (C13_C12_MASS_DIFF/2 + 0.1)
                 keep_data[i] = true
             end
         end

--- a/src/structs/SpectralLibrary/PartitionedFragmentIndex/search.jl
+++ b/src/structs/SpectralLibrary/PartitionedFragmentIndex/search.jl
@@ -497,8 +497,8 @@ function _precompute_scan_properties(spectra, all_scan_idxs, rt_to_irt_spline,
         scan_irt_lo[si] = irt_lo
         scan_irt_hi[si] = irt_hi
         scan_irts[si] = scan_irt
-        scan_prec_min[si] = Float32(getPrecMinBound(quad_func) - NEUTRON * first(iso_bounds) / 2)
-        scan_prec_max[si] = Float32(getPrecMaxBound(quad_func) + NEUTRON * last(iso_bounds) / 2)
+        scan_prec_min[si] = Float32(getPrecMinBound(quad_func) - C13_C12_MASS_DIFF * first(iso_bounds) / 2)
+        scan_prec_max[si] = Float32(getPrecMaxBound(quad_func) + C13_C12_MASS_DIFF * last(iso_bounds) / 2)
     end
     return scan_irt_lo, scan_irt_hi, scan_prec_min, scan_prec_max, scan_irts
 end

--- a/src/utils/isotopeSplines.jl
+++ b/src/utils/isotopeSplines.jl
@@ -376,7 +376,7 @@ function getPrecursorIsotopeSet(prec_mz::Float32,
                                 max_prec_mz::Float32)
     first_iso, last_iso = -1, -1
     @fastmath for iso_count in range(0, MAX_PRECURSOR_ISOTOPE)
-        iso_mz = iso_count*NEUTRON/prec_charge + prec_mz
+        iso_mz = iso_count*C13_C12_MASS_DIFF/prec_charge + prec_mz
         if (iso_mz > min_prec_mz) & (iso_mz < max_prec_mz)
             if first_iso < 0
                 first_iso = iso_count
@@ -418,7 +418,7 @@ function getPrecursorIsotopeTransmission!(
     prec_iso_mz = prec_mono_mz
     @inbounds @fastmath for i in range(1, length(prec_isotope_transmission))
         prec_isotope_transmission[i] = qtf(prec_iso_mz)
-        prec_iso_mz += Float32(NEUTRON/prec_charge)
+        prec_iso_mz += Float32(C13_C12_MASS_DIFF/prec_charge)
     end
 end
 

--- a/src/utils/isotopes.jl
+++ b/src/utils/isotopes.jl
@@ -122,7 +122,7 @@ function getIsotopes(comp::Composition, roots::QRoots, npeaks::Int, charge::I, p
     isotopes = Vector{Isotope{precision}}(undef, npeaks)
     for i in eachindex(isotopes)
         isotopes[i] = Isotope(mass, q[i], UInt8(i), UInt32(prec_id))
-        mass += Float32((NEUTRON/charge))
+        mass += Float32((C13_C12_MASS_DIFF/charge))
     end
     return isotopes
 end
@@ -210,7 +210,7 @@ function getIsotopes(comp::Composition, roots::QRoots, npeaks::Int, mz::Float32,
     isotopes = Vector{Isotope{precision}}(undef, npeaks)
     for i in eachindex(isotopes)
         isotopes[i] = Isotope(mass, q[i], UInt8(i), UInt32(prec_id))
-        mass += Float32((NEUTRON/charge))
+        mass += Float32((C13_C12_MASS_DIFF/charge))
     end
     return isotopes
 end

--- a/src/utils/quadTransmissionModeling/RazoQuadModel.jl
+++ b/src/utils/quadTransmissionModeling/RazoQuadModel.jl
@@ -574,7 +574,7 @@ function simmulateQuad(
         #Precursor charge state, m0 and m0 m/z, and m0 mass 
         prec_charge_state = rand([2])
         m0_mz = center_mz + offset
-        m1_mz =  m0_mz + NEUTRON/prec_charge_state
+        m1_mz =  m0_mz + C13_C12_MASS_DIFF/prec_charge_state
         mono_mass = Float32(m0_mz*prec_charge_state) #Approximate not accounting for proton 
 
 

--- a/test/UnitTests/isotopeSplines.jl
+++ b/test/UnitTests/isotopeSplines.jl
@@ -129,14 +129,14 @@ function plotIsotopes(
     p = plot(title = title)
     iso_idx = 0
     for i in range(1, length(iso_a))
-        mz = test_frag.mz + iso_idx*NEUTRON/frag_charge
+        mz = test_frag.mz + iso_idx*C13_C12_MASS_DIFF/frag_charge
         plot!(p, [mz, mz], [0.0, iso_a[i]], color = 1, alpha = 0.5, lw = 5, label = nothing)
         iso_idx += 1
     end
     hline!(p,[0.0], lw = 4, color = 1, labels = label_a)
     iso_idx = 0
     for i in range(1, length(iso_b))
-        mz = test_frag.mz + iso_idx*NEUTRON/frag_charge
+        mz = test_frag.mz + iso_idx*C13_C12_MASS_DIFF/frag_charge
         plot!(p, [mz, mz], [0.0, iso_b[i]], color = 2, alpha = 0.5, lw = 5, label = nothing)
         iso_idx += 1
     end

--- a/test/UnitTests/test_fused_prec_filters.jl
+++ b/test/UnitTests/test_fused_prec_filters.jl
@@ -21,10 +21,9 @@ const compute_ppm_err             = Pioneer.compute_ppm_err
 const push_match!                 = Pioneer.push_match!
 const push_miss!                  = Pioneer.push_miss!
 const FusedScratch                = Pioneer.FusedScratch
-# NEUTRON is already imported into Main via runtests.jl's
-# `using Pioneer: H2O, PROTON, NEUTRON`. Re-`const`-declaring it here
-# is fatal under Julia 1.12 (was a warning under 1.11).
-const NEUTRON_F32                 = Pioneer.NEUTRON_F32
+# Use the module-qualified Float64 constant below so this file works both
+# standalone and when included after test_setup.jl.
+const C13_C12_MASS_DIFF_F32 = Pioneer.C13_C12_MASS_DIFF_F32
 
 # A minimal QuadTransmissionFunction stand-in: GeneralGaussModel exists in
 # Pioneer and supports getPrecMinBound / getPrecMaxBound. Using a fixed-bounds
@@ -50,21 +49,21 @@ Pioneer.getPrecMaxBound(q::FixedQuadFunc) = q.hi
         # Quad bounds [500, 510], iso bounds (-1, 1), charge 2.
         qfunc = FixedQuadFunc(500.0f0, 510.0f0)
         low, high = quad_window_with_iso_bounds(qfunc, 2, (-1, 1))
-        @test low  === 500.0f0 - Float32(NEUTRON * (-1) / 2)
-        @test high === 510.0f0 + Float32(NEUTRON *  1  / 2)
+        @test low  === 500.0f0 - Float32(Pioneer.C13_C12_MASS_DIFF * (-1) / 2)
+        @test high === 510.0f0 + Float32(Pioneer.C13_C12_MASS_DIFF *  1  / 2)
 
-        # Charge dependence: |NEUTRON/charge| is smaller at higher charge,
+        # Charge dependence: the C13-C12 m/z offset is smaller at higher charge,
         # so the offset relative to literal quad bounds shrinks with charge.
         for charge in (1, 2, 3, 4)
             l, h = quad_window_with_iso_bounds(qfunc, charge, (-1, 1))
-            @test l === 500.0f0 - Float32(NEUTRON * (-1) / charge)
-            @test h === 510.0f0 + Float32(NEUTRON *   1  / charge)
+            @test l === 500.0f0 - Float32(Pioneer.C13_C12_MASS_DIFF * (-1) / charge)
+            @test h === 510.0f0 + Float32(Pioneer.C13_C12_MASS_DIFF *   1  / charge)
         end
 
         # Asymmetric bounds (-2, 0) → first/last applied independently.
         low_a, high_a = quad_window_with_iso_bounds(qfunc, 2, (-2, 0))
-        @test low_a  === 500.0f0 - Float32(NEUTRON * (-2) / 2)
-        @test high_a === 510.0f0 + Float32(NEUTRON *   0  / 2)
+        @test low_a  === 500.0f0 - Float32(Pioneer.C13_C12_MASS_DIFF * (-2) / 2)
+        @test high_a === 510.0f0 + Float32(Pioneer.C13_C12_MASS_DIFF *   0  / 2)
     end
 
     @testset "passes_prec_mz_filter" begin
@@ -81,19 +80,19 @@ Pioneer.getPrecMaxBound(q::FixedQuadFunc) = q.hi
         @test iso_mz_for(800.123f0, 0, 0.5f0)    === 800.123f0
 
         # +1 isotope at charge 1 / 2 / 3.
-        @test iso_mz_for(500.0f0, 1, 1f0)        ≈ 500.0f0 + NEUTRON_F32
-        @test iso_mz_for(500.0f0, 1, 1f0/2f0)    ≈ 500.0f0 + NEUTRON_F32/2f0
-        @test iso_mz_for(500.0f0, 1, 1f0/3f0)    ≈ 500.0f0 + NEUTRON_F32/3f0
+        @test iso_mz_for(500.0f0, 1, 1f0)        ≈ 500.0f0 + C13_C12_MASS_DIFF_F32
+        @test iso_mz_for(500.0f0, 1, 1f0/2f0)    ≈ 500.0f0 + C13_C12_MASS_DIFF_F32/2f0
+        @test iso_mz_for(500.0f0, 1, 1f0/3f0)    ≈ 500.0f0 + C13_C12_MASS_DIFF_F32/3f0
 
-        # +2 isotope at charge 2 → exactly NEUTRON higher than monoisotopic.
-        @test iso_mz_for(500.0f0, 2, 1f0/2f0)    ≈ 500.0f0 + NEUTRON_F32
+        # +2 isotope at charge 2 → exactly one C13-C12 spacing above monoisotopic.
+        @test iso_mz_for(500.0f0, 2, 1f0/2f0)    ≈ 500.0f0 + C13_C12_MASS_DIFF_F32
 
         # bit-identical to the original expression.
         for frag_mz in (123.45f0, 800.5f0, 1500.001f0),
             iso_idx in 0:3,
             charge in (1, 2, 3, 4)
             inv = 1f0 / Float32(charge)
-            ref = Float32(frag_mz + Float32(iso_idx) * NEUTRON_F32 * inv)
+            ref = Float32(frag_mz + Float32(iso_idx) * C13_C12_MASS_DIFF_F32 * inv)
             @test iso_mz_for(frag_mz, iso_idx, inv) === ref
         end
     end
@@ -195,9 +194,9 @@ Pioneer.getPrecMaxBound(q::FixedQuadFunc) = q.hi
         qfunc = FixedQuadFunc(498.7f0, 511.3f0)
         for prec_charge in (1, 2, 3, 4), bounds in ((-1,1), (-2,0), (0,2), (-3,3))
             ref_lo = Pioneer.getPrecMinBound(qfunc) -
-                     Float32(NEUTRON * first(bounds) / prec_charge)
+                     Float32(Pioneer.C13_C12_MASS_DIFF * first(bounds) / prec_charge)
             ref_hi = Pioneer.getPrecMaxBound(qfunc) +
-                     Float32(NEUTRON * last(bounds)  / prec_charge)
+                     Float32(Pioneer.C13_C12_MASS_DIFF * last(bounds)  / prec_charge)
             lo, hi = quad_window_with_iso_bounds(qfunc, prec_charge, bounds)
             @test lo === ref_lo
             @test hi === ref_hi

--- a/test/UnitTests/test_run_fused.jl
+++ b/test/UnitTests/test_run_fused.jl
@@ -29,7 +29,7 @@ const SquareQuadFunction     = Pioneer.SquareQuadFunction
 const SimpleMassErrorModel   = Pioneer.SimpleMassErrorModel
 # parseIsoXML is already imported into Main via runtests.jl
 # (`using Pioneer: parseIsoXML`); re-`const`-declaring it is a hard error
-# under Julia 1.12 — same issue as the NEUTRON case in
+# under Julia 1.12 — same issue as the C13_C12_MASS_DIFF case in
 # test_fused_prec_filters.jl.
 const run_fused!             = Pioneer.run_fused!
 

--- a/test/UnitTests/test_summarize_precursor.jl
+++ b/test/UnitTests/test_summarize_precursor.jl
@@ -41,7 +41,7 @@ using Pioneer
         @test result.yt == 10.0f0  # Expected extreme ratio
         @test result.x0 ≈ 0.1f0
         @test result.prec_charge == 2
-        # x1 should be m1_mz - center_mz where m1_mz = iso_mz + NEUTRON/charge
+        # x1 should be m1_mz - center_mz where m1_mz = iso_mz + C13_C12_MASS_DIFF/charge
     end
     
     @testset "Single M1 isotope" begin

--- a/test/test_setup.jl
+++ b/test/test_setup.jl
@@ -12,7 +12,7 @@ using Pioneer  # Load the Pioneer module for exported functions
 using Pioneer: parseIsoXML
 using Pioneer: UniSpecFragAnnotation, GenericFragAnnotation
 using Pioneer: SplineCoefficientModel, RetentionTimeModel
-using Pioneer: H2O, PROTON, NEUTRON
+using Pioneer: H2O, PROTON, C13_C12_MASS_DIFF
 using Pioneer: InterpolationTypeAlias
 using Pioneer: DetailedFrag, SimpleFrag, LibraryFragmentLookup
 using Pioneer: DEBUG_CONSOLE_LEVEL


### PR DESCRIPTION
## Summary

- Replace the misnamed `NEUTRON` isotope-spacing constant with `C13_C12_MASS_DIFF`.
- Define the spacing from the exact C13-C12 mass difference and add the Float32 companion `C13_C12_MASS_DIFF_F32`.
- Update isotope spacing call sites in fused matching, isotope splines, quadrupole/chromatogram bounds, MainSearch MS1 features, quad tuning utilities, and tests.
- Do not keep `NEUTRON` or `NEUTRON_F32` compatibility aliases.

## Why

Peptide isotope spacing is the C13-C12 mass difference, not the free-neutron mass. The old name/value made the code less clear and slightly less precise.

## Validation

- `julia --project=. test/UnitTests/test_fused_prec_filters.jl`
- `julia --project=. test/runtests_part3_units.jl`
- `julia --project=. -e 'using Pioneer; @assert Pioneer.C13_C12_MASS_DIFF ≈ (13.00335483507 - 12.0) atol=1e-12; @assert Pioneer.C13_C12_MASS_DIFF_F32 === Float32(Pioneer.C13_C12_MASS_DIFF); @assert !isdefined(Pioneer, :NEUTRON); @assert !isdefined(Pioneer, :NEUTRON_F32); println("C13_C12_MASS_DIFF=", Pioneer.C13_C12_MASS_DIFF)'`
- `rg -n "\\bNEUTRON\\b|NEUTRON_F32|MS1_DIAG_NEUTRON" src test docs --glob '!docs/build/**'`
- `git diff --check`