### PR TITLE
Add charge to LightGBM features

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
@@ -143,7 +143,7 @@ const PRESCORE_FEATURES = [
     # Core PSM / sequence metrics
     :fitted_manhattan_distance, :irt_error, :poisson, :err_norm,
     :total_ions, :missed_cleavage, :y_count, :weight, :gof,
-    :Mox, :spectrum_peak_count, :sequence_length,
+    :charge, :Mox, :spectrum_peak_count, :sequence_length,
     :fitted_hellinger,
 
     # Cross-precursor at-scan

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/model_config.jl
@@ -46,7 +46,7 @@ const ADVANCED_FEATURE_SET = [
     # Kept in sync manually with PRESCORE_FEATURES (MainSearch/features.jl).
     :fitted_manhattan_distance, :irt_error, :poisson, :err_norm,
     :total_ions, :missed_cleavage, :y_count, :weight, :gof,
-    :Mox, :spectrum_peak_count, :sequence_length,
+    :charge, :Mox, :spectrum_peak_count, :sequence_length,
     :fitted_hellinger,
     :weight_ratio_at_scan, :weight_rank_at_scan,
     :ms1_m0_mass_err_ppm,


### PR DESCRIPTION
## Summary
- add the existing per-PSM `charge` column to the MainSearch prescore LightGBM feature list
- keep PrecursorScoringSearch `ADVANCED_FEATURE_SET` in sync

## Validation
- julia --startup-file=no --project=. -e 'using Pioneer; @assert :charge in Pioneer.PRESCORE_FEATURES; @assert :charge in Pioneer.ADVANCED_FEATURE_SET; println("charge feature lists ok")'\n- git diff --check