### PR TITLE
[codex] Add RT-aware mass calibration

### DIFF
--- a/src/Routines/SearchDIA/CommonSearchUtils/fusedMatch.jl
+++ b/src/Routines/SearchDIA/CommonSearchUtils/fusedMatch.jl
@@ -426,12 +426,12 @@ update and `frag1..6_int` captures (those fields don't exist on
 end
 
 """
-    prepare_scan_peaks!(corrected, obs_low, obs_high, mem, scan_mz, scan_int) -> Int
+    prepare_scan_peaks!(corrected, obs_low, obs_high, mem, scan_mz, scan_int, scan_rt) -> Int
 
 Per-scan precompute of the SoA peak table used by `run_fused!`. For each
-peak calls the 3-arg `getCorrectedMzAndBounds(mem, mz, intensity)` so the
-intensity-dependent bias and tolerance (IntensityMassErrorModel) are
-fully applied. Missing m/z or intensity → `Inf` / impossible window.
+peak calls the 4-arg `getCorrectedMzAndBounds(mem, mz, intensity, rt)` so
+the intensity- and RT-dependent bias and tolerance (IntensityMassErrorModel)
+are fully applied. Missing m/z or intensity → `Inf` / impossible window.
 
 Three parallel `Vector{Float32}`s (not a tuple-packed AoS) so SIMD
 bsearch primitives can load 8 adjacent values per operation.
@@ -443,7 +443,8 @@ function prepare_scan_peaks!(corrected::Vector{Float32},
                               obs_high::Vector{Float32},
                               mem::AbstractMassErrorModel,
                               scan_mz::AbstractArray{Union{Missing, Float32}},
-                              scan_int::AbstractArray{Union{Missing, Float32}})
+                              scan_int::AbstractArray{Union{Missing, Float32}},
+                              scan_rt::Float32)
     n = length(scan_mz)
     if length(corrected) < n
         resize!(corrected, n)
@@ -458,7 +459,7 @@ function prepare_scan_peaks!(corrected::Vector{Float32},
             obs_low[i]   = Float32(Inf)
             obs_high[i]  = -Float32(Inf)  # never matches any theoretical
         else
-            c, lo, hi = getCorrectedMzAndBounds(mem, Float32(m), Float32(it))
+            c, lo, hi = getCorrectedMzAndBounds(mem, Float32(m), Float32(it), scan_rt)
             corrected[i] = c
             obs_low[i]   = lo
             obs_high[i]  = hi
@@ -945,9 +946,10 @@ function run_fused_masserr!(
     prec_range::UnitRange{Int64},
     mem::AbstractMassErrorModel,
     scan_mz::AbstractArray{Union{Missing, Float32}},
-    scan_int::AbstractArray{Union{Missing, Float32}};
+    scan_int::AbstractArray{Union{Missing, Float32}},
+    scan_rt::Float32;
     max_rank::Int = 6,
-    min_ion_position::Int = 5)
+    min_ion_position::Int = 4)
 
     fragments = getFragments(ion_list)
     n_peaks = peak_mz_len
@@ -992,7 +994,7 @@ function run_fused_masserr!(
                 raw_int = scan_int[best_peak]
                 int_obs = ismissing(raw_int) ? 0f0 : Float32(raw_int)
 
-                samples[samples_idx] = MassErrSample(frag_mz, raw_mz, int_obs)
+                samples[samples_idx] = MassErrSample(frag_mz, raw_mz, int_obs, scan_rt)
 
                 # Monotonic advance: next fragment's mono mz ≥ current,
                 # so its match peak index can't precede this one.

--- a/src/Routines/SearchDIA/SearchMethods/HuberTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/HuberTuningSearch/utils.jl
@@ -203,7 +203,7 @@ function process_huber_calibration_scans!(
         scan_int = getIntensityArray(spectra, scan_idx)
         peak_mz_len = prepare_scan_peaks!(
             corr_mz, obs_low, obs_high,
-            mass_error_model, scan_mz, scan_int,
+            mass_error_model, scan_mz, scan_int, Float32(rt),
         )
 
         nmatches, nmisses = run_fused!(

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
@@ -808,7 +808,8 @@ function build_chromatograms(
         scan_mz  = getMzArray(spectra, scan_idx)
         scan_int = getIntensityArray(spectra, scan_idx)
         peak_mz_len = prepare_scan_peaks!(corr_mz, obs_low, obs_high,
-                                          mass_error_model, scan_mz, scan_int)
+                                          mass_error_model, scan_mz, scan_int,
+                                          Float32(rt))
 
         # 3. Fused match+build. iRT + iso_err_bounds filters already done
         #    upstream — skipped by FusedRTIndexed's check_prec_filters = false.

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/constants.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/constants.jl
@@ -22,6 +22,14 @@ const TUNING_TOPN_PEAKS = Int64(200)            # Top-N intensity peak filter fo
 const TUNING_MAX_FRAGS_FOR_MASS_ERR = UInt8(3)  # Fragments per PSM for mass error estimation
 const TUNING_MIN_COLLECT_SCANS = Int64(5000)    # Minimum initial scan estimate for collection
 const TUNING_MAX_SCAN_FRACTION = Float64(0.10)  # Legacy: kept for struct compatibility
+const TUNING_CALIBRATION_BIN_SIZE = Int64(200)  # Equal-count bins for mass-error calibration summaries
+const TUNING_MZ_BIAS_BIN_SIZE = Int64(100)      # Denser bins for m/z-dependent bias medians
+const TUNING_MZ_BIAS_KNOTS = Int64(24)          # Knots for binned m/z-dependent bias spline
+const TUNING_MZ_BIAS_LAMBDA = Float64(0.1)      # Smoothness penalty for m/z-dependent bias spline
+const TUNING_RT_BIAS_BIN_SIZE = Int64(100)      # Denser bins for RT-dependent bias medians
+const TUNING_RT_BIAS_KNOTS = Int64(48)          # Knots for raw RT bias spline
+const TUNING_RT_BIAS_LAMBDA = Float64(0.03)     # Smoothness penalty for RT-dependent bias spline
+const TUNING_BIAS_EXTRAP_EDGE_POINTS = Int64(5) # Binned medians per edge for robust linear extrapolation
 
 # Wide scout constants
 const WIDE_SCOUT_TOL_PPM = Float32(100.0)       # ±100 ppm wide scout tolerance

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/fit_intensity_mass_error.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/fit_intensity_mass_error.jl
@@ -360,6 +360,119 @@ function _select_regularized_mz_spread_correction(corr_centers::AbstractVector{<
            mz_spread_α, mz_spread_β, mz_spread_γ, label
 end
 
+function _project_convex_coeffs!(c::Vector{Float64}, convex_up::Bool; floor_val::Union{Nothing, Float64}=nothing)
+    for _ in 1:30
+        changed = false
+        for i in 1:(length(c)-2)
+            v = c[i+2] - 2*c[i+1] + c[i]
+            if convex_up ? (v < 0) : (v > 0)
+                correction = abs(v)
+                if convex_up
+                    c[i] += correction / 3
+                    c[i+1] -= 2 * correction / 3
+                    c[i+2] += correction / 3
+                else
+                    c[i] -= correction / 3
+                    c[i+1] += 2 * correction / 3
+                    c[i+2] -= correction / 3
+                end
+                changed = true
+            end
+        end
+        !changed && break
+    end
+
+    if floor_val !== nothing
+        for i in eachindex(c)
+            c[i] = max(c[i], floor_val)
+        end
+    end
+    return c
+end
+
+function _project_monotone_coeffs!(c::Vector{Float64}, increasing::Bool)
+    for _ in 1:30
+        changed = false
+        for i in 1:(length(c)-1)
+            if increasing ? (c[i+1] < c[i]) : (c[i+1] > c[i])
+                avg = (c[i] + c[i+1]) / 2
+                c[i] = avg
+                c[i+1] = avg
+                changed = true
+            end
+        end
+        !changed && break
+    end
+    return c
+end
+
+function _projected_gradient!(
+    c::Vector{Float64},
+    H::AbstractMatrix{Float64},
+    rhs::AbstractVector{Float64},
+    project!::F;
+    lr::Float64,
+    max_iter::Int,
+    tol::Float64,
+    check_every::Int,
+) where {F}
+    project!(c)
+
+    # opnorm(H) is the gradient Lipschitz constant of this convex quadratic.
+    lr_eff = min(lr, 1.8 / opnorm(H))
+    grad = similar(c)
+    prev_obj = Inf
+    for iter in 1:max_iter
+        mul!(grad, H, c)
+        grad .-= rhs
+        c .-= lr_eff .* grad
+        project!(c)
+        if iter % check_every == 0
+            mul!(grad, H, c)
+            obj = 0.5 * dot(c, grad) - dot(rhs, c)
+            if abs(prev_obj - obj) / max(abs(obj), 1.0) < tol
+                break
+            end
+            prev_obj = obj
+        end
+    end
+    return c
+end
+
+function _projected_irls_coeffs(
+    X::AbstractMatrix{Float64},
+    y::Vector{Float64},
+    n_coeffs::Int,
+    project!::F;
+    λ::Float64,
+    max_iter::Int,
+    lr::Float64,
+    tol::Float64,
+    n_irls::Int,
+) where {F}
+    w = ones(length(y))
+    c = zeros(n_coeffs)
+    resid = similar(y)
+
+    for irls_iter in 1:n_irls
+        H, rhs = _penalized_spline_system(X, y; λ=λ, weights=w, order=2)
+        c = H \ rhs
+        _projected_gradient!(c, H, rhs, project!;
+                             lr=lr, max_iter=max_iter, tol=tol, check_every=200)
+
+        irls_iter == n_irls && break
+        mul!(resid, X, c)
+        resid .= y .- resid
+        σ_hat = median(abs.(resid)) / 0.6744897501960817
+        δ = 1.345 * max(σ_hat, 1e-10)
+        for i in eachindex(w, resid)
+            r_abs = abs(resid[i])
+            w[i] = r_abs <= δ ? 1.0 : δ / r_abs
+        end
+    end
+    return c
+end
+
 #==========================================================
 Convexity-constrained smoothing spline for bias
 ==========================================================#
@@ -386,78 +499,15 @@ function fit_convex_bias_spline(x::Vector{Float64}, y::Vector{Float64};
     n_pts = length(x)
     n_pts < n_knots && return nothing
 
-    _first = minimum(x); _last = maximum(x)
-    bin_width = (_last - _first) / (n_knots - 1)
-    knots = collect(LinRange(_first, _last, n_knots))
-    X = _build_numeric_design_matrix(x, knots, bin_width)
-    n_coeffs = n_knots + 3
+    basis = _make_uniform_spline_basis(x, n_knots)
+    X = basis.X
+    n_coeffs = basis.n_coeffs
 
-    D2 = build_difference_matrix(n_coeffs, 2)
-    P = D2' * D2
+    project!(c) = _project_convex_coeffs!(c, convex_up)
+    c = _projected_irls_coeffs(X, y, n_coeffs, project!;
+                               λ=λ, max_iter=max_iter, lr=lr, tol=tol, n_irls=n_irls)
 
-    function project!(c::Vector{Float64})
-        for _ in 1:30
-            changed = false
-            for i in 1:(length(c)-2)
-                v = c[i+2] - 2*c[i+1] + c[i]
-                if convex_up ? (v < 0) : (v > 0)
-                    correction = abs(v)
-                    if convex_up
-                        c[i] += correction / 3
-                        c[i+1] -= 2 * correction / 3
-                        c[i+2] += correction / 3
-                    else
-                        c[i] -= correction / 3
-                        c[i+1] += 2 * correction / 3
-                        c[i+2] -= correction / 3
-                    end
-                    changed = true
-                end
-            end
-            !changed && break
-        end
-    end
-
-    w = ones(n_pts)
-    c = zeros(n_coeffs)
-
-    for irls_iter in 1:n_irls
-        WX = Diagonal(w) * X
-        H = WX' * X + λ * P
-        Xty = WX' * y
-        c = H \ Xty
-        project!(c)
-
-        # Lipschitz-safe step cap: opnorm(H) is the gradient Lipschitz
-        # constant of this convex quadratic, so any lr ≤ 2/L is stable.
-        # Without this cap, fixed lr diverges once n_pts is large enough
-        # that L grows past 1/lr (LU factorization at the next IRLS
-        # iteration then throws on the resulting Inf/NaN coefficients).
-        lr_eff = min(lr, 1.8 / opnorm(H))
-
-        prev_obj = Inf
-        for iter in 1:max_iter
-            grad = H * c - Xty
-            c .-= lr_eff .* grad
-            project!(c)
-            if iter % 200 == 0
-                obj = 0.5 * (c' * H * c) - (Xty' * c)
-                if abs(prev_obj - obj) / max(abs(obj), 1.0) < tol
-                    break
-                end
-                prev_obj = obj
-            end
-        end
-
-        irls_iter == n_irls && break
-        resid = y .- X * c
-        σ_hat = median(abs.(resid)) / 0.6744897501960817
-        δ = 1.345 * max(σ_hat, 1e-10)
-        w = [abs(r) <= δ ? 1.0 : δ / abs(r) for r in resid]
-    end
-
-    degree = 3
-    return _coeffs_to_spline(c, knots, bin_width, degree, n_knots, _first, _last)
+    return _coeffs_to_spline(c, basis)
 end
 
 """
@@ -531,32 +581,29 @@ function fit_binned_regularized_bias_spline(
     _last <= _first && return nothing, "failed (degenerate m/z bins)"
 
     n_fit_knots = min(n_knots, max(3, n_bins - 3))
-    knots = collect(LinRange(_first, _last, n_fit_knots))
-    bin_width = (_last - _first) / (n_fit_knots - 1)
-    X = _build_numeric_design_matrix(centers, knots, bin_width)
-    n_coeffs = n_fit_knots + 3
-    D2 = build_difference_matrix(n_coeffs, 2)
-    P = D2' * D2
-    ridge = 1e-8 * Matrix{Float64}(I, n_coeffs, n_coeffs)
+    basis = _make_uniform_spline_basis(centers, n_fit_knots)
+    X = basis.X
 
     base_weights = weights ./ median(weights)
     fit_weights = copy(base_weights)
-    c = zeros(n_coeffs)
+    c = zeros(basis.n_coeffs)
+    resid = similar(vals)
     for irls_iter in 1:n_irls
-        WX = Diagonal(fit_weights) * X
-        H = WX' * X + λ * P + ridge
-        Xty = X' * (fit_weights .* vals)
-        c = H \ Xty
+        H, rhs = _penalized_spline_system(X, vals; λ=λ, weights=fit_weights, order=2, ridge=1e-8)
+        c = H \ rhs
 
         irls_iter == n_irls && break
-        resid = vals .- X * c
+        mul!(resid, X, c)
+        resid .= vals .- resid
         σ_hat = median(abs.(resid)) / 0.6744897501960817
         δ = 1.345 * max(σ_hat, 1e-10)
-        huber_weights = [abs(r) <= δ ? 1.0 : δ / abs(r) for r in resid]
-        fit_weights = base_weights .* huber_weights
+        for i in eachindex(fit_weights, base_weights, resid)
+            r_abs = abs(resid[i])
+            fit_weights[i] = base_weights[i] * (r_abs <= δ ? 1.0 : δ / r_abs)
+        end
     end
 
-    spline = _coeffs_to_spline(c, knots, bin_width, 3, n_fit_knots, _first, _last)
+    spline = _coeffs_to_spline(c, basis)
     return spline, "binned regularized (λ=$(λ), knots=$(n_fit_knots), bins=$(n_bins))"
 end
 
@@ -586,64 +633,15 @@ function fit_monotone_bias_spline(x::Vector{Float64}, y::Vector{Float64};
     n_pts = length(x)
     n_pts < n_knots && return nothing
 
-    _first = minimum(x); _last = maximum(x)
-    bin_width = (_last - _first) / (n_knots - 1)
-    knots = collect(LinRange(_first, _last, n_knots))
-    X = _build_numeric_design_matrix(x, knots, bin_width)
-    n_coeffs = n_knots + 3
+    basis = _make_uniform_spline_basis(x, n_knots)
+    X = basis.X
+    n_coeffs = basis.n_coeffs
 
-    D2 = build_difference_matrix(n_coeffs, 2)
-    P = D2' * D2
+    project!(c) = _project_monotone_coeffs!(c, increasing)
+    c = _projected_irls_coeffs(X, y, n_coeffs, project!;
+                               λ=λ, max_iter=max_iter, lr=lr, tol=tol, n_irls=n_irls)
 
-    function project!(c::Vector{Float64})
-        for _ in 1:30
-            changed = false
-            for i in 1:(length(c)-1)
-                if increasing ? (c[i+1] < c[i]) : (c[i+1] > c[i])
-                    avg = (c[i] + c[i+1]) / 2
-                    c[i] = avg; c[i+1] = avg; changed = true
-                end
-            end
-            !changed && break
-        end
-    end
-
-    w = ones(n_pts)
-    c = zeros(n_coeffs)
-
-    for irls_iter in 1:n_irls
-        WX = Diagonal(w) * X
-        H = WX' * X + λ * P
-        Xty = WX' * y
-        c = H \ Xty
-        project!(c)
-
-        # See fit_convex_bias_spline for rationale.
-        lr_eff = min(lr, 1.8 / opnorm(H))
-
-        prev_obj = Inf
-        for iter in 1:max_iter
-            grad = H * c - Xty
-            c .-= lr_eff .* grad
-            project!(c)
-            if iter % 200 == 0
-                obj = 0.5 * (c' * H * c) - (Xty' * c)
-                if abs(prev_obj - obj) / max(abs(obj), 1.0) < tol
-                    break
-                end
-                prev_obj = obj
-            end
-        end
-
-        irls_iter == n_irls && break
-        resid = y .- X * c
-        σ_hat = median(abs.(resid)) / 0.6744897501960817
-        δ = 1.345 * max(σ_hat, 1e-10)
-        w = [abs(r) <= δ ? 1.0 : δ / abs(r) for r in resid]
-    end
-
-    degree = 3
-    return _coeffs_to_spline(c, knots, bin_width, degree, n_knots, _first, _last)
+    return _coeffs_to_spline(c, basis)
 end
 
 """
@@ -678,7 +676,7 @@ Regularized spline for Laplace spread
 ==========================================================#
 
 """
-    fit_monotone_convex_spread_spline(bin_centers, bin_scales; ...)
+    fit_regularized_spread_spline(bin_centers, bin_scales; ...)
 
 Fit an unconstrained regularized cubic B-spline to pre-binned Laplace scale.
 Knot count is adaptive: at most n_knots, reduced until each knot interval has
@@ -686,14 +684,11 @@ enough binned scale estimates to avoid poorly supported local wiggles.
 Takes (bin_centers, bin_scales) from `binned_laplace_scale`.
 Returns a UniformSpline (Float64), or nothing.
 """
-function fit_monotone_convex_spread_spline(
+function fit_regularized_spread_spline(
     bin_centers::Vector{Float64},
     bin_scales::Vector{Float64};
     n_knots::Int = 20,
     λ::Float64 = 0.01,
-    max_iter::Int = 5000,
-    lr::Float64 = 0.001,
-    tol::Float64 = 1e-8,
     floor_val::Float64 = 0.0001
 )
     n_pts = length(bin_centers)
@@ -728,21 +723,14 @@ function fit_monotone_convex_spread_spline(
     end
     n_knots < 3 && return nothing
 
-    spline_bin_width = (_last - _first) / (n_knots - 1)
-    knots = collect(LinRange(_first, _last, n_knots))
-    X = _build_numeric_design_matrix(t, knots, spline_bin_width)
-    n_coeffs = n_knots + 3
+    basis = _make_uniform_spline_basis(t, n_knots)
+    H, rhs = _penalized_spline_system(basis.X, y; λ=λ, order=2, ridge=1e-8)
+    c = H \ rhs
+    for i in eachindex(c)
+        c[i] = max(c[i], floor_val)
+    end
 
-    D2 = build_difference_matrix(n_coeffs, 2)
-    P = D2' * D2
-    ridge = 1e-8 * Matrix{Float64}(I, n_coeffs, n_coeffs)
-    H = X' * X + λ * P + ridge
-    Xty = X' * y
-    c = H \ Xty
-    c = max.(c, floor_val)
-
-    degree = 3
-    return _coeffs_to_spline(c, knots, spline_bin_width, degree, n_knots, _first, _last)
+    return _coeffs_to_spline(c, basis)
 end
 
 #==========================================================
@@ -862,7 +850,7 @@ function fit_intensity_mass_error_model(
     spread_centers, spread_b_vals = binned_laplace_scale(
         I_order, log2I, full_residuals_mda, TUNING_CALIBRATION_BIN_SIZE)
 
-    spread_spline_f64 = fit_monotone_convex_spread_spline(spread_centers, spread_b_vals)
+    spread_spline_f64 = fit_regularized_spread_spline(spread_centers, spread_b_vals)
 
     if spread_spline_f64 === nothing
         @user_warn "Spread spline fitting failed, keeping SimpleMassErrorModel"

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/fit_intensity_mass_error.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/fit_intensity_mass_error.jl
@@ -19,19 +19,21 @@
 Intensity-Aware Mass Error Model Fitting Pipeline
 
 Fits an IntensityMassErrorModel from matched fragment data:
-  1. m/z-dependent bias: convexity-constrained smoothing spline (Da)
+  1. m/z-dependent bias: binned robust regularized spline (Da)
   2. intensity-dependent bias: convexity-constrained smoothing spline (Da)
-  3. Laplace spread: monotone-decreasing convex spline of log2(I) (**ppm**)
-  4. Coverage multiplier k (from PEP-based tolerance scanning)
+  3. RT-dependent bias: binned robust regularized spline on raw RT (Da)
+  4. Laplace spread: regularized spline of log2(I) (mDa)
+  5. m/z-dependent spread correction
+  6. Empirical coverage multiplier k
 
-Bias is fit in Da space. Spread is fit in ppm space — after bias correction,
-Da residuals are divided by (mz / 1e6) to get ppm, then binned Laplace scale
-is computed on those ppm residuals. This yields m/z-proportional tolerance.
+Bias is fit in Da space. Spread is fit in mDa space after bias correction,
+then adjusted by a fitted m/z-dependent correction factor.
 ==========================================================#
 
 # Empirical-k coverage parameters. Quantile of |residual|/σ used to set the
-# coverage multiplier k; the result is clamped to [1.96, EMPK_CLAMP_HI].
+# coverage multiplier k; the result is clamped to [EMPK_MIN_K, EMPK_CLAMP_HI].
 const EMPK_QUANTILE = 0.95
+const EMPK_MIN_K = Float32(quantile(Normal(), (1.0 + EMPK_QUANTILE) / 2.0))
 const EMPK_CLAMP_HI = 4.5f0
 
 #==========================================================
@@ -62,6 +64,301 @@ function binned_laplace_scale(order::Vector{Int}, vals::Vector{Float64},
     return centers, b_vals
 end
 
+function _binned_bias_medians(x::AbstractVector{<:Real},
+                              y::AbstractVector{<:Real},
+                              lo::Real,
+                              hi::Real;
+                              bin_size::Int = TUNING_CALIBRATION_BIN_SIZE)
+    length(x) == length(y) || throw(ArgumentError("x and y must have the same length"))
+    lo_f = Float64(lo)
+    hi_f = Float64(hi)
+    valid = Int[]
+    for i in eachindex(x)
+        xi = Float64(x[i])
+        yi = Float64(y[i])
+        if isfinite(xi) && isfinite(yi) && lo_f <= xi <= hi_f
+            push!(valid, Int(i))
+        end
+    end
+    length(valid) < 2 && return Float64[], Float64[]
+
+    order = valid[sortperm(Float64.(x[valid]))]
+    n = length(order)
+    n_bins = max(n ÷ bin_size, 1)
+    centers = Float64[]
+    vals = Float64[]
+    sizehint!(centers, n_bins)
+    sizehint!(vals, n_bins)
+
+    for b in 1:n_bins
+        s = (b - 1) * bin_size + 1
+        e = b == n_bins ? n : b * bin_size
+        idx = order[s:e]
+        push!(centers, median(Float64.(x[idx])))
+        push!(vals, median(Float64.(y[idx])))
+    end
+
+    return centers, vals
+end
+
+function _theil_sen_slope(x::AbstractVector{Float64}, y::AbstractVector{Float64})
+    length(x) == length(y) || throw(ArgumentError("x and y must have the same length"))
+    length(x) < 2 && return nothing
+
+    slopes = Float64[]
+    for j in 2:length(x)
+        for i in 1:(j - 1)
+            dx = x[j] - x[i]
+            abs(dx) <= eps(Float64) && continue
+            push!(slopes, (y[j] - y[i]) / dx)
+        end
+    end
+
+    isempty(slopes) && return nothing
+    return median(slopes)
+end
+
+function _edge_point_slope(centers::Vector{Float64},
+                           vals::Vector{Float64},
+                           side::Symbol,
+                           n_edge_points::Int)
+    n = length(centers)
+    n < 2 && return nothing
+    n_take = min(max(n_edge_points, 2), n)
+    if side === :lo
+        idx = 1:n_take
+    elseif side === :hi
+        idx = (n - n_take + 1):n
+    else
+        throw(ArgumentError("side must be :lo or :hi"))
+    end
+    return _theil_sen_slope(centers[idx], vals[idx])
+end
+
+function make_edge_point_spline_extrap(spline::UniformSpline{N, T},
+                                       x::AbstractVector{<:Real},
+                                       y::AbstractVector{<:Real},
+                                       lo::T,
+                                       hi::T;
+                                       n_edge_points::Int = TUNING_BIAS_EXTRAP_EDGE_POINTS,
+                                       bin_size::Int = TUNING_CALIBRATION_BIN_SIZE) where {N, T}
+    centers, vals = _binned_bias_medians(x, y, lo, hi; bin_size=bin_size)
+    lo_slope = _edge_point_slope(centers, vals, :lo, n_edge_points)
+    hi_slope = _edge_point_slope(centers, vals, :hi, n_edge_points)
+    extrap_lo = length(centers) >= 2 ? T(first(centers)) : lo
+    extrap_hi = length(centers) >= 2 ? T(last(centers)) : hi
+
+    return SplineExtrap{T}(
+        extrap_lo, extrap_hi,
+        spline(extrap_lo), T(lo_slope === nothing ? 0.0 : lo_slope),
+        spline(extrap_hi), T(hi_slope === nothing ? 0.0 : hi_slope)
+    )
+end
+
+function make_binned_bound_spline_extrap(spline::UniformSpline{N, T},
+                                         x::AbstractVector{<:Real},
+                                         y::AbstractVector{<:Real},
+                                         lo::T,
+                                         hi::T;
+                                         bin_size::Int = TUNING_CALIBRATION_BIN_SIZE) where {N, T}
+    centers, _ = _binned_bias_medians(x, y, lo, hi; bin_size=bin_size)
+    extrap_lo = length(centers) >= 2 ? T(first(centers)) : lo
+    extrap_hi = length(centers) >= 2 ? T(last(centers)) : hi
+    return make_spline_extrap(spline, extrap_lo, extrap_hi)
+end
+
+function make_rt_range_edge_spline_extrap(spline::UniformSpline{N, T},
+                                          x::AbstractVector{<:Real},
+                                          y::AbstractVector{<:Real},
+                                          lo::T,
+                                          hi::T;
+                                          bound_bin_size::Int = TUNING_RT_BIAS_BIN_SIZE) where {N, T}
+    bound_centers, _ = _binned_bias_medians(x, y, lo, hi; bin_size=bound_bin_size)
+    lo_f = length(bound_centers) >= 2 ? first(bound_centers) : Float64(lo)
+    hi_f = length(bound_centers) >= 2 ? last(bound_centers) : Float64(hi)
+    span = hi_f - lo_f
+    if !(isfinite(span) && span > 0)
+        return SplineExtrap{T}(
+            lo, hi,
+            spline(lo), zero(T),
+            spline(hi), zero(T)
+        )
+    end
+
+    return SplineExtrap{T}(
+        T(lo_f), T(hi_f),
+        spline(T(lo_f)), zero(T),
+        spline(T(hi_f)), zero(T)
+    )
+end
+
+function _constant_mz_spread_correction_spline(first_mz::Float64,
+                                                last_mz::Float64;
+                                                value::Float64 = 1.0)
+    _first = isfinite(first_mz) ? first_mz : 0.0
+    _last = isfinite(last_mz) ? last_mz : _first + 1.0
+    _last <= _first && (_last = _first + 1.0)
+    value = clamp(value, 0.1, 10.0)
+    degree = 3
+    n_knots = 3
+    bin_width = (_last - _first) / (n_knots - 1)
+    coeffs = Float64[]
+    for _ in 1:n_knots
+        append!(coeffs, (value, 0.0, 0.0, 0.0))
+    end
+    return UniformSpline{length(coeffs), Float64}(
+        SVector{length(coeffs), Float64}(coeffs),
+        degree,
+        _first,
+        _last,
+        bin_width
+    )
+end
+
+function _constant_mz_spread_correction_extrap(spline::UniformSpline{N, Float64}) where N
+    return SplineExtrap{Float64}(
+        spline.first,
+        spline.last,
+        spline(spline.first),
+        0.0,
+        spline(spline.last),
+        0.0
+    )
+end
+
+function _constant_bias_spline(first_x::Float64,
+                               last_x::Float64;
+                               value::Float64 = 0.0)
+    _first = isfinite(first_x) ? first_x : 0.0
+    _last = isfinite(last_x) ? last_x : _first + 1.0
+    _last <= _first && (_last = _first + 1.0)
+    degree = 3
+    n_knots = 3
+    coeffs = Float64[]
+    for _ in 1:n_knots
+        append!(coeffs, (value, 0.0, 0.0, 0.0))
+    end
+    return UniformSpline{length(coeffs), Float64}(
+        SVector{length(coeffs), Float64}(coeffs),
+        degree,
+        _first,
+        _last,
+        (_last - _first) / (n_knots - 1)
+    )
+end
+
+function _constant_bias_extrap(spline::UniformSpline{N, Float64}) where N
+    return SplineExtrap{Float64}(
+        spline.first,
+        spline.last,
+        spline(spline.first),
+        0.0,
+        spline(spline.last),
+        0.0
+    )
+end
+
+function _shift_spline(spline::UniformSpline{N, Float64}, offset::Float64) where N
+    coeffs = collect(spline.coeffs)
+    stride = spline.degree + 1
+    for i in 1:stride:length(coeffs)
+        coeffs[i] -= offset
+    end
+    return UniformSpline{N, Float64}(
+        SVector{N, Float64}(coeffs),
+        spline.degree,
+        spline.first,
+        spline.last,
+        spline.bin_width
+    )
+end
+
+function _linear_mz_spread_correction_spline(first_mz::Float64,
+                                             last_mz::Float64,
+                                             intercept::Float64,
+                                             slope::Float64)
+    _first = isfinite(first_mz) ? first_mz : 0.0
+    _last = isfinite(last_mz) ? last_mz : _first + 1.0
+    _last <= _first && (_last = _first + 1.0)
+
+    degree = 3
+    n_knots = 3
+    bin_width = (_last - _first) / (n_knots - 1)
+    coeffs = Float64[]
+    for k in 0:(n_knots - 1)
+        mz = _first + k * bin_width
+        append!(coeffs, (intercept + slope * mz, slope * bin_width, 0.0, 0.0))
+    end
+
+    return UniformSpline{length(coeffs), Float64}(
+        SVector{length(coeffs), Float64}(coeffs),
+        degree,
+        _first,
+        _last,
+        bin_width
+    )
+end
+
+function _fit_robust_linear_mz_spread_correction(
+    corr_centers::Vector{Float64},
+    corr_vals::Vector{Float64};
+    floor_val::Float64 = 0.1,
+    ceiling_val::Float64 = 10.0,
+)
+    n_pts = length(corr_centers)
+    n_pts < 2 && return nothing, Float32(1.0), Float32(0.0), Float32(0.0),
+                         "constant (too few m/z correction bins)"
+
+    order = sortperm(corr_centers)
+    x = corr_centers[order]
+    y = clamp.(corr_vals[order], floor_val, ceiling_val)
+    _first = minimum(x)
+    _last = maximum(x)
+    _last <= _first && return nothing, Float32(1.0), Float32(0.0), Float32(0.0),
+                         "constant (degenerate m/z correction bins)"
+
+    slope = _theil_sen_slope(x, y)
+    slope === nothing && return nothing, Float32(1.0), Float32(0.0), Float32(0.0),
+                              "constant (too few m/z correction bins)"
+    intercept = median(y .- slope .* x)
+
+    spline = _linear_mz_spread_correction_spline(_first, _last, intercept, slope)
+    return spline, Float32(intercept), Float32(slope), Float32(0.0),
+           "robust linear (Theil-Sen, bins=$(n_pts))"
+end
+
+function _select_regularized_mz_spread_correction(corr_centers::AbstractVector{<:Real},
+                                                  corr_vals::AbstractVector{<:Real})
+    centers = Float64[]
+    vals = Float64[]
+    for (center, val) in zip(corr_centers, corr_vals)
+        c = Float64(center)
+        v = Float64(val)
+        if isfinite(c) && isfinite(v) && v > 0.0
+            push!(centers, c)
+            push!(vals, v)
+        end
+    end
+
+    if isempty(centers)
+        spline = _constant_mz_spread_correction_spline(0.0, 1.0)
+        return spline, _constant_mz_spread_correction_extrap(spline),
+               Float32(1.0), Float32(0.0), Float32(0.0), "constant (too few fragments)"
+    end
+
+    spline, mz_spread_α, mz_spread_β, mz_spread_γ, label =
+        _fit_robust_linear_mz_spread_correction(centers, vals)
+    if spline === nothing
+        value = median(clamp.(vals, 0.1, 10.0))
+        spline = _constant_mz_spread_correction_spline(minimum(centers), maximum(centers); value=value)
+        mz_spread_α = Float32(value)
+        mz_spread_β = Float32(0.0)
+        mz_spread_γ = Float32(0.0)
+    end
+
+    return spline, _constant_mz_spread_correction_extrap(spline),
+           mz_spread_α, mz_spread_β, mz_spread_γ, label
+end
 
 #==========================================================
 Convexity-constrained smoothing spline for bias
@@ -190,6 +487,79 @@ function fit_best_convex_bias(x::Vector{Float64}, y::Vector{Float64};
     end
 end
 
+"""
+    fit_binned_regularized_bias_spline(x, y; n_knots, λ, bin_size)
+
+Fit an unconstrained cubic smoothing spline to equal-count m/z bins. Each bin
+contributes the median m/z and median Da error, which lets local m/z structure
+drive the bias curve without forcing one global convex/concave shape.
+Returns (spline, label) or (nothing, "failed").
+"""
+function fit_binned_regularized_bias_spline(
+    x::Vector{Float64},
+    y::Vector{Float64};
+    n_knots::Int = TUNING_MZ_BIAS_KNOTS,
+    λ::Float64 = 1.0,
+    bin_size::Int = TUNING_MZ_BIAS_BIN_SIZE,
+    n_irls::Int = 3,
+    min_bins::Int = 5
+)
+    length(x) == length(y) || throw(ArgumentError("x and y must have the same length"))
+
+    valid = findall(i -> isfinite(x[i]) && isfinite(y[i]), eachindex(x))
+    n_valid = length(valid)
+    n_valid == 0 && return nothing, "failed (no valid points)"
+
+    order = valid[sortperm(x[valid])]
+    n_bins = max(n_valid ÷ bin_size, 1)
+    n_bins < min_bins && return nothing, "failed (too few m/z bins)"
+
+    centers = Vector{Float64}(undef, n_bins)
+    vals = Vector{Float64}(undef, n_bins)
+    weights = Vector{Float64}(undef, n_bins)
+    for b in 1:n_bins
+        s = (b - 1) * bin_size + 1
+        e = b == n_bins ? n_valid : b * bin_size
+        idx = order[s:e]
+        centers[b] = median(x[idx])
+        vals[b] = median(y[idx])
+        weights[b] = Float64(length(idx))
+    end
+
+    _first = minimum(centers)
+    _last = maximum(centers)
+    _last <= _first && return nothing, "failed (degenerate m/z bins)"
+
+    n_fit_knots = min(n_knots, max(3, n_bins - 3))
+    knots = collect(LinRange(_first, _last, n_fit_knots))
+    bin_width = (_last - _first) / (n_fit_knots - 1)
+    X = _build_numeric_design_matrix(centers, knots, bin_width)
+    n_coeffs = n_fit_knots + 3
+    D2 = build_difference_matrix(n_coeffs, 2)
+    P = D2' * D2
+    ridge = 1e-8 * Matrix{Float64}(I, n_coeffs, n_coeffs)
+
+    base_weights = weights ./ median(weights)
+    fit_weights = copy(base_weights)
+    c = zeros(n_coeffs)
+    for irls_iter in 1:n_irls
+        WX = Diagonal(fit_weights) * X
+        H = WX' * X + λ * P + ridge
+        Xty = X' * (fit_weights .* vals)
+        c = H \ Xty
+
+        irls_iter == n_irls && break
+        resid = vals .- X * c
+        σ_hat = median(abs.(resid)) / 0.6744897501960817
+        δ = 1.345 * max(σ_hat, 1e-10)
+        huber_weights = [abs(r) <= δ ? 1.0 : δ / abs(r) for r in resid]
+        fit_weights = base_weights .* huber_weights
+    end
+
+    spline = _coeffs_to_spline(c, knots, bin_width, 3, n_fit_knots, _first, _last)
+    return spline, "binned regularized (λ=$(λ), knots=$(n_fit_knots), bins=$(n_bins))"
+end
+
 #==========================================================
 Monotonicity-constrained smoothing spline for intensity bias
 ==========================================================#
@@ -304,15 +674,15 @@ function fit_best_monotone_bias(x::Vector{Float64}, y::Vector{Float64};
 end
 
 #==========================================================
-Monotone-decreasing convex spline for Laplace spread
+Regularized spline for Laplace spread
 ==========================================================#
 
 """
     fit_monotone_convex_spread_spline(bin_centers, bin_scales; ...)
 
-Fit a monotone-decreasing, convex cubic B-spline to pre-binned Laplace scale.
-Knot count is adaptive: at most n_knots, reduced to maintain a 10:1
-data-to-coefficient ratio.
+Fit an unconstrained regularized cubic B-spline to pre-binned Laplace scale.
+Knot count is adaptive: at most n_knots, reduced until each knot interval has
+enough binned scale estimates to avoid poorly supported local wiggles.
 Takes (bin_centers, bin_scales) from `binned_laplace_scale`.
 Returns a UniformSpline (Float64), or nothing.
 """
@@ -329,13 +699,18 @@ function fit_monotone_convex_spread_spline(
     n_pts = length(bin_centers)
     n_pts < 5 && return nothing
 
-    t = Float64.(bin_centers)
-    y = Float64.(bin_scales)
+    valid = findall(i -> isfinite(bin_centers[i]) && isfinite(bin_scales[i]), eachindex(bin_centers))
+    length(valid) < 5 && return nothing
+
+    order = valid[sortperm(bin_centers[valid])]
+    t = Float64.(bin_centers[order])
+    y = max.(Float64.(bin_scales[order]), floor_val)
     _first = minimum(t); _last = maximum(t)
+    _last <= _first && return nothing
 
     # Adaptive knot count: reduce n_knots until every uniform knot interval
-    # contains at least `min_pts_per_interval` data points (Laplace bin centers).
-    min_pts_per_interval = 5
+    # contains enough binned Laplace-scale estimates.
+    min_pts_per_interval = 3
     while n_knots > 1
         bin_width = (_last - _first) / (n_knots - 1)
         # Count data points in each knot interval
@@ -351,7 +726,7 @@ function fit_monotone_convex_spread_spline(
         min_count >= min_pts_per_interval && break
         n_knots -= 1
     end
-    n_knots < 1 && return nothing
+    n_knots < 3 && return nothing
 
     spline_bin_width = (_last - _first) / (n_knots - 1)
     knots = collect(LinRange(_first, _last, n_knots))
@@ -360,40 +735,11 @@ function fit_monotone_convex_spread_spline(
 
     D2 = build_difference_matrix(n_coeffs, 2)
     P = D2' * D2
-    H = X' * X + λ * P
+    ridge = 1e-8 * Matrix{Float64}(I, n_coeffs, n_coeffs)
+    H = X' * X + λ * P + ridge
     Xty = X' * y
     c = H \ Xty
-
-    function project!(c::Vector{Float64})
-        for _ in 1:30
-            changed = false
-            # Convexity: f''(x) >= 0
-            for i in 1:(length(c)-2)
-                v = c[i+2] - 2*c[i+1] + c[i]
-                if v < 0
-                    c[i] += (-v) / 3; c[i+1] -= 2 * (-v) / 3; c[i+2] += (-v) / 3
-                    changed = true
-                end
-            end
-            !changed && break
-        end
-        for i in eachindex(c); c[i] = max(c[i], floor_val); end
-    end
-
-    project!(c)
-    # See fit_convex_bias_spline for rationale.
-    lr_eff = min(lr, 1.8 / opnorm(H))
-    prev_obj = Inf
-    for iter in 1:max_iter
-        grad = H * c - Xty
-        c .-= lr_eff .* grad
-        project!(c)
-        if iter % 100 == 0
-            obj = 0.5 * (c' * H * c) - (Xty' * c)
-            if abs(prev_obj - obj) / max(abs(obj), 1.0) < tol; break; end
-            prev_obj = obj
-        end
-    end
+    c = max.(c, floor_val)
 
     degree = 3
     return _coeffs_to_spline(c, knots, spline_bin_width, degree, n_knots, _first, _last)
@@ -407,9 +753,9 @@ Orchestrator: fit_intensity_mass_error_model
     fit_intensity_mass_error_model(fragments, old_model; k, conservative_k)
 
 Fit an IntensityMassErrorModel from matched fragment data.
-Bias in Da space; spread in ppm space. Bias uses convexity-constrained
-smoothing splines fit to all per-fragment data; spread uses monotone-decreasing
-convex spline fit to binned Laplace scale values of ppm residuals.
+Bias is fit in Da space with m/z, intensity, and RT components. Spread is fit
+in mDa space from binned Laplace scale estimates, with an m/z-dependent spread
+correction and empirical coverage multiplier.
 """
 function fit_intensity_mass_error_model(
     samples::AbstractVector{MassErrSample},
@@ -426,31 +772,43 @@ function fit_intensity_mass_error_model(
     # Extract data in Da
     frag_mzs = Vector{Float32}(undef, n)
     intensities = Vector{Float32}(undef, n)
+    rts = Vector{Float32}(undef, n)
     da_errs = Vector{Float64}(undef, n)
 
     @inbounds for i in 1:n
         s = samples[i]
         frag_mzs[i] = s.theoretical_mz
         intensities[i] = s.intensity
+        rts[i] = s.rt
         da_errs[i] = Float64(s.observed_mz - s.theoretical_mz)
     end
 
-    valid = intensities .> 0.0f0
+    valid = (intensities .> 0.0f0) .& isfinite.(rts)
     if sum(valid) < 50
         @user_warn "Too few valid-intensity fragments ($(sum(valid))) for IntensityMassErrorModel"
         return old_model
     end
     frag_mzs = frag_mzs[valid]
     intensities = intensities[valid]
+    rts = rts[valid]
     da_errs = da_errs[valid]
     n = length(da_errs)
 
     log2I = log2.(Float64.(intensities))
     mz_f64 = Float64.(frag_mzs)
+    rt_f64 = Float64.(rts)
 
-    # Step 1: m/z bias — convex spline on ALL data
-    mz_spline_f64, mz_label = fit_best_convex_bias(mz_f64, da_errs;
-        n_knots=10, λ=1.0, lr=0.0001)
+    # Step 1: m/z bias — binned robust spline, unconstrained in curvature
+    mz_spline_f64, mz_label = fit_binned_regularized_bias_spline(
+        mz_f64, da_errs; n_knots=TUNING_MZ_BIAS_KNOTS, λ=TUNING_MZ_BIAS_LAMBDA,
+        bin_size=TUNING_MZ_BIAS_BIN_SIZE)
+
+    if mz_spline_f64 === nothing
+        fallback_spline, fallback_label = fit_best_convex_bias(mz_f64, da_errs;
+            n_knots=TUNING_MZ_BIAS_KNOTS, λ=TUNING_MZ_BIAS_LAMBDA, lr=0.0001)
+        mz_spline_f64 = fallback_spline
+        mz_label = "fallback $(fallback_label)"
+    end
 
     if mz_spline_f64 === nothing
         @user_warn "m/z bias spline fitting failed, keeping SimpleMassErrorModel"
@@ -468,15 +826,41 @@ function fit_intensity_mass_error_model(
         return old_model
     end
 
-    full_residuals = mz_residuals .- [I_spline_f64(li) for li in log2I]
+    intensity_residuals = mz_residuals .- [I_spline_f64(li) for li in log2I]
 
-    # Step 3: Spread — binned MAD → Gaussian σ per intensity bin
+    # Step 3: RT bias — binned robust spline on raw RT.
+    rt_min = minimum(rt_f64)
+    rt_max = maximum(rt_f64)
+    rt_width = rt_max - rt_min
+    rt_spline_f64 = _constant_bias_spline(rt_min, rt_max)
+    rt_label = "none (degenerate RT range)"
+
+    if rt_width > 0 && n >= TUNING_RT_BIAS_BIN_SIZE * 5
+        fitted_rt_spline, fitted_rt_label = fit_binned_regularized_bias_spline(
+            rt_f64,
+            intensity_residuals;
+            n_knots = TUNING_RT_BIAS_KNOTS,
+            λ = TUNING_RT_BIAS_LAMBDA,
+            bin_size = TUNING_RT_BIAS_BIN_SIZE,
+            min_bins = 5,
+        )
+        if fitted_rt_spline !== nothing
+            rt_center = median([fitted_rt_spline(rt) for rt in rt_f64])
+            rt_spline_f64 = _shift_spline(fitted_rt_spline, rt_center)
+            rt_label = fitted_rt_label
+        else
+            rt_label = fitted_rt_label
+        end
+    end
+
+    full_residuals = intensity_residuals .- [rt_spline_f64(rt) for rt in rt_f64]
+
+    # Step 4: Spread — binned MAD → Gaussian σ per intensity bin
     full_residuals_mda = full_residuals .* 1e3  # Da → mDa
 
     I_order = sortperm(log2I)
-    spread_centers, spread_b_vals = binned_laplace_scale(I_order, log2I, full_residuals_mda, 100)
-    # binned_laplace_scale returns Laplace b = MAD / ln(2). Convert to Gaussian σ = MAD / 0.6745
-    spread_σ_vals = spread_b_vals .* (log(2.0) / 0.6744897501960817)
+    spread_centers, spread_b_vals = binned_laplace_scale(
+        I_order, log2I, full_residuals_mda, TUNING_CALIBRATION_BIN_SIZE)
 
     spread_spline_f64 = fit_monotone_convex_spread_spline(spread_centers, spread_b_vals)
 
@@ -490,17 +874,19 @@ function fit_intensity_mass_error_model(
     I_spline = convert_spline_to_f32(I_spline_f64)
     spread_spline = convert_spline_to_f32(spread_spline_f64)
 
-    # Step 4: m/z-dependent spread correction in mDa space
-    # AICc selects among constant (1), linear (α + β·mz), quadratic (α + β·mz + γ·mz²)
+    # Step 5: m/z-dependent spread correction in mDa space
+    # Regularized spline for the correction factor c(mz), with constant endpoint extrapolation.
     mz_spread_α = Float32(1.0)
     mz_spread_β = Float32(0.0)
     mz_spread_γ = Float32(0.0)
+    mz_spread_spline_f64 = _constant_mz_spread_correction_spline(minimum(mz_f64), maximum(mz_f64))
+    mz_spread_extrap_f64 = _constant_mz_spread_correction_extrap(mz_spread_spline_f64)
     mz_corr_label = "none (too few fragments)"
     if n >= 400
         fitted_b_mda = [max(Float64(spread_spline_f64(Float32(l2i))), 1e-4) for l2i in log2I]
         std_resid = abs.(full_residuals_mda) ./ fitted_b_mda
 
-        mz_corr_bin_sz = 200
+        mz_corr_bin_sz = TUNING_CALIBRATION_BIN_SIZE
         mz_corr_sort = sortperm(mz_f64)
         n_mz_corr_bins = max(n ÷ mz_corr_bin_sz, 1)
         corr_centers = Vector{Float64}(undef, n_mz_corr_bins)
@@ -514,65 +900,24 @@ function fit_intensity_mass_error_model(
             corr_vals[b] = median(std_resid[idx]) / log(2)
         end
 
-        nb = n_mz_corr_bins
-        function _aicc(rss::Float64, n_obs::Int, k_params::Int)
-            n_obs <= k_params + 1 && return Inf
-            aic = n_obs * log(rss / n_obs) + 2.0 * k_params
-            return k_params == 0 ? aic : aic + 2.0 * k_params * (k_params + 1) / (n_obs - k_params - 1)
-        end
-
-        # Null: c(mz) = 1.0 (constant, 0 free parameters)
-        rss_null = sum((corr_vals .- 1.0).^2)
-        aicc_null = _aicc(rss_null, nb, 0)
-
-        # Linear: c(mz) = α + β·mz (2 parameters)
-        X_lin = hcat(ones(nb), corr_centers)
-        coefs_lin = X_lin \ corr_vals
-        rss_lin = sum((corr_vals .- X_lin * coefs_lin).^2)
-        aicc_lin = _aicc(rss_lin, nb, 2)
-
-        # Quadratic: c(mz) = α + β·mz + γ·mz² (3 parameters)
-        X_quad = hcat(ones(nb), corr_centers, corr_centers .^ 2)
-        coefs_quad = nb > 3 ? X_quad \ corr_vals : [1.0, 0.0, 0.0]
-        rss_quad = nb > 3 ? sum((corr_vals .- X_quad * coefs_quad).^2) : Inf
-        aicc_quad = nb > 3 ? _aicc(rss_quad, nb, 3) : Inf
-
-        # Select best model by AICc (require ΔAICc > 4 over null)
-        best_aicc = min(aicc_null, aicc_lin, aicc_quad)
-        if aicc_quad == best_aicc && aicc_null - aicc_quad > 4.0
-            mz_spread_α = Float32(coefs_quad[1])
-            mz_spread_β = Float32(coefs_quad[2])
-            mz_spread_γ = Float32(coefs_quad[3])
-            mz_corr_label = "quadratic (ΔAICc=$(round(aicc_null - aicc_quad, digits=1)))"
-        elseif aicc_lin == best_aicc && aicc_null - aicc_lin > 4.0
-            mz_spread_α = Float32(coefs_lin[1])
-            mz_spread_β = Float32(coefs_lin[2])
-            mz_corr_label = "linear (ΔAICc=$(round(aicc_null - aicc_lin, digits=1)))"
-        else
-            mz_corr_label = "none (best ΔAICc=$(round(aicc_null - best_aicc, digits=1)))"
-        end
+        mz_spread_spline_f64, mz_spread_extrap_f64,
+        mz_spread_α, mz_spread_β, mz_spread_γ, mz_corr_label =
+            _select_regularized_mz_spread_correction(corr_centers, corr_vals)
     end
 
-    # Empirical k: fit k so the ±k·σ envelope covers ~95% of observed
-    # bias-corrected residuals. Replaces the previous static k=1.96 (which
-    # only achieves 95% under a Gaussian assumption — Olsen Exploris fragments
-    # showed ~86% empirical coverage at k=1.96, evidence the residual tails
-    # are heavier than Gaussian). Per-file fit; clamped to [1.96, 4.5] to
-    # avoid pathological blow-up on noisy files.
-    # 2026-05-15: 98% target was tested and dramatically regressed (−50k prec,
-    # −3.7k PG on 23-file Olsen) because BitVec LUT calibration trained on
-    # the wider window learns a stricter score cutoff. 95% is the sweet spot.
+    # Empirical k: fit k so the ±k·σ envelope covers the target fraction of
+    # observed bias-corrected residuals. Per-file fit; clamped to
+    # [EMPK_MIN_K, EMPK_CLAMP_HI] to avoid pathological under/over-widths.
     laplace_to_gauss = log(2.0) / 0.6744897501960817
     σ_per_frag_mda = Vector{Float64}(undef, n)
     @inbounds for i in 1:n
         σ_base = max(Float64(spread_spline_f64(Float32(log2I[i]))), 1e-4) * laplace_to_gauss
-        mz_corr = max(Float64(mz_spread_α) + Float64(mz_spread_β) * mz_f64[i] +
-                      Float64(mz_spread_γ) * mz_f64[i]^2, 0.1)
+        mz_corr = Float64(_mz_spread_correction(mz_spread_spline_f64, mz_spread_extrap_f64, mz_f64[i]))
         σ_per_frag_mda[i] = σ_base * mz_corr
     end
     normalized_residuals = abs.(full_residuals_mda) ./ σ_per_frag_mda
     k_emp = Float32(quantile(normalized_residuals, EMPK_QUANTILE))
-    k = clamp(k_emp, 1.96f0, EMPK_CLAMP_HI)
+    k = clamp(k_emp, EMPK_MIN_K, EMPK_CLAMP_HI)
 
     # Conservative tolerance in Da = collection tolerance from the SimpleMassErrorModel.
     # SimpleMassErrorModel stores tolerance in ppm; convert to Da at max training m/z.
@@ -600,48 +945,61 @@ function fit_intensity_mass_error_model(
     max_da_observed = Float32(maximum(abs_residuals))
     max_da_tolerance = Float32(quantile(abs_residuals, 0.99))
 
-    # Precompute extrapolation boundaries at 2%/98% quantiles of training data.
-    # Splines are fit on all data but evaluation switches to extrapolation
-    # outside these boundaries.
-    # The SPREAD spline uses CONSTANT extrapolation on both ends. The
-    # low-intensity tail can be sparsely sampled and the monotone-convex
-    # spline's linear extrapolation tended to blow up the spread there,
-    # which derails BitVecCalibration (admits more low-intensity noise →
-    # fewer bits clear the target/decoy excess threshold → narrower
-    # candidate set → fewer PSMs). Constant extrapolation beyond [q02, q98]
-    # caps the spread at its value at the boundary.
-    mz_q02, mz_q98 = Float32.(quantile(mz_f64, [0.02, 0.98]))
-    I_q02, I_q98   = Float32.(quantile(log2I, [0.02, 0.98]))
-    I_q05, I_q95   = Float32.(quantile(log2I, [0.05, 0.95]))
-    mz_extrap = make_spline_extrap(mz_spline, mz_q02, mz_q98)
-    int_extrap = make_spline_extrap(I_spline, I_q02, I_q98)
-    spread_extrap_raw = make_spline_extrap(spread_spline, I_q05, I_q95)
+    # Precompute bias extrapolation at the first/last binned training points.
+    # Splines are fit on all data; outside the binned boundaries, m/z and
+    # intensity bias use robust edge slopes and RT bias uses range-binned
+    # edge slopes.
+    # The spread spline uses constant extrapolation outside its supported range:
+    # low intensity is capped at the 5% boundary, while high intensity uses the
+    # fitted spline through its right edge.
+    mz_qlo, mz_qhi = Float32(minimum(mz_f64)), Float32(maximum(mz_f64))
+    I_qlo, I_qhi   = Float32(minimum(log2I)), Float32(maximum(log2I))
+    rt_qlo, rt_qhi = Float32(minimum(rt_f64)), Float32(maximum(rt_f64))
+    I_lo_spread = Float32(quantile(log2I, 0.05))
+    I_hi_spread = spread_spline.last
+    mz_extrap = make_edge_point_spline_extrap(
+        mz_spline, mz_f64, da_errs, mz_qlo, mz_qhi)
+    int_extrap = make_edge_point_spline_extrap(
+        I_spline, log2I, mz_residuals, I_qlo, I_qhi)
+    rt_spline = convert_spline_to_f32(rt_spline_f64)
+    rt_extrap = make_rt_range_edge_spline_extrap(
+        rt_spline, rt_f64, intensity_residuals, rt_qlo, rt_qhi;
+        bound_bin_size = TUNING_RT_BIAS_BIN_SIZE)
+    spread_extrap_raw = make_spline_extrap(spread_spline, I_lo_spread, I_hi_spread)
     spread_extrap = SplineExtrap{Float32}(
         spread_extrap_raw.lo, spread_extrap_raw.hi,
         spread_extrap_raw.lo_val, Float32(0),  # constant extrap on left  (low intensity)
         spread_extrap_raw.hi_val, Float32(0)   # constant extrap on right (high intensity)
     )
+    mz_spread_spline = convert_spline_to_f32(mz_spread_spline_f64)
+    mz_spread_extrap = convert_spline_extrap_to_f32(mz_spread_extrap_f64)
 
     model = IntensityMassErrorModel(
         mz_spline,
         I_spline,
         spread_spline,
+        rt_spline,
         mz_extrap,
         int_extrap,
         spread_extrap,
+        rt_extrap,
         k,
         conservative_tol_da,
+        mz_spread_spline,
+        mz_spread_extrap,
         mz_spread_α,
         mz_spread_β,
         mz_spread_γ,
         default_top3_ll,
-        max_da_tolerance
+        max_da_tolerance,
+        Float32(rt_min),
+        Float32(rt_max)
     )
 
     # Model's unclamped worst-case: k * spread_mDa(leftmost) * max_mz_correction
     max_spread_mda = max(Float64(spread_spline(spread_spline.first)), 1e-4)
     mz_min, mz_max = Float64(minimum(mz_f64)), Float64(maximum(mz_f64))
-    _corr(mz) = Float64(mz_spread_α) + Float64(mz_spread_β) * mz + Float64(mz_spread_γ) * mz^2
+    _corr(mz) = Float64(_mz_spread_correction(mz_spread_spline_f64, mz_spread_extrap_f64, mz))
     max_mz_corr = max(_corr(mz_min), _corr((mz_min + mz_max) / 2), _corr(mz_max), 0.1)
     model_max_mda = Float64(k) * max_spread_mda * max_mz_corr
 
@@ -649,8 +1007,9 @@ function fit_intensity_mass_error_model(
     @debug_l1 "Fitted IntensityMassErrorModel (bias Da, spread mDa):" *
         "\n  m/z bias: $mz_label spline ($(length(mz_spline.coeffs)) coeffs)" *
         "\n  intensity bias: $I_label spline ($(length(I_spline.coeffs)) coeffs)" *
-        "\n  spread: monotone-convex spline ($(length(spread_spline.coeffs)) coeffs)" *
-        "\n  m/z spread correction (mDa): $mz_corr_label (α=$(round(mz_spread_α, digits=4)), β=$(round(mz_spread_β, sigdigits=2)), γ=$(round(mz_spread_γ, sigdigits=2)))" *
+        "\n  RT bias: $rt_label spline ($(length(rt_spline.coeffs)) coeffs)" *
+        "\n  spread: regularized spline ($(length(spread_spline.coeffs)) coeffs)" *
+        "\n  m/z spread correction (mDa): $mz_corr_label ($(length(mz_spread_spline.coeffs)) coeffs; α=$(round(mz_spread_α, digits=4)), β=$(round(mz_spread_β, sigdigits=2)), γ=$(round(mz_spread_γ, sigdigits=2)))" *
         "\n  k=$(k), Da clamp (q99)=$(round(max_da_tolerance * 1e3, digits=2)) mDa, max observed=$(round(max_da_observed * 1e3, digits=2)) mDa, model max=$(round(model_max_mda, digits=2)) mDa" *
         "\n  MAD after correction: $(round(mad_corr_mda, digits=2)) mDa" *
         "\n  n_fragments=$(n)"
@@ -771,11 +1130,13 @@ function fit_scout_calibrated_model(
     mz_spline = convert_spline_to_f32(mz_spline_f64)
     I_spline = convert_spline_to_f32(I_spline_f64)
 
-    # Precompute linear extrapolation at [2%, 98%] quantiles
-    mz_q02, mz_q98 = Float32.(quantile(mz_f64, [0.02, 0.98]))
-    I_q02, I_q98 = Float32.(quantile(log2I, [0.02, 0.98]))
-    mz_extrap = make_spline_extrap(mz_spline, mz_q02, mz_q98)
-    int_extrap = make_spline_extrap(I_spline, I_q02, I_q98)
+    # Precompute spline-derivative bias extrapolation at binned data endpoints.
+    mz_qlo, mz_qhi = Float32(minimum(mz_f64)), Float32(maximum(mz_f64))
+    I_qlo, I_qhi = Float32(minimum(log2I)), Float32(maximum(log2I))
+    mz_extrap = make_binned_bound_spline_extrap(
+        mz_spline, mz_f64, da_errs, mz_qlo, mz_qhi)
+    int_extrap = make_binned_bound_spline_extrap(
+        I_spline, log2I, mz_residuals, I_qlo, I_qhi)
 
     model = ScoutCalibratedMassErrorModel(
         mz_spline, mz_extrap,

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
@@ -357,15 +357,16 @@ function mass_error_search(
 
                 scan_mz  = getMzArray(spectra, scan_idx)
                 scan_int = getIntensityArray(spectra, scan_idx)
+                scan_rt = Float32(getRetentionTime(spectra, scan_idx))
                 peak_mz_len = prepare_scan_peaks!(corr_mz, obs_low, obs_high,
-                                                  mem, scan_mz, scan_int)
+                                                  mem, scan_mz, scan_int, scan_rt)
 
                 sample_idx = run_fused_masserr!(
                     samples, sample_idx,
                     corr_mz, obs_low, obs_high, peak_mz_len,
                     ion_list,
                     precursor_idxs, scan_to_prec_idx[scan_idx],
-                    mem, scan_mz, scan_int;
+                    mem, scan_mz, scan_int, scan_rt;
                     max_rank = max_rank)
             end
 
@@ -439,7 +440,7 @@ end
 After tolerance scanning, fit an IntensityMassErrorModel from the collected
 fragment data and install it as the mass error model for this file.
 The SimpleMassErrorModel remains available as fallback.
-Spread is fitted in ppm space; bias stays in Da.
+Spread is fitted in mDa space; bias stays in Da.
 """
 function fit_and_install_intensity_model!(
     search_context::SearchContext,
@@ -547,7 +548,7 @@ end
     generate_mass_error_plot_mda(fragments, model, fname)
 
 Generates bias-corrected mDa mass error histogram with tolerance bounds.
-Uses the IntensityMassErrorModel to subtract mz + intensity bias, then shows
+Uses the IntensityMassErrorModel to subtract m/z + intensity + RT bias, then shows
 both the max observed error clamp and the empirical 99.9% quantile clamp.
 """
 function generate_mass_error_plot_mda(
@@ -557,6 +558,7 @@ function generate_mass_error_plot_mda(
 )
     frag_mzs = frag_data.frag_mzs
     log2I = frag_data.log2I
+    rts = frag_data.rts
     da_errs = frag_data.da_errs
     n = length(da_errs)
     n < 10 && return nothing
@@ -566,7 +568,12 @@ function generate_mass_error_plot_mda(
 
     corrected_mda = Vector{Float64}(undef, n)
     @inbounds for i in 1:n
-        bias_da = Float64(_mz_bias_da(model, frag_mzs[i])) + Float64(_intensity_bias_da(model, Float32(log2I[i])))
+        bias_da = Float64(_total_bias_da(
+            model,
+            Float32(frag_mzs[i]),
+            Float32(log2I[i]),
+            Float32(rts[i]),
+        ))
         corrected_mda[i] = (da_errs[i] - bias_da) * 1e3
     end
 
@@ -667,33 +674,73 @@ end
 
 Generate diagnostic plots for an IntensityMassErrorModel showing:
 1. Bias fit: corrected residuals vs m/z and vs log2(intensity) with fitted curves
-2. Spread fit: Laplace scale vs log2(intensity) with fitted quadratic
-3. Corrected scatter: residuals after full bias correction vs m/z (should be centered at 0)
+2. RT-dependent bias: residuals after m/z + intensity correction vs RT
+3. Spread fit: Laplace scale vs log2(intensity) with fitted spline
+4. Corrected scatter: residuals after full bias correction vs m/z (should be centered at 0)
 
 Returns a vector of Plot objects.
 """
 # Extract arrays from FragmentMatch vector for plotting. Returns NamedTuple
-# with (frag_mzs, log2I, da_errs, mda_errs). Call once, pass to multiple plotters.
+# with (frag_mzs, log2I, rts, da_errs, mda_errs). Call once, pass to multiple plotters.
 function extract_fragment_plot_data(samples::AbstractVector{MassErrSample})
     n = length(samples)
     frag_mzs = Vector{Float32}(undef, n)
     intensities = Vector{Float32}(undef, n)
+    rts = Vector{Float32}(undef, n)
     da_errs = Vector{Float64}(undef, n)
 
     @inbounds for i in 1:n
         s = samples[i]
         frag_mzs[i] = s.theoretical_mz
         intensities[i] = s.intensity
+        rts[i] = s.rt
         da_errs[i] = Float64(s.observed_mz - s.theoretical_mz)
     end
 
-    valid = intensities .> 0.0f0
+    valid = (intensities .> 0.0f0) .& isfinite.(rts)
     frag_mzs = frag_mzs[valid]
+    rts = rts[valid]
     da_errs = da_errs[valid]
     log2I = log2.(Float64.(intensities[valid]))
     mda_errs = da_errs .* 1e3
 
-    return (frag_mzs=frag_mzs, log2I=log2I, da_errs=da_errs, mda_errs=mda_errs)
+    return (frag_mzs=frag_mzs, log2I=log2I, rts=rts, da_errs=da_errs, mda_errs=mda_errs)
+end
+
+function _diagnostic_axis_grid(values::AbstractVector, n_bins::Integer)
+    n = max(Int(n_bins), 2)
+    finite_values = Float64[x for x in values if isfinite(x)]
+    isempty(finite_values) && return collect(range(0.0, 1.0; length=n))
+
+    lo, hi = extrema(finite_values)
+    if lo == hi
+        pad = max(abs(lo) * 0.01, 1.0)
+        lo -= pad
+        hi += pad
+    end
+    return collect(range(lo, hi; length=n))
+end
+
+function _model_tolerance_heatmap_grid(
+    model::IntensityMassErrorModel,
+    frag_mzs::AbstractVector,
+    log2I::AbstractVector;
+    n_mz_bins::Integer=80,
+    n_intensity_bins::Integer=80,
+)
+    mz_grid = _diagnostic_axis_grid(frag_mzs, n_mz_bins)
+    log2I_grid = _diagnostic_axis_grid(log2I, n_intensity_bins)
+    tolerance_mda = Matrix{Float64}(undef, length(log2I_grid), length(mz_grid))
+
+    @inbounds for (iy, intensity) in pairs(log2I_grid)
+        sigma_mda = Float64(_gaussian_sigma_mda(model, Float32(intensity)))
+        for (ix, mz) in pairs(mz_grid)
+            correction = Float64(_mz_spread_correction(model, Float32(mz)))
+            tolerance_mda[iy, ix] = Float64(model.k) * sigma_mda * correction
+        end
+    end
+
+    return mz_grid, log2I_grid, tolerance_mda
 end
 
 function generate_intensity_model_plots(
@@ -704,6 +751,7 @@ function generate_intensity_model_plots(
     plots_out = Plots.Plot[]
     frag_mzs = frag_data.frag_mzs
     log2I = frag_data.log2I
+    rts = frag_data.rts
     da_errs = frag_data.da_errs
     mda_errs = frag_data.mda_errs
     n = length(da_errs)
@@ -713,13 +761,15 @@ function generate_intensity_model_plots(
     # Bias in Da, spread in ppm (converted to Da per-fragment for calibration)
     mz_bias = Vector{Float64}(undef, n)
     int_bias = Vector{Float64}(undef, n)
+    rt_bias = Vector{Float64}(undef, n)
     total_bias = Vector{Float64}(undef, n)
     laplace_scale_mda = Vector{Float64}(undef, n)
 
     @inbounds for i in 1:n
         mz_bias[i] = Float64(_mz_bias_da(model, Float32(frag_mzs[i])))
         int_bias[i] = Float64(_intensity_bias_da(model, Float32(log2I[i])))
-        total_bias[i] = mz_bias[i] + int_bias[i]
+        rt_bias[i] = Float64(_rt_bias_da(model, Float32(rts[i])))
+        total_bias[i] = mz_bias[i] + int_bias[i] + rt_bias[i]
         laplace_scale_mda[i] = Float64(_laplace_scale_mda(model, Float32(log2I[i])))  # now actually mDa
     end
 
@@ -727,17 +777,17 @@ function generate_intensity_model_plots(
     corrected_mda = corrected .* 1e3
 
     # ── Bias diagnostics: two separate pages ──
-    n_bins = 20
+    diagnostic_bin_sz = TUNING_CALIBRATION_BIN_SIZE
+    n_bins = max(n ÷ diagnostic_bin_sz, 1)
     mz_order = sortperm(frag_mzs)
-    bin_size = n ÷ n_bins
     mz_f64 = Float64.(frag_mzs)
 
     # Page 1: m/z-dependent bias
     bin_mz_c = Float64[]
     bin_med_raw = Float64[]
     for b in 1:n_bins
-        s = (b - 1) * bin_size + 1
-        e = b == n_bins ? n : b * bin_size
+        s = (b - 1) * diagnostic_bin_sz + 1
+        e = b == n_bins ? n : b * diagnostic_bin_sz
         idx = mz_order[s:e]
         push!(bin_mz_c, Float64(median(frag_mzs[idx])))
         push!(bin_med_raw, median(mda_errs[idx]))
@@ -754,7 +804,7 @@ function generate_intensity_model_plots(
     plot!(p_mz_bias, mz_range, mz_fit, lw=2.5, color=:red, label="m/z bias spline")
     hline!(p_mz_bias, [0.0], color=:black, lw=1, ls=:dot, label=nothing)
     vline!(p_mz_bias, [Float64(model.mz_bias_extrap.lo), Float64(model.mz_bias_extrap.hi)],
-           color=:orange, lw=1.5, ls=:dot, label="2%/98% extrap boundary")
+           color=:orange, lw=1.5, ls=:dot, label="extrap boundary")
     title!(p_mz_bias, _split_title(fname, "m/z-dependent bias (mDa)"))
     push!(plots_out, p_mz_bias)
 
@@ -764,8 +814,8 @@ function generate_intensity_model_plots(
     bin_med_resid = Float64[]
     mz_resid_mda = (da_errs .- mz_bias) .* 1e3
     for b in 1:n_bins
-        s = (b - 1) * bin_size + 1
-        e = b == n_bins ? n : b * bin_size
+        s = (b - 1) * diagnostic_bin_sz + 1
+        e = b == n_bins ? n : b * diagnostic_bin_sz
         idx = int_order[s:e]
         push!(bin_log2I_c, median(log2I[idx]))
         push!(bin_med_resid, median(mz_resid_mda[idx]))
@@ -782,12 +832,43 @@ function generate_intensity_model_plots(
     plot!(p_int_bias, log2I_range, int_fit, lw=2.5, color=:red, label="intensity bias spline")
     hline!(p_int_bias, [0.0], color=:black, lw=1, ls=:dot, label=nothing)
     vline!(p_int_bias, [Float64(model.int_bias_extrap.lo), Float64(model.int_bias_extrap.hi)],
-           color=:orange, lw=1.5, ls=:dot, label="2%/98% extrap boundary")
+           color=:orange, lw=1.5, ls=:dot, label="extrap boundary")
     title!(p_int_bias, _split_title(fname, "Intensity-dependent bias (mDa)"))
     push!(plots_out, p_int_bias)
 
+    # Page 3: RT-dependent bias
+    rt_raw = Float64.(rts)
+    rt_order = sortperm(rt_raw)
+    bin_rt_c = Float64[]
+    bin_med_rt_resid = Float64[]
+    mz_int_resid_mda = (da_errs .- mz_bias .- int_bias) .* 1e3
+    for b in 1:n_bins
+        s = (b - 1) * diagnostic_bin_sz + 1
+        e = b == n_bins ? n : b * diagnostic_bin_sz
+        idx = rt_order[s:e]
+        push!(bin_rt_c, median(rt_raw[idx]))
+        push!(bin_med_rt_resid, median(mz_int_resid_mda[idx]))
+    end
+
+    rt_range = range(minimum(rt_raw), maximum(rt_raw), length=200)
+    rt_fit = [Float64(_rt_bias_da(model, Float32(x))) * 1e3
+              for x in rt_range]
+    p_rt_bias = plot(size=(900, 900), bottommargin=10Plots.mm, leftmargin=10Plots.mm)
+    scatter!(p_rt_bias, rt_raw, mz_int_resid_mda,
+             alpha=0.08, markersize=1, color=:gray, label=nothing)
+    scatter!(p_rt_bias, bin_rt_c, bin_med_rt_resid,
+             xlabel="RT (min)", ylabel="Residual after m/z + intensity bias (mDa)",
+             label="bin median", marker=:circle, color=:blue, ms=4)
+    plot!(p_rt_bias, rt_range, rt_fit, lw=2.5, color=:red, label="RT bias spline")
+    hline!(p_rt_bias, [0.0], color=:black, lw=1, ls=:dot, label=nothing)
+    vline!(p_rt_bias, [Float64(model.rt_bias_extrap.lo), Float64(model.rt_bias_extrap.hi)],
+           color=:orange, lw=1.5, ls=:dot, label="extrap boundary")
+    title!(p_rt_bias, _split_title(fname, "RT-dependent bias (mDa)") *
+                      "\nRT $(round(model.rt_min, digits=2))-$(round(model.rt_max, digits=2)) min")
+    push!(plots_out, p_rt_bias)
+
     # ── Shared spread computation ──
-    spread_bin_sz = 100
+    spread_bin_sz = TUNING_CALIBRATION_BIN_SIZE
     k_sel = Float64(model.k)
     scatter_idx = 1:n  # plot all points — PNG rendering handles size
 
@@ -817,8 +898,7 @@ function generate_intensity_model_plots(
     n_within_env = 0
     for i in 1:n
         σ_i = Float64(_laplace_scale_mda(model, Float32(log2I[i]))) * laplace_to_gauss *
-              max(Float64(model.mz_spread_α) + Float64(model.mz_spread_β) * mz_f64[i] +
-                  Float64(model.mz_spread_γ) * mz_f64[i]^2, 0.1)
+              Float64(_mz_spread_correction(model, Float32(mz_f64[i])))
         if abs(corrected_mda[i]) <= k_sel * σ_i
             n_within_env += 1
         end
@@ -847,7 +927,7 @@ function generate_intensity_model_plots(
     push!(plots_out, p_envelope)
 
     # ── Plot 4: m/z-dependent spread correction (top panel only) ──
-    mz_bin_sz = 200
+    mz_bin_sz = TUNING_CALIBRATION_BIN_SIZE
     mz_sort = sortperm(mz_f64)
     n_mz_bins = max(n ÷ mz_bin_sz, 1)
 
@@ -870,19 +950,8 @@ function generate_intensity_model_plots(
     mz_fit_range = range(minimum(bin_mz_centers), maximum(bin_mz_centers), length=200)
     fit_corr = coef_corr[1] .+ coef_corr[2] .* mz_fit_range
 
-    model_α = Float64(model.mz_spread_α)
-    model_β = Float64(model.mz_spread_β)
-    model_γ = Float64(model.mz_spread_γ)
-    model_corr = model_α .+ model_β .* mz_fit_range .+ model_γ .* mz_fit_range .^ 2
-    has_quad = abs(model_γ) > 0.0
-    has_linear = abs(model_β) > 0.0 || has_quad
-    model_label = if has_quad
-        "model: $(round(model_α, digits=3)) + $(round(model_β, sigdigits=2))·mz + $(round(model_γ, sigdigits=2))·mz²"
-    elseif has_linear
-        "model: $(round(model_α, digits=3)) + $(round(model_β, sigdigits=2))·mz"
-    else
-        "model: constant $(round(model_α, digits=3))"
-    end
+    model_corr = [Float64(_mz_spread_correction(model, Float32(mz))) for mz in mz_fit_range]
+    model_label = "model: correction spline ($(length(model.mz_spread_spline.coeffs)) coeffs)"
 
     p_corr = plot(size=(900, 900),
         plot_title=_split_title(fname, "m/z-dependent spread correction"),
@@ -895,6 +964,25 @@ function generate_intensity_model_plots(
     plot!(p_corr, mz_fit_range, model_corr; lw=2.5, color=:green, label=model_label)
     hline!(p_corr, [1.0]; lw=1.5, ls=:dash, color=:black, label="ideal (1.0)")
     push!(plots_out, p_corr)
+
+    # ── Plot 5: fitted tolerance surface over fragment m/z and intensity ──
+    mz_heat, log2I_heat, tolerance_heat_mda =
+        _model_tolerance_heatmap_grid(model, frag_mzs, log2I)
+    p_tolerance_heatmap = heatmap(
+        mz_heat,
+        log2I_heat,
+        tolerance_heat_mda;
+        xlabel="Fragment m/z",
+        ylabel="log2(intensity)",
+        title=_split_title(fname, "Fitted tolerance heatmap") *
+              "\ncolor = k*sigma tolerance half-width (mDa)",
+        size=(900, 900),
+        color=:viridis,
+        rightmargin=12Plots.mm,
+        bottommargin=10Plots.mm,
+        leftmargin=10Plots.mm,
+    )
+    push!(plots_out, p_tolerance_heatmap)
 
     return plots_out
 end

--- a/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/utils.jl
@@ -824,8 +824,9 @@ function perform_quad_transmission_search(
 
         scan_mz  = getMzArray(spectra, scan_idx)
         scan_int = getIntensityArray(spectra, scan_idx)
+        scan_rt  = Float32(getRetentionTime(spectra, scan_idx))
         peak_mz_len = prepare_scan_peaks!(corr_mz, obs_low, obs_high,
-                                          mem, scan_mz, scan_int)
+                                          mem, scan_mz, scan_int, scan_rt)
 
         quad_fn = getQuadTransmissionFunction(
             getQuadTransmissionModel(search_context, ms_file_idx),
@@ -1366,6 +1367,5 @@ function fit_quad_model(psms::DataFrame, window_width::Float64;
     )
     return fitted_params, initial_params
 end
-
 
 

--- a/src/Routines/SearchDIA/process_scans_fused.jl
+++ b/src/Routines/SearchDIA/process_scans_fused.jl
@@ -72,14 +72,15 @@ function process_scans_fused!(
         msn ∉ getSpecOrder(params) && continue
         ismissing(get_prec_range(prec_index, scan_idx)) && continue
 
-        scan_irt = Float32(rt_to_irt_spline(getRetentionTime(spectra, scan_idx)))
+        scan_rt = Float32(getRetentionTime(spectra, scan_idx))
+        scan_irt = Float32(rt_to_irt_spline(scan_rt))
 
         # Pre-compute per-peak (corrected_mz, obs_low, obs_high) once per scan
-        # using the 3-arg intensity-aware MEM API.
+        # using the intensity/RT-aware MEM API.
         scan_mz  = getMzArray(spectra, scan_idx)
         scan_int = getIntensityArray(spectra, scan_idx)
         peak_mz_len = prepare_scan_peaks!(corr_mz, obs_low, obs_high,
-                                           mem, scan_mz, scan_int)
+                                           mem, scan_mz, scan_int, scan_rt)
 
         quad_fn = getQuadTransmissionFunction(qtm,
             getCenterMz(spectra, scan_idx),

--- a/src/structs/IntensityMassErrorModel.jl
+++ b/src/structs/IntensityMassErrorModel.jl
@@ -17,7 +17,7 @@
 
 """
 Precomputed linear extrapolation at the boundaries of a spline.
-Outside [lo, hi] (typically the 2% and 98% quantiles of training data),
+Outside [lo, hi] (configured from training-data quantiles),
 evaluation switches from the spline to: val + slope * (t - boundary).
 This avoids trusting the spline in sparse tail regions while keeping
 the full data for fitting.
@@ -34,32 +34,36 @@ end
 """
 Intensity-aware mass error model.
 
-Bias is decomposed into two convexity-constrained smoothing splines (Da):
-  bias_Da(mz, I) = mz_bias_spline(mz) + intensity_bias_spline(log2(I))
+Bias is decomposed into m/z- and intensity-dependent smoothing splines (Da):
+  bias_Da(mz, I, rt) =
+      mz_bias_spline(mz) + intensity_bias_spline(log2(I)) + rt_bias_spline(rt)
 
 Spread is Laplace-distributed with scale parameter **in mDa** modeled as a
-monotone-decreasing convex cubic B-spline of log2(I).
+regularized cubic B-spline of log2(I), then adjusted by an m/z-dependent
+correction factor.
 
-Splines are fit on all training data but evaluate with **linear extrapolation**
-outside the [2%, 98%] quantile range of the training data. This avoids trusting
-the spline in sparse tail regions. `conservative_tol_da` is the stopping bound
-for 2-arg methods. No hard clamp is applied — the tolerance is determined by
-`k * σ_mDa / 1e3` with linear extrapolation.
+Bias splines are fit on all training data but use configured extrapolation
+outside their supported ranges. `conservative_tol_da` is the stopping bound
+for 2-arg methods. The active tolerance is determined by `k * σ_mDa / 1e3`.
 """
-struct IntensityMassErrorModel{Nmz, NI, Nspread, T<:AbstractFloat} <: AbstractMassErrorModel
-    # m/z-dependent bias (Da): convexity-constrained smoothing spline
+struct IntensityMassErrorModel{Nmz, NI, Nspread, Nrt, Nmzspread, T<:AbstractFloat} <: AbstractMassErrorModel
+    # m/z-dependent bias (Da): binned robust regularized spline
     mz_bias_spline::UniformSpline{Nmz, T}
 
     # Intensity-dependent bias (Da): convexity-constrained smoothing spline of log2(I)
     intensity_bias_spline::UniformSpline{NI, T}
 
-    # Laplace spread (mDa): monotone-decreasing convex spline of log2(I)
+    # Laplace spread (mDa): regularized spline of log2(I)
     spread_spline::UniformSpline{Nspread, T}
 
-    # Linear extrapolation outside [q2, q98] of training data
+    # RT-dependent additive bias (Da), evaluated on raw RT within this run.
+    rt_bias_spline::UniformSpline{Nrt, T}
+
+    # Extrapolation rules outside supported spline ranges
     mz_bias_extrap::SplineExtrap{T}
     int_bias_extrap::SplineExtrap{T}
     spread_extrap::SplineExtrap{T}
+    rt_bias_extrap::SplineExtrap{T}
 
     # Coverage multiplier (k * Laplace_scale_mDa / 1e3 gives half-width in Da)
     k::T
@@ -67,8 +71,11 @@ struct IntensityMassErrorModel{Nmz, NI, Nspread, T<:AbstractFloat} <: AbstractMa
     # Maximum tolerance in Da. Used as conservative stopping bound for 2-arg methods.
     conservative_tol_da::T
 
-    # m/z-dependent spread correction: effective_spread_mDa = b_mda(log2I) * (α + β·mz + γ·mz²)
-    # Default α=1, β=0, γ=0 gives no correction.
+    # m/z-dependent spread correction: effective_spread_mDa = b_mda(log2I) * c(mz).
+    # Coefficients are retained for logging; evaluation uses mz_spread_spline
+    # with constant endpoint extrapolation.
+    mz_spread_spline::UniformSpline{Nmzspread, T}
+    mz_spread_extrap::SplineExtrap{T}
     mz_spread_α::T
     mz_spread_β::T
     mz_spread_γ::T
@@ -81,6 +88,10 @@ struct IntensityMassErrorModel{Nmz, NI, Nspread, T<:AbstractFloat} <: AbstractMa
     # Diagnostic only — NOT used as a clamp. Tolerance is determined by the
     # Gaussian model (k * σ_mDa / 1e3) with no upper bound.
     max_da_tolerance::T
+
+    # Raw RT range covered by rt_bias_spline.
+    rt_min::T
+    rt_max::T
 end
 
 #==========================================================
@@ -123,7 +134,7 @@ function make_spline_extrap(spline::UniformSpline{N, T}, lo::T, hi::T) where {N,
 end
 
 #==========================================================
-Spline evaluation with linear extrapolation outside [q2, q98]
+Spline evaluation with linear extrapolation outside stored quantile boundaries
 ==========================================================#
 
 @inline function _eval_with_extrap(spline::UniformSpline, e::SplineExtrap{T}, t::U) where {T, U<:AbstractFloat}
@@ -150,8 +161,19 @@ end
     return _eval_with_extrap(m.intensity_bias_spline, m.int_bias_extrap, log2I)
 end
 
+@inline function _rt_bias_da(m::IntensityMassErrorModel, rt::T) where {T<:AbstractFloat}
+    if !isfinite(rt)
+        rt = (T(m.rt_min) + T(m.rt_max)) / T(2)
+    end
+    return _eval_with_extrap(m.rt_bias_spline, m.rt_bias_extrap, rt)
+end
+
 @inline function _total_bias_da(m::IntensityMassErrorModel, mz::T, log2I::T) where {T<:AbstractFloat}
     return _mz_bias_da(m, mz) + _intensity_bias_da(m, log2I)
+end
+
+@inline function _total_bias_da(m::IntensityMassErrorModel, mz::T, log2I::T, rt::T) where {T<:AbstractFloat}
+    return _total_bias_da(m, mz, log2I) + _rt_bias_da(m, rt)
 end
 
 #==========================================================
@@ -175,8 +197,12 @@ end
 m/z-dependent spread correction factor (in mDa space)
 ==========================================================#
 
+@inline function _mz_spread_correction(spline::UniformSpline, e::SplineExtrap{T}, mz::U) where {T, U<:AbstractFloat}
+    @fastmath return min(max(_eval_with_extrap(spline, e, mz), U(0.1)), U(10.0))
+end
+
 @inline function _mz_spread_correction(m::IntensityMassErrorModel, mz::T) where {T<:AbstractFloat}
-    @fastmath return max(muladd(muladd(T(m.mz_spread_γ), mz, T(m.mz_spread_β)), mz, T(m.mz_spread_α)), T(0.1))
+    return _mz_spread_correction(m.mz_spread_spline, m.mz_spread_extrap, mz)
 end
 
 #==========================================================
@@ -204,7 +230,7 @@ getMassOffset(m::IntensityMassErrorModel) = Float32(m.mz_bias_spline(m.mz_bias_s
 getMassCorrection(m::IntensityMassErrorModel) = getMassOffset(m)
 
 #==========================================================
-3-arg interface (fragment index search — intensity-aware)
+Intensity/RT-aware interface used by fragment matching.
 Spread is in mDa; converted to Da directly.
 ==========================================================#
 
@@ -214,11 +240,20 @@ function getCorrectedMz(m::IntensityMassErrorModel, mz::Float32, intensity::Floa
     return Float32(mz - bias_da)
 end
 
+function getCorrectedMz(m::IntensityMassErrorModel, mz::Float32, intensity::Float32, rt::Float32)
+    log2I = fast_log2(intensity)
+    bias_da = _total_bias_da(m, mz, log2I, rt)
+    return Float32(mz - bias_da)
+end
+
 function getMzBoundsReverse(m::IntensityMassErrorModel, mass::Float32, log2I::Float32)
     σ_mda = _gaussian_sigma_mda(m, log2I) * _mz_spread_correction(m, mass)
     half_width = m.k * σ_mda / 1f3  # mDa → Da
     return Float32(mass - half_width), Float32(mass + half_width)
 end
+
+getMzBoundsReverse(m::IntensityMassErrorModel, mass::Float32, log2I::Float32, ::Float32) =
+    getMzBoundsReverse(m, mass, log2I)
 
 """
     getCorrectedMzAndBounds(m, mz, intensity) -> (corrected, low, high)
@@ -234,6 +269,17 @@ Avoids redundant log2 computation vs calling getCorrectedMz + getMzBoundsReverse
         corrected = mz - bias_da
         σ_mda = _gaussian_sigma_mda(m, log2I) * _mz_spread_correction(m, corrected)
         half_width = m.k * σ_mda * 1f-3  # mDa → Da (multiply faster than divide)
+        return corrected, corrected - half_width, corrected + half_width
+    end
+end
+
+@inline function getCorrectedMzAndBounds(m::IntensityMassErrorModel, mz::Float32, intensity::Float32, rt::Float32)
+    @fastmath begin
+        log2I = fast_log2(intensity)
+        bias_da = _total_bias_da(m, mz, log2I, rt)
+        corrected = mz - bias_da
+        σ_mda = _gaussian_sigma_mda(m, log2I) * _mz_spread_correction(m, corrected)
+        half_width = m.k * σ_mda * 1f-3
         return corrected, corrected - half_width, corrected + half_width
     end
 end
@@ -279,6 +325,12 @@ function convert_spline_to_f32(s::UniformSpline{N, Float64}) where N
         Float32(s.bin_width)
     )
 end
+
+convert_spline_extrap_to_f32(e::SplineExtrap{Float64}) = SplineExtrap{Float32}(
+    Float32(e.lo), Float32(e.hi),
+    Float32(e.lo_val), Float32(e.lo_slope),
+    Float32(e.hi_val), Float32(e.hi_slope)
+)
 
 #==========================================================
 ScoutCalibratedMassErrorModel
@@ -347,6 +399,10 @@ function getCorrectedMz(m::ScoutCalibratedMassErrorModel, mz::Float32, intensity
 end
 
 getMzBoundsReverse(m::ScoutCalibratedMassErrorModel, mass::Float32, ::Float32) = getMzBoundsReverse(m, mass)
+getCorrectedMz(m::ScoutCalibratedMassErrorModel, mz::Float32, intensity::Float32, ::Float32) =
+    getCorrectedMz(m, mz, intensity)
+getMzBoundsReverse(m::ScoutCalibratedMassErrorModel, mass::Float32, log2I::Float32, ::Float32) =
+    getMzBoundsReverse(m, mass, log2I)
 laplace_log_density(::ScoutCalibratedMassErrorModel, ::Float32, ::Float32, ::Float32) = Float32(0)
 get_default_top3_ll(::ScoutCalibratedMassErrorModel) = Float32(0)
 
@@ -357,4 +413,8 @@ get_default_top3_ll(::ScoutCalibratedMassErrorModel) = Float32(0)
         corrected = mz - bias_da
         return corrected, Float32(corrected - m.tolerance_da), Float32(corrected + m.tolerance_da)
     end
+end
+
+@inline function getCorrectedMzAndBounds(m::ScoutCalibratedMassErrorModel, mz::Float32, intensity::Float32, ::Float32)
+    return getCorrectedMzAndBounds(m, mz, intensity)
 end

--- a/src/structs/MassErrorModel.jl
+++ b/src/structs/MassErrorModel.jl
@@ -55,11 +55,19 @@ end
 # 3-arg forwarding: SimpleMassErrorModel ignores intensity
 getCorrectedMz(mem::SimpleMassErrorModel, mz::Float32, ::Float32) = getCorrectedMz(mem, mz)
 getMzBoundsReverse(mem::SimpleMassErrorModel, mass::Float32, ::Float32) = getMzBoundsReverse(mem, mass)
+getCorrectedMz(mem::SimpleMassErrorModel, mz::Float32, intensity::Float32, ::Float32) =
+    getCorrectedMz(mem, mz, intensity)
+getMzBoundsReverse(mem::SimpleMassErrorModel, mass::Float32, log2I::Float32, ::Float32) =
+    getMzBoundsReverse(mem, mass, log2I)
 
 @inline function getCorrectedMzAndBounds(mem::SimpleMassErrorModel, mz::Float32, ::Float32)
     corrected = getCorrectedMz(mem, mz)
     low, high = getMzBoundsReverse(mem, corrected)
     return corrected, low, high
+end
+
+@inline function getCorrectedMzAndBounds(mem::SimpleMassErrorModel, mz::Float32, intensity::Float32, ::Float32)
+    return getCorrectedMzAndBounds(mem, mz, intensity)
 end
 
 #==========================================================
@@ -93,11 +101,19 @@ getMassCorrection(m::LinearDaMassErrorModel) = m.intercept
 # 3-arg forwarding: ignores intensity
 getCorrectedMz(m::LinearDaMassErrorModel, mz::Float32, ::Float32) = getCorrectedMz(m, mz)
 getMzBoundsReverse(m::LinearDaMassErrorModel, mass::Float32, ::Float32) = getMzBoundsReverse(m, mass)
+getCorrectedMz(m::LinearDaMassErrorModel, mz::Float32, intensity::Float32, ::Float32) =
+    getCorrectedMz(m, mz, intensity)
+getMzBoundsReverse(m::LinearDaMassErrorModel, mass::Float32, log2I::Float32, ::Float32) =
+    getMzBoundsReverse(m, mass, log2I)
 
 @inline function getCorrectedMzAndBounds(m::LinearDaMassErrorModel, mz::Float32, ::Float32)
     corrected = getCorrectedMz(m, mz)
     low, high = getMzBoundsReverse(m, corrected)
     return corrected, low, high
+end
+
+@inline function getCorrectedMzAndBounds(m::LinearDaMassErrorModel, mz::Float32, intensity::Float32, ::Float32)
+    return getCorrectedMzAndBounds(m, mz, intensity)
 end
 
 # Scoring fallbacks
@@ -139,11 +155,19 @@ getMassCorrection(m::LinearBiasPpmTolMassErrorModel) = m.intercept
 
 getCorrectedMz(m::LinearBiasPpmTolMassErrorModel, mz::Float32, ::Float32) = getCorrectedMz(m, mz)
 getMzBoundsReverse(m::LinearBiasPpmTolMassErrorModel, mass::Float32, ::Float32) = getMzBoundsReverse(m, mass)
+getCorrectedMz(m::LinearBiasPpmTolMassErrorModel, mz::Float32, intensity::Float32, ::Float32) =
+    getCorrectedMz(m, mz, intensity)
+getMzBoundsReverse(m::LinearBiasPpmTolMassErrorModel, mass::Float32, log2I::Float32, ::Float32) =
+    getMzBoundsReverse(m, mass, log2I)
 
 @inline function getCorrectedMzAndBounds(m::LinearBiasPpmTolMassErrorModel, mz::Float32, ::Float32)
     corrected = getCorrectedMz(m, mz)
     low, high = getMzBoundsReverse(m, corrected)
     return corrected, low, high
+end
+
+@inline function getCorrectedMzAndBounds(m::LinearBiasPpmTolMassErrorModel, mz::Float32, intensity::Float32, ::Float32)
+    return getCorrectedMzAndBounds(m, mz, intensity)
 end
 
 laplace_log_density(::LinearBiasPpmTolMassErrorModel, ::Float32, ::Float32, ::Float32) = Float32(0)

--- a/src/structs/MatchIon.jl
+++ b/src/structs/MatchIon.jl
@@ -18,7 +18,7 @@
 """
     MassErrSample
 
-12-byte sample emitted by `run_fused_masserr!` (ParameterTuning's per-thread
+16-byte sample emitted by `run_fused_masserr!` (ParameterTuning's per-thread
 mass-error collector) and consumed by `fit_mass_err_model`,
 `fit_intensity_mass_error_model`, `fit_scout_calibrated_model`,
 `extract_fragment_plot_data`, and `generate_wide_scout_plot`.
@@ -29,6 +29,7 @@ struct MassErrSample
     theoretical_mz::Float32   # 4B — fragment library m/z
     observed_mz::Float32      # 4B — raw peak m/z
     intensity::Float32        # 4B — peak intensity
+    rt::Float32               # 4B — scan retention time
 end
 
-MassErrSample() = MassErrSample(0f0, 0f0, 0f0)
+MassErrSample() = MassErrSample(0f0, 0f0, 0f0, 0f0)

--- a/src/utils/Splines/uniformBasisCubicSpline.jl
+++ b/src/utils/Splines/uniformBasisCubicSpline.jl
@@ -160,6 +160,56 @@ function _setup_knots(sorted_t::Vector{T}, n_knots::Int) where {T}
     return knots, bin_width, _first, _last
 end
 
+function _make_uniform_spline_basis(t::Vector{T}, n_knots::Integer) where {T<:AbstractFloat}
+    n_knots_int = Int(n_knots)
+    knots, bin_width, _first, _last = _setup_knots(t, n_knots_int)
+    return (
+        X = _build_numeric_design_matrix(t, knots, bin_width),
+        knots = knots,
+        bin_width = bin_width,
+        first = _first,
+        last = _last,
+        n_knots = n_knots_int,
+        n_coeffs = n_knots_int + 3,
+    )
+end
+
+function _penalized_spline_system(
+    X::AbstractMatrix{T},
+    y::AbstractVector{T};
+    λ::Real = zero(T),
+    weights::Union{Nothing, AbstractVector{<:Real}} = nothing,
+    order::Int = 2,
+    ridge::Real = 0,
+) where {T<:AbstractFloat}
+    size(X, 1) == length(y) || throw(DimensionMismatch("X row count must equal length(y)"))
+
+    if weights === nothing
+        H = X' * X
+        rhs = X' * y
+    else
+        length(weights) == size(X, 1) || throw(DimensionMismatch("length(weights) must equal number of rows in X"))
+        w = T.(weights)
+        H = (X .* reshape(w, :, 1))' * X
+        rhs = X' * (w .* y)
+    end
+
+    if λ != 0
+        D = build_difference_matrix(size(X, 2), order)
+        H = H + T(λ) * (D' * D)
+    end
+
+    if ridge != 0
+        H = H + T(ridge) * I
+    end
+
+    return H, rhs
+end
+
+function _coeffs_to_spline(c::Vector{T}, basis) where {T<:AbstractFloat}
+    return _coeffs_to_spline(c, basis.knots, basis.bin_width, 3, basis.n_knots, basis.first, basis.last)
+end
+
 #############################################################################
 # UniformSpline — unpenalized least squares fit
 #############################################################################
@@ -173,12 +223,8 @@ function UniformSpline(
 
     _validate_spline_inputs(u, t, degree, n_knots)
     sorted_u, sorted_t = _sort_inputs(u, t)
-    knots, bin_width, _first, _last = _setup_knots(sorted_t, n_knots)
-
-    X = _build_numeric_design_matrix(sorted_t, knots, bin_width)
-    c = X \ sorted_u
-
-    return _coeffs_to_spline(c, knots, bin_width, degree, n_knots, _first, _last)
+    basis = _make_uniform_spline_basis(sorted_t, n_knots)
+    return _coeffs_to_spline(convert(Vector{T}, basis.X \ sorted_u), basis)
 end
 
 #############################################################################
@@ -294,21 +340,14 @@ function UniformSplinePenalized(
     λ < 0 && error("Penalty parameter λ must be non-negative")
 
     sorted_u, sorted_t = _sort_inputs(u, t)
-    knots, bin_width, _first, _last = _setup_knots(sorted_t, n_knots)
-
-    X = _build_numeric_design_matrix(sorted_t, knots, bin_width)
-    n_coeffs = n_knots + degree
-
-    if λ == 0
-        c = X \ sorted_u
+    basis = _make_uniform_spline_basis(sorted_t, n_knots)
+    c = if λ == 0
+        basis.X \ sorted_u
     else
-        D = build_difference_matrix(n_coeffs, order)
-        P = D' * D
-        c = (X'X + T(λ) * P) \ (X'sorted_u)
+        H, rhs = _penalized_spline_system(basis.X, sorted_u; λ=λ, order=order)
+        H \ rhs
     end
-    c = convert(Vector{T}, c)
-
-    return _coeffs_to_spline(c, knots, bin_width, degree, n_knots, _first, _last)
+    return _coeffs_to_spline(convert(Vector{T}, c), basis)
 end
 
 #############################################################################

--- a/test/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/test_intensity_spline_lipschitz.jl
+++ b/test/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/test_intensity_spline_lipschitz.jl
@@ -11,8 +11,16 @@
 # trip the original divergence and assert the fit returns a finite
 # UniformSpline.
 
+using Random
+using Statistics: median
 using Pioneer: fit_convex_bias_spline, fit_monotone_bias_spline,
-               fit_monotone_convex_spread_spline
+               fit_monotone_convex_spread_spline,
+               fit_intensity_mass_error_model,
+               IntensityMassErrorModel,
+               MassErrSample,
+               SimpleMassErrorModel,
+               getCorrectedMz,
+               _rt_bias_da
 
 @testset "Intensity spline Lipschitz step cap" begin
     rng = MersenneTwister(0x5eedfa11)
@@ -51,4 +59,40 @@ using Pioneer: fit_convex_bias_spline, fit_monotone_bias_spline,
         @test spline !== nothing
         @test all(isfinite, spline.coeffs)
     end
+end
+
+@testset "Intensity mass error model learns RT-dependent bias" begin
+    rng = MersenneTwister(0x71cafe)
+    n = 1_800
+    rts = collect(range(5.0, 85.0; length=n))
+    mzs = [420.0 + 7.0 * mod(i, 120) + 0.03 * randn(rng) for i in 1:n]
+    log2I = [10.0 + 0.05 * mod(37 * i, 220) for i in 1:n]
+    intensities = Float32.(2.0 .^ log2I)
+
+    rt_bias = @. 0.0014 * tanh((rts - 48.0) / 7.0)
+    noise = 0.00003 .* randn(rng, n)
+    da_err = rt_bias .+ noise
+
+    samples = [
+        MassErrSample(Float32(mzs[i]), Float32(mzs[i] + da_err[i]), intensities[i], Float32(rts[i]))
+        for i in 1:n
+    ]
+
+    model = fit_intensity_mass_error_model(
+        samples,
+        SimpleMassErrorModel(0.0f0, (30.0f0, 30.0f0)),
+    )
+
+    @test model isa IntensityMassErrorModel
+    @test model.rt_min ≈ Float32(first(rts))
+    @test model.rt_max ≈ Float32(last(rts))
+
+    early_bias = _rt_bias_da(model, 10.0f0)
+    late_bias = _rt_bias_da(model, 80.0f0)
+    @test late_bias - early_bias > 0.0015f0
+
+    obs_mz = 700.0f0
+    intensity = Float32(2.0 ^ 16.0)
+    @test getCorrectedMz(model, obs_mz, intensity, 80.0f0) <
+          getCorrectedMz(model, obs_mz, intensity, 10.0f0)
 end

--- a/test/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/test_intensity_spline_lipschitz.jl
+++ b/test/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/test_intensity_spline_lipschitz.jl
@@ -1,7 +1,7 @@
 # Regression test for the Lipschitz step cap in
 # fit_intensity_mass_error.jl. The projected gradient descent loops
 # inside fit_convex_bias_spline / fit_monotone_bias_spline /
-# fit_monotone_convex_spread_spline used a fixed lr=1e-4. opnorm(H)
+# constrained spline fitting used a fixed lr=1e-4. opnorm(H)
 # scales with the row count of the design matrix, so once n_pts pushes
 # L = opnorm(H) past 1/lr the optimizer diverges, IRLS reweights to
 # non-finite values, and the next H \ Xty throws
@@ -14,7 +14,7 @@
 using Random
 using Statistics: median
 using Pioneer: fit_convex_bias_spline, fit_monotone_bias_spline,
-               fit_monotone_convex_spread_spline,
+               fit_regularized_spread_spline,
                fit_intensity_mass_error_model,
                IntensityMassErrorModel,
                MassErrSample,
@@ -46,16 +46,14 @@ using Pioneer: fit_convex_bias_spline, fit_monotone_bias_spline,
         @test all(isfinite, spline.coeffs)
     end
 
-    @testset "fit_monotone_convex_spread_spline" begin
-        # The spread fit consumes pre-binned (centers, scales) so its
-        # design matrix is small; the Lipschitz cap still has to be
-        # finite. This guards against regression of the same code path.
+    @testset "fit_regularized_spread_spline" begin
+        # The spread fit consumes pre-binned (centers, scales) so its design
+        # matrix is small. This guards the same shared spline-system path.
         centers = collect(range(10.0, 30.0; length=200))
         scales = max.(0.5 .+ 5.0 .* exp.(-(centers .- 10.0) ./ 5.0)
                        .+ 0.05 .* randn(rng, length(centers)), 0.05)
-        spline = fit_monotone_convex_spread_spline(centers, scales;
-                                                    n_knots=10, λ=0.01,
-                                                    max_iter=1000, lr=1e-3)
+        spline = fit_regularized_spread_spline(centers, scales;
+                                                n_knots=10, λ=0.01)
         @test spline !== nothing
         @test all(isfinite, spline.coeffs)
     end

--- a/test/UnitTests/test_mass_error_model.jl
+++ b/test/UnitTests/test_mass_error_model.jl
@@ -14,7 +14,7 @@ using Pioneer: SimpleMassErrorModel, LinearDaMassErrorModel,
                getRightTol, getLeftTol, getMassOffset, getMassCorrection,
                getCorrectedMz, getMzBounds, getMzBoundsReverse,
                getCorrectedMzAndBounds, laplace_log_density,
-               get_default_top3_ll
+               get_default_top3_ll, MassErrSample
 
 @testset "MassErrorModel" begin
 
@@ -114,6 +114,17 @@ using Pioneer: SimpleMassErrorModel, LinearDaMassErrorModel,
             @test getCorrectedMz(mem, mz, 0.0f0) == getCorrectedMz(mem, mz)
             @test getMzBoundsReverse(mem, mz, 5.0f0) == getMzBoundsReverse(mem, mz)
         end
+
+        @testset "4-arg forwarding ignores scan retention time" begin
+            mem = SimpleMassErrorModel(2.5f0, (12.0f0, 9.0f0))
+            mz = 750.0f0
+            intensity = 42.0f0
+            scan_rt = 31.5f0
+            @test getCorrectedMz(mem, mz, intensity, scan_rt) == getCorrectedMz(mem, mz, intensity)
+            @test getMzBoundsReverse(mem, mz, intensity, scan_rt) == getMzBoundsReverse(mem, mz, intensity)
+            @test getCorrectedMzAndBounds(mem, mz, intensity, scan_rt) ==
+                  getCorrectedMzAndBounds(mem, mz, intensity)
+        end
     end
 
     @testset "LinearDaMassErrorModel" begin
@@ -186,6 +197,17 @@ using Pioneer: SimpleMassErrorModel, LinearDaMassErrorModel,
             @test getCorrectedMz(m, 1000.0f0, 0.5f0) == getCorrectedMz(m, 1000.0f0)
             @test getMzBoundsReverse(m, 1000.0f0, 0.5f0) == getMzBoundsReverse(m, 1000.0f0)
         end
+
+        @testset "4-arg forwarding ignores scan retention time" begin
+            m = LinearDaMassErrorModel(0.001f0, 0.0f0, 0.002f0)
+            mz = 1000.0f0
+            intensity = 0.5f0
+            scan_rt = 18.25f0
+            @test getCorrectedMz(m, mz, intensity, scan_rt) == getCorrectedMz(m, mz, intensity)
+            @test getMzBoundsReverse(m, mz, intensity, scan_rt) == getMzBoundsReverse(m, mz, intensity)
+            @test getCorrectedMzAndBounds(m, mz, intensity, scan_rt) ==
+                  getCorrectedMzAndBounds(m, mz, intensity)
+        end
     end
 
     @testset "LinearBiasPpmTolMassErrorModel" begin
@@ -242,6 +264,25 @@ using Pioneer: SimpleMassErrorModel, LinearDaMassErrorModel,
             @test getCorrectedMz(m, 1000.0f0, 0.5f0) == getCorrectedMz(m, 1000.0f0)
             @test getMzBoundsReverse(m, 1000.0f0, 0.5f0) == getMzBoundsReverse(m, 1000.0f0)
         end
+
+        @testset "4-arg forwarding ignores scan retention time" begin
+            m = LinearBiasPpmTolMassErrorModel(0.0005f0, 0.0f0, 6.0f0)
+            mz = 1000.0f0
+            intensity = 0.5f0
+            scan_rt = 18.25f0
+            @test getCorrectedMz(m, mz, intensity, scan_rt) == getCorrectedMz(m, mz, intensity)
+            @test getMzBoundsReverse(m, mz, intensity, scan_rt) == getMzBoundsReverse(m, mz, intensity)
+            @test getCorrectedMzAndBounds(m, mz, intensity, scan_rt) ==
+                  getCorrectedMzAndBounds(m, mz, intensity)
+        end
+    end
+
+    @testset "MassErrSample stores scan retention time" begin
+        sample = MassErrSample(500.0f0, 500.002f0, 1234.0f0, 42.5f0)
+        @test sample.theoretical_mz == 500.0f0
+        @test sample.observed_mz == 500.002f0
+        @test sample.intensity == 1234.0f0
+        @test sample.rt == 42.5f0
     end
 
 end


### PR DESCRIPTION
## Summary

- add RT-aware parameter-tuning mass calibration with m/z, intensity, and RT bias components
- model intensity-dependent spread, m/z-dependent spread correction, and empirical coverage multiplier
- pass scan RT through fused mass-error matching and add focused model/calibration tests

## Validation

- julia --project=. -e 'using Test; include("test/UnitTests/test_mass_error_model.jl")'
- julia --project=. -e 'using Test; include("test/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/test_intensity_spline_lipschitz.jl")'
- git diff --check