### PR TITLE
[codex] Add spectral contrast feature

### DIFF
--- a/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
+++ b/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
@@ -88,6 +88,7 @@ struct MainSearchScoredPSM{H,L<:AbstractFloat} <: ScoredPSM{H,L}
     weight::H
 
     fitted_hellinger::L
+    spectral_contrast::L
 
     # Rank feature carried from MainUnscoredPSM. Added 2026-05-11 so the
     # experiment-wide LightGBM in PrecursorScoringSearch has the same rank
@@ -178,6 +179,7 @@ function Score!(scored_psms::Vector{MainSearchScoredPSM{H, L}},
             weight[scores_idx],
 
             spectral_scores[scores_idx].fitted_hellinger,
+            spectral_scores[scores_idx].spectral_contrast,
 
             unscored_PSMs[i].best_rank,
 

--- a/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
+++ b/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
@@ -72,17 +72,12 @@ function getDistanceMetrics(w::Vector{T},
         sum_shadow = zero(T)     # sum of clamped shadow_peak (for normalization)
         dot_product = zero(T)
         pred_norm2 = zero(T)
-        obs_norm2 = zero(T)
+        shadow_norm2 = zero(T)
 
         @inbounds @fastmath for i in H.colptr[col]:(H.colptr[col+1]-1)
             x_sum += H.x[i]
             fitted_peak = w[col]*H.nzval[i]
             manhattan_distance += abs(fitted_peak - H.x[i])
-            pred_peak = max(H.nzval[i], zero(T))
-            obs_peak = max(H.x[i], zero(T))
-            dot_product += pred_peak * obs_peak
-            pred_norm2 += pred_peak * pred_peak
-            obs_norm2 += obs_peak * obs_peak
 
             shadow_peak = fitted_peak - r[H.rowval[i]]
             r_abs = abs(r[H.rowval[i]])
@@ -93,6 +88,10 @@ function getDistanceMetrics(w::Vector{T},
             sum_fitted += fitted_peak
             sum_shadow += x_i
             bc_sum += sqrt(fitted_peak * x_i)
+            pred_peak = max(fitted_peak, zero(T))
+            dot_product += pred_peak * x_i
+            pred_norm2 += pred_peak * pred_peak
+            shadow_norm2 += x_i * x_i
 
             if matched_at(H, i)
                 sum_of_fitted_peaks_matched += fitted_peak
@@ -119,7 +118,7 @@ function getDistanceMetrics(w::Vector{T},
         hellinger_denom = sqrt(sum_fitted * sum_shadow)
         hellinger_sq = hellinger_denom > 0 ? one(T) - bc_sum / hellinger_denom : one(T)
         fitted_hellinger = -log2(max(hellinger_sq, T(1e-10)))
-        spectral_denom = sqrt(pred_norm2 * obs_norm2)
+        spectral_denom = sqrt(pred_norm2 * shadow_norm2)
         spectral_contrast = spectral_denom > zero(T) ? dot_product / spectral_denom : zero(T)
 
         spectral_scores[col] = SpectralScoresMainSearch(

--- a/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
+++ b/src/Routines/SearchDIA/PSMs/spectralDistanceMetrics.jl
@@ -22,6 +22,7 @@ struct SpectralScoresMainSearch{T<:AbstractFloat} <: SpectralScores{T}
     max_unmatched_residual::T
     fitted_manhattan_distance::T
     fitted_hellinger::T
+    spectral_contrast::T
 end
 function getDistanceMetrics(w::Vector{T},
     r::Vector{T},
@@ -53,7 +54,7 @@ function getDistanceMetrics(w::Vector{T},
         # Skip zero-weight columns
         if w[col] <= zero(T)
             spectral_scores[col] = SpectralScoresMainSearch(
-                zero(U), zero(U), zero(U), zero(U), zero(U)
+                zero(U), zero(U), zero(U), zero(U), zero(U), zero(U)
             )
             continue
         end
@@ -69,11 +70,19 @@ function getDistanceMetrics(w::Vector{T},
         bc_sum = zero(T)         # Bhattacharyya coefficient
         sum_fitted = zero(T)     # sum of fitted_peak (for normalization)
         sum_shadow = zero(T)     # sum of clamped shadow_peak (for normalization)
+        dot_product = zero(T)
+        pred_norm2 = zero(T)
+        obs_norm2 = zero(T)
 
         @inbounds @fastmath for i in H.colptr[col]:(H.colptr[col+1]-1)
             x_sum += H.x[i]
             fitted_peak = w[col]*H.nzval[i]
             manhattan_distance += abs(fitted_peak - H.x[i])
+            pred_peak = max(H.nzval[i], zero(T))
+            obs_peak = max(H.x[i], zero(T))
+            dot_product += pred_peak * obs_peak
+            pred_norm2 += pred_peak * pred_peak
+            obs_norm2 += obs_peak * obs_peak
 
             shadow_peak = fitted_peak - r[H.rowval[i]]
             r_abs = abs(r[H.rowval[i]])
@@ -110,13 +119,16 @@ function getDistanceMetrics(w::Vector{T},
         hellinger_denom = sqrt(sum_fitted * sum_shadow)
         hellinger_sq = hellinger_denom > 0 ? one(T) - bc_sum / hellinger_denom : one(T)
         fitted_hellinger = -log2(max(hellinger_sq, T(1e-10)))
+        spectral_denom = sqrt(pred_norm2 * obs_norm2)
+        spectral_contrast = spectral_denom > zero(T) ? dot_product / spectral_denom : zero(T)
 
         spectral_scores[col] = SpectralScoresMainSearch(
             U(gof),
             U(max_matched_residual),
             U(max_unmatched_residual),
             U(fitted_manhattan_distance),
-            U(fitted_hellinger)
+            U(fitted_hellinger),
+            U(spectral_contrast)
         )
     end
 end

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
@@ -144,7 +144,7 @@ const PRESCORE_FEATURES = [
     :fitted_manhattan_distance, :irt_error, :poisson, :err_norm,
     :total_ions, :missed_cleavage, :y_count, :weight, :gof,
     :Mox, :spectrum_peak_count, :sequence_length,
-    :fitted_hellinger,
+    :fitted_hellinger, :spectral_contrast,
 
     # Cross-precursor at-scan
     :weight_ratio_at_scan, :weight_rank_at_scan,

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/model_config.jl
@@ -47,7 +47,7 @@ const ADVANCED_FEATURE_SET = [
     :fitted_manhattan_distance, :irt_error, :poisson, :err_norm,
     :total_ions, :missed_cleavage, :y_count, :weight, :gof,
     :Mox, :spectrum_peak_count, :sequence_length,
-    :fitted_hellinger,
+    :fitted_hellinger, :spectral_contrast,
     :weight_ratio_at_scan, :weight_rank_at_scan,
     :ms1_m0_mass_err_ppm,
     :ms1_weight_apex_to_m0_apex_irt,

--- a/test/UnitTests/test_feature_finiteness.jl
+++ b/test/UnitTests/test_feature_finiteness.jl
@@ -54,6 +54,41 @@ function _score_single(w_val::Float32, nzval, x, matched)
     spectral_scores[1]
 end
 
+function _score_shared_peak_column1()
+    H = _SparseArrayFused(UInt32(3))
+    H.n_vals = 3
+    H.m = 2
+    H.n = 2
+    @inbounds begin
+        # Column 1: predicted [1, 2], raw observed [3, 1].
+        H.rowval[1] = UInt32(1)
+        H.nzval[1] = 1.0f0
+        H.x[1] = 3.0f0
+        H.meta[1] = _pack_meta(true, UInt8(0))
+        H.rowval[2] = UInt32(2)
+        H.nzval[2] = 2.0f0
+        H.x[2] = 1.0f0
+        H.meta[2] = _pack_meta(true, UInt8(0))
+
+        # Column 2 explains 2 units of the shared first peak, leaving
+        # column 1 with shadow spectrum [1, 1].
+        H.rowval[3] = UInt32(1)
+        H.nzval[3] = 2.0f0
+        H.x[3] = 3.0f0
+        H.meta[3] = _pack_meta(true, UInt8(0))
+    end
+    resize!(H.colptr, 3)
+    H.colptr[1] = UInt32(1)
+    H.colptr[2] = UInt32(3)
+    H.colptr[3] = UInt32(4)
+
+    w = Float32[1.0f0, 1.0f0]
+    r = zeros(Float32, H.m)
+    spectral_scores = Vector{_SpectralScoresMainSearch{Float16}}(undef, 2)
+    _getDistanceMetrics(w, r, H, spectral_scores)
+    spectral_scores[1]
+end
+
 @testset "Feature finiteness — psm_getPoisson" begin
     # Hypothesis from production: zero-error or zero-fragment edge cases
     # should never produce NaN or Inf in any feature.
@@ -155,6 +190,15 @@ end
     expected_contrast = (1.0f0 * 2.0f0 + 2.0f0 * 1.0f0) /
         sqrt((1.0f0^2 + 2.0f0^2) * (2.0f0^2 + 1.0f0^2))
     @test Float32(s.spectral_contrast) ≈ expected_contrast rtol=1.0f-3
+
+    # Case E3 — shared peaks use the deconvolved shadow spectrum, not raw H.x.
+    s = _score_shared_peak_column1()
+    expected_shadow_contrast = (1.0f0 * 1.0f0 + 2.0f0 * 1.0f0) /
+        sqrt((1.0f0^2 + 2.0f0^2) * (1.0f0^2 + 1.0f0^2))
+    raw_contrast = (1.0f0 * 3.0f0 + 2.0f0 * 1.0f0) /
+        sqrt((1.0f0^2 + 2.0f0^2) * (3.0f0^2 + 1.0f0^2))
+    @test Float32(s.spectral_contrast) ≈ expected_shadow_contrast rtol=1.0f-3
+    @test !isapprox(Float32(s.spectral_contrast), raw_contrast; rtol=1.0f-3)
 
     # Case F — purely unmatched fragments (sum_of_fitted_peaks_matched = 0
     # → branch returns zero, must not produce NaN)

--- a/test/UnitTests/test_feature_finiteness.jl
+++ b/test/UnitTests/test_feature_finiteness.jl
@@ -98,6 +98,8 @@ end
     @test isfinite(s.max_unmatched_residual)
     @test isfinite(s.fitted_manhattan_distance)
     @test isfinite(s.fitted_hellinger)
+    @test isfinite(s.spectral_contrast)
+    @test Float32(s.spectral_contrast) ≈ 1.0f0
 
     # Case B — perfect multi-fragment match
     s = _score_single(1.0f0,
@@ -105,9 +107,11 @@ end
                       Float32[1.0, 2.0, 3.0],
                       Bool[true, true, true])
     for v in (s.gof, s.max_matched_residual, s.max_unmatched_residual,
-              s.fitted_manhattan_distance, s.fitted_hellinger)
+              s.fitted_manhattan_distance, s.fitted_hellinger,
+              s.spectral_contrast)
         @test isfinite(v)
     end
+    @test Float32(s.spectral_contrast) ≈ 1.0f0
 
     # Case C — zero-weight column (early exit path, all zeros)
     s = _score_single(0.0f0,
@@ -115,7 +119,8 @@ end
                       Float32[1.0, 2.0],
                       Bool[true, true])
     for v in (s.gof, s.max_matched_residual, s.max_unmatched_residual,
-              s.fitted_manhattan_distance, s.fitted_hellinger)
+              s.fitted_manhattan_distance, s.fitted_hellinger,
+              s.spectral_contrast)
         @test isfinite(v)
         @test v == zero(Float16)
     end
@@ -136,9 +141,20 @@ end
                       Float32[0.0, 0.0],
                       Bool[true, true])
     for v in (s.gof, s.max_matched_residual, s.max_unmatched_residual,
-              s.fitted_manhattan_distance, s.fitted_hellinger)
+              s.fitted_manhattan_distance, s.fitted_hellinger,
+              s.spectral_contrast)
         @test isfinite(v)
     end
+    @test s.spectral_contrast == zero(Float16)
+
+    # Case E2 — non-proportional observed shape gets the expected cosine.
+    s = _score_single(1.0f0,
+                      Float32[1.0, 2.0],
+                      Float32[2.0, 1.0],
+                      Bool[true, true])
+    expected_contrast = (1.0f0 * 2.0f0 + 2.0f0 * 1.0f0) /
+        sqrt((1.0f0^2 + 2.0f0^2) * (2.0f0^2 + 1.0f0^2))
+    @test Float32(s.spectral_contrast) ≈ expected_contrast rtol=1.0f-3
 
     # Case F — purely unmatched fragments (sum_of_fitted_peaks_matched = 0
     # → branch returns zero, must not produce NaN)
@@ -147,7 +163,8 @@ end
                       Float32[1.0, 1.0],
                       Bool[false, false])
     for v in (s.gof, s.max_matched_residual, s.max_unmatched_residual,
-              s.fitted_manhattan_distance, s.fitted_hellinger)
+              s.fitted_manhattan_distance, s.fitted_hellinger,
+              s.spectral_contrast)
         @test isfinite(v)
     end
 
@@ -174,6 +191,7 @@ end
         @test isfinite(s.max_unmatched_residual)
         @test isfinite(s.fitted_manhattan_distance)
         @test isfinite(s.fitted_hellinger)
+        @test isfinite(s.spectral_contrast)
     end
 end
 


### PR DESCRIPTION
## Summary
- Compute spectral_contrast in the existing spectral distance metric pass.
- Propagate the score into MainSearch PSM rows and LightGBM feature sets.
- Add focused unit coverage for finite values and expected cosine behavior.

## Validation
- julia --startup-file=no --project=. test/UnitTests/test_feature_finiteness.jl
- git diff --check