### PR TITLE
Combined: M1 best-PSM + lightweight MainSearch LGBM (config C) + main-thread Pass-1 predict

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/scoring.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/scoring.jl
@@ -34,6 +34,13 @@ const SHARED_LGBM_HP = (num_iterations=50, learning_rate=0.20, max_depth=8,
                         bagging_fraction=0.8, bagging_freq=1, is_unbalance=true,
                         max_bin=255, lambda_l1=1.0, lambda_l2=1.0)
 
+# Lightweight per-file MainSearch model (config C): smaller trees + coarser bins.
+# Applies ONLY to the MainSearch per-file best-scan/PEP-gate model
+# (train_lgbm_and_select_best) — NOT pass1_oom, the FTR model, or ScoringSearch,
+# which keep SHARED_LGBM_HP / SCORING_LGBM_HP. Matches the env-sweep "C" arm.
+const MAINSEARCH_LGBM_HP = merge(SHARED_LGBM_HP,
+    (max_depth = 4, num_leaves = 15, max_bin = 63))
+
 # Per-experiment scoring LGBM hyperparams (used by PrecursorScoringSearch).
 # Same shape as SHARED_LGBM_HP but lower learning rate × more iterations:
 # the slower lr lets boosting refine more decision boundaries on the
@@ -433,7 +440,7 @@ Returns:
 function train_lgbm_and_select_best(
     psms::DataFrame;
     features::Vector{Symbol} = collect(PRESCORE_FEATURES),
-    lgbm_hp = SHARED_LGBM_HP,
+    lgbm_hp = MAINSEARCH_LGBM_HP,
     center_mzs = nothing,
     isolation_widths = nothing,
 )

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/scoring.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/scoring.jl
@@ -1271,7 +1271,6 @@ function select_best_per_precursor!(
     end
 
     # Reusable buffers
-    p75_buf = Vector{Float32}(undef, 128)
     smooth_w_buf  = Vector{Float32}(undef, 128)  # weights sorted by rt
     smooth_rt_buf = Vector{Float32}(undef, 128)  # rt sorted ascending
     smooth_ord_buf = Vector{Int}(undef, 128)     # per-group sort permutation
@@ -1308,18 +1307,11 @@ function select_best_per_precursor!(
             end
         end
 
-        # --- Sub-pass 1b: p75 re-selection by weight ---
-        if weights !== nothing && group_len >= 4
-            if length(p75_buf) < group_len
-                resize!(p75_buf, group_len)
-            end
-            @inbounds for k in 0:(group_len - 1)
-                p75_buf[k + 1] = scores[perm[group_start + k]]
-            end
-            p75_idx = ceil(Int, 0.75 * group_len)
-            partialsort!(view(p75_buf, 1:group_len), p75_idx)
-            score_threshold = p75_buf[p75_idx]
-
+        # --- Sub-pass 1b (Method 1: score-margin 0.1): among scans scoring
+        # within 0.1 of the max score, pick the highest-weight one. Falls back
+        # to the max-score row (best_row) when only that row qualifies. ---
+        if weights !== nothing
+            score_threshold = best_s - 0.1f0
             best_w = typemin(Float32)
             @inbounds for k in 0:(group_len - 1)
                 row = perm[group_start + k]

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/pass1_oom.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/pass1_oom.jl
@@ -318,7 +318,9 @@ function _predict_pass1_to_sidecar(
         # competing for 10 physical cores (oversubscription). With
         # num_threads=1 each predict is single-threaded internally and
         # parallelism comes from the Julia-level file loop.
-        raw = LightGBM.predict(cls, X_fold; num_threads=1)
+        raw = lock(LGBM_C_LOCK) do
+            LightGBM.predict(cls, X_fold; num_threads=1)
+        end
         s = ndims(raw) == 2 ? dropdims(raw; dims = 2) : raw
         return clamp.(Float32.(s), 1f-6, 1f0 - 1f-4)
     end

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/pass1_oom.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/pass1_oom.jl
@@ -312,15 +312,11 @@ function _predict_pass1_to_sidecar(
         if cls isa NamedTuple && cls.kind == :constant
             return fill(clamp(Float32(cls.value), 1f-6, 1f0 - 1f-4), length(rows))
         end
-        # num_threads=1: this function runs inside a parallel_foreach! over
-        # files (one Julia task per file). Letting LightGBM's internal
-        # OpenMP fan out to all cores per call → 8 files × 10 OpenMP threads
-        # competing for 10 physical cores (oversubscription). With
-        # num_threads=1 each predict is single-threaded internally and
-        # parallelism comes from the Julia-level file loop.
-        raw = lock(LGBM_C_LOCK) do
-            LightGBM.predict(cls, X_fold; num_threads=1)
-        end
+        # Design A: Pass-3 runs SEQUENTIALLY on the main thread (see
+        # _predict_pass1_files below), so the predict can safely use all cores.
+        # libomp is only ever entered from the main thread (never a worker), so
+        # no lock and no crash/corruption. Multi-threaded predict per file.
+        raw = LightGBM.predict(cls, X_fold; num_threads=Threads.nthreads())
         s = ndims(raw) == 2 ? dropdims(raw; dims = 2) : raw
         return clamp.(Float32.(s), 1f-6, 1f0 - 1f-4)
     end
@@ -381,24 +377,26 @@ function _predict_pass1_files(
     collect_results = !direct_output && !write_sidecars
     result_type = NamedTuple{(:scores, :targets), Tuple{Vector{Float32}, Vector{Bool}}}
     results = collect_results ? Vector{result_type}(undef, length(file_paths)) : nothing
-    parallel_foreach!(length(file_paths)) do chunk
-        for f_idx in chunk
-            first_row = direct_output ? file_offsets[f_idx] + 1 : 1
-            last_row = direct_output ? file_offsets[f_idx + 1] : 0
-            score_slice = scores_out === nothing ? nothing : @view scores_out[first_row:last_row]
-            target_slice = targets_out === nothing ? nothing : @view targets_out[first_row:last_row]
-            result = _predict_pass1_to_sidecar(
-                file_paths[f_idx],
-                features,
-                cls_trained_on,
-                compute_infold,
-                write_sidecars;
-                scores_out = score_slice,
-                targets_out = target_slice,
-                return_predictions = collect_results,
-            )
-            collect_results && (results[f_idx] = result)
-        end
+    # Design A: sequential on the main thread. The dominant cost (the LightGBM
+    # predict) is recovered via multi-threaded predict per file (_predict_block),
+    # which is only safe because it runs on the main thread here. Matrix build +
+    # sidecar write lose across-file parallelism (acceptable if predict-bound).
+    for f_idx in 1:length(file_paths)
+        first_row = direct_output ? file_offsets[f_idx] + 1 : 1
+        last_row = direct_output ? file_offsets[f_idx + 1] : 0
+        score_slice = scores_out === nothing ? nothing : @view scores_out[first_row:last_row]
+        target_slice = targets_out === nothing ? nothing : @view targets_out[first_row:last_row]
+        result = _predict_pass1_to_sidecar(
+            file_paths[f_idx],
+            features,
+            cls_trained_on,
+            compute_infold,
+            write_sidecars;
+            scores_out = score_slice,
+            targets_out = target_slice,
+            return_predictions = collect_results,
+        )
+        collect_results && (results[f_idx] = result)
     end
     return results
 end

--- a/src/utils/ML/PSMScoring/lightgbm_utils.jl
+++ b/src/utils/ML/PSMScoring/lightgbm_utils.jl
@@ -9,6 +9,11 @@ end
 const LightGBMModelVector = Vector{LightGBMModel}
 const LightGBMModelWrapper = LightGBMModel
 
+# Serializes every entry into LightGBM's C API. LightGBM's bundled OpenMP
+# (libomp) aborts in __kmpc_end_serialized_parallel when predict is entered
+# concurrently from multiple Julia threads (pass1_oom.jl's parallel_foreach!).
+const LGBM_C_LOCK = ReentrantLock()
+
 """
     feature_matrix(df, features) -> Matrix{Float32}
 


### PR DESCRIPTION
Combines three independently-validated branches onto current `develop` so they can be regression-tested and merged together. Rebuilt fresh from `develop` (cherry-picked, not merged) so history is linear; only 3 files change vs develop (`scoring.jl`, `pass1_oom.jl`, `lightgbm_utils.jl`).

## Commits
- **`02f427899` fix: serialize concurrent LightGBM predict (OpenMP abort)** — `LGBM_C_LOCK` around predict; the shared base of all three source branches.
- **`12e016d8a` feat: best-PSM = highest weight within 0.1 score margin (M1)** — `select_best_per_precursor!` now picks, among scans within 0.1 LGBM-score of the max, the highest-*weight* (apex) scan → more reproducible RT landmark, lower cross-run iRT dispersion.
- **`082de1b2b` feat: lightweight MainSearch per-file LGBM (config C)** — `MAINSEARCH_LGBM_HP` (depth 4 / 15 leaves / 63 bins) for the per-file best-scan/PEP-gate model only (not pass1_oom, FTR, or ScoringSearch). ~25% faster per-file LGBM.
- **`ebe586fd2` perf: Pass-1 OOM predict on the main thread (Design A)** — runs the experiment-wide ScoringSearch Pass-1 predict multi-threaded on the main thread instead of single-threaded inside `parallel_foreach!` workers. Correct (no OpenMP corruption) **and** fast.

## Faithfulness check
The Pass-1 main-thread fix is byte-identical to `feat/pass1-predict-mainthread` in the predict region (`num_threads=Threads.nthreads()`, no lock, plain main-thread loop). The other two source branches carried only the correct lock version of the predict (no broken multi-thread variant), so nothing stale was merged in. The combined branch additionally picks up develop's newer semisupervised q-threshold code.

## Regression (full "all" run, vs develop)
- **IDs:** MTAC +10,130 precursors (+1.6%), Exploris +8,656 (+0.6%), APMS_Astral +298,665 (+4.5%).
- **Speed:** faster across most datasets — YEAST_KO_Astral −16%, APMS_Astral −16%, Exploris −4.9% (the main-thread predict payoff). One watch item: Seer_Astral_45 +9%.
- **Quant:** CV flat-to-better everywhere (MacCoss noNorm −0.0097 precursor / −0.0124 PG); no regression.
- **eFDR:** entrapment stable within ±0.4pp on every dataset — calibration unchanged.
- **Only substantive cost:** SCP_Astral_250pg_6ms −296 unique precursors (−4.1%) from config-C's lightweight LGBM on the hardest low-load data (its entrapment is unchanged — an ID/sensitivity tradeoff, not a calibration issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)