### PR TITLE
perf: combined allocation reduction (−60% alloc, −10% runtime on MTAC)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,36 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
+## 5. Julia Performance & Memory Discipline
+
+**Pioneer is performance- and allocation-critical (per-scan/per-precursor hot loops, threaded deconvolution). When editing Pioneer code, follow Julia's official guidance:**
+- Performance Tips: https://docs.julialang.org/en/v1/manual/performance-tips/
+- Memory Management: https://docs.julialang.org/en/v1/manual/memory-management/
+
+Apply these *especially in hot paths* (anything inside per-scan, per-precursor, or per-fragment loops). Outside hot paths, prefer clarity (§2) — don't micro-optimize where the profiler doesn't point.
+
+**Type stability**
+- Functions should return a single concrete type; avoid code where a variable's type changes. Verify hot functions with `@code_warntype` (no red `Any`/`Union`).
+- Use function barriers to isolate unavoidable instability (e.g. reading untyped data) from the hot kernel.
+
+**Concrete types**
+- No abstract field types in structs and no abstract element types in containers (`Vector{AbstractFoo}` dispatches dynamically and boxes). Use concrete or parametric types.
+- Module-level globals used in hot code must be `const` (or a `Ref`/typed constant).
+
+**Allocation (the usual win here)**
+- Don't allocate in hot loops. Pre-allocate buffers/workspaces once and reuse them (per-thread where threaded); prefer in-place `!` functions.
+- Use `@view`/`view(...)` instead of array slices (`a[1:n]` copies).
+- Small fixed-size collections (≤ ~16) → `NTuple` or `StaticArrays.MVector` (stack, alloc-free), not heap `Vector`. Mark the producing function `@inline` so non-escaping stack scratch elides.
+- Know stack vs heap: `isbits`/immutable values are stack-allocated and allocation-free; mutable/heap types allocate and add GC pressure.
+
+**Measure, don't guess**
+- Use `@time`/`@allocated`/`@btime`. Distinguish *cumulative* allocation (`@allocated`, `@timed.bytes` — process-global, sums across threads) from *peak working set* (RSS): a large cumulative number against a small RSS means avoidable churn, not a large footprint.
+- `@allocated` on a standalone call is pessimistic (forces a non-inlined boundary); measure the realistic call pattern (e.g. amortized over a loop) before concluding a function still allocates.
+- Profile first; optimize where the data points. State the before/after allocation or timing number when claiming a perf win.
+
+**Safety**
+- Only add `@inbounds`/`@simd` when bounds are provably safe, and verify results are bit-identical to the unoptimized version.
+
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/src/Routines/SearchDIA/LibrarySearch.jl
+++ b/src/Routines/SearchDIA/LibrarySearch.jl
@@ -184,7 +184,11 @@ function library_search(
     t_deconv = time() - t_deconv_start
 
     t_post_start = time()
-    result = vcat(all_results...)
+    # Single NCE model is the common case; `vcat(all_results...)` would copy the
+    # whole (large) PSM table for nothing. all_results[1] is already the
+    # materialized per-NCE table (from the inner vcat(fetched...)), so return it
+    # directly. Only concatenate when there are multiple NCE models.
+    result = length(all_results) == 1 ? all_results[1] : vcat(all_results...)
     t_vcat = time() - t_post_start
 
     if params isa MainSearchParameters

--- a/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
+++ b/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
@@ -144,7 +144,10 @@ struct MainSearchScoredPSM{H,L<:AbstractFloat} <: ScoredPSM{H,L}
     scan_idx::UInt32
 end
 function growScoredPSMs!(scored_psms::Vector{MainSearchScoredPSM{H,L}}, block_size::Int64) where {L,H<:AbstractFloat}
-    scored_psms = append!(scored_psms, Vector{MainSearchScoredPSM{H,L}}(undef, block_size))
+    # Grow in place (geometric buffer growth) without allocating a throwaway
+    # `Vector(undef, block_size)` temp each call. New elements are undef, same
+    # as the previous append! — they get overwritten by subsequent scores.
+    resize!(scored_psms, length(scored_psms) + block_size)
 end
 function Score!(scored_psms::Vector{MainSearchScoredPSM{H, L}},
                 unscored_PSMs::Vector{MainUnscoredPSM{H}},
@@ -289,7 +292,7 @@ struct TuningScoredPSM{H,L<:AbstractFloat} <: ScoredPSM{H,L}
 end
 
 function growScoredPSMs!(scored_psms::Vector{TuningScoredPSM{H,L}}, block_size::Int64) where {L,H<:AbstractFloat}
-    scored_psms = append!(scored_psms, Vector{TuningScoredPSM{H,L}}(undef, block_size))
+    resize!(scored_psms, length(scored_psms) + block_size)
 end
 
 function Score!(scored_psms::Vector{TuningScoredPSM{H, L}},

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/MainSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/MainSearch.jl
@@ -167,6 +167,32 @@ function permute_psms_by_precursor_idx!(psms::DataFrame)
 end
 
 """
+    _log_psm_table_footprint(psms, label, ms_file_idx)
+
+Diagnostic: report the in-memory footprint of the post-deconv PSMs table
+(rows x cols, per-column type + bytes, total). Gated behind the
+`PIONEER_DIAG_PSM_FOOTPRINT` env var so it costs nothing when off. Lets us
+compare the *irreducible* data size against the phase's cumulative allocation
+to gauge how much of Main Search's allocation is avoidable churn.
+"""
+function _log_psm_table_footprint(psms::DataFrame, label::AbstractString, ms_file_idx)
+    haskey(ENV, "PIONEER_DIAG_PSM_FOOTPRINT") || return nothing
+    n = nrow(psms)
+    total = 0
+    @user_print "[PSM FOOTPRINT] file=$ms_file_idx $label: $n rows x $(ncol(psms)) cols"
+    for nm in names(psms)
+        col = psms[!, nm]
+        et = eltype(col)
+        b = isbitstype(et) ? n * sizeof(et) : Base.summarysize(col)
+        total += b
+        @user_print "    $(rpad(nm, 34)) $(rpad(string(et), 26)) $(round(b / 1e6, digits=2)) MB"
+    end
+    @user_print "[PSM FOOTPRINT] file=$ms_file_idx total table = $(round(total / 1e9, digits=3)) GB " *
+                "($(round(total / max(n,1)))  bytes/row)"
+    return nothing
+end
+
+"""
 Process a single file: load fragment index matches and deconvolve with prescore settings.
 """
 function process_file!(
@@ -217,6 +243,8 @@ function process_file!(
     t_sort = @elapsed permute_psms_by_precursor_idx!(psms)
 
     results.psms[] = psms
+
+    _log_psm_table_footprint(psms, "post-deconv (before best-per-precursor)", ms_file_idx)
 
     @debug_l1 "  MainSearch process_file! (file_idx=$ms_file_idx, $file_name): " *
                "$(nrow(psms)) PSMs from deconv; library_search elapsed: $(round(t_lib_search, digits=2))s  " *
@@ -285,6 +313,7 @@ function process_search_results!(
 
     # Train LightGBM on ALL PSMs, select best scan per precursor
     n_total_psms = nrow(psms)
+    _log_psm_table_footprint(psms, "full pre-reduction (after all feature passes)", ms_file_idx)
     Pioneer.DIAG_DUMP_FILE_IDX[] = 0
     t_lgbm_start = time()
     best_psms, scores, lgbm_timings, lgbm_predictor =

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/MainSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/MainSearch.jl
@@ -167,6 +167,26 @@ function permute_psms_by_precursor_idx!(psms::DataFrame)
 end
 
 """
+    @alloc_bucket(label, expr)
+
+Evaluate `expr`; when `PIONEER_DIAG_ALLOC` is set, print the heap bytes it
+allocated (process-global counter delta — sums across all threads, so it is
+valid for the multithreaded deconv). Beyond two `gc_bytes()` reads it adds no
+overhead when the env var is unset.
+"""
+macro alloc_bucket(label, ex)
+    quote
+        local _b0 = Base.gc_bytes()
+        local _r = $(esc(ex))
+        if haskey(ENV, "PIONEER_DIAG_ALLOC")
+            @user_print string("[ALLOC] ", $(esc(label)), ": ",
+                               round((Base.gc_bytes() - _b0) / 1e9, digits=3), " GB")
+        end
+        _r
+    end
+end
+
+"""
     _log_psm_table_footprint(psms, label, ms_file_idx)
 
 Diagnostic: report the in-memory footprint of the post-deconv PSMs table
@@ -206,7 +226,7 @@ function process_file!(
     t_file_start = time()
     file_name = getParsedFileName(search_context, ms_file_idx)
 
-    psms = library_search(spectra, search_context, params, ms_file_idx)
+    psms = @alloc_bucket "library_search (deconv)" library_search(spectra, search_context, params, ms_file_idx)
     t_lib_search = time() - t_file_start
 
     # IMPORTANT: the next two steps depend on the deconv output being
@@ -222,7 +242,7 @@ function process_file!(
     # contiguous-by-scan invariant: linear sweep for run boundaries
     # + threaded per-run rank/ratio. ~4× faster than the previous
     # Dict-based version (measured 2026-05-19).
-    t_scan_comp = @elapsed add_scan_competition_features!(psms)
+    t_scan_comp = @elapsed @alloc_bucket "scan_competition_features" add_scan_competition_features!(psms)
 
     # MS1 lookup features (ms1_m0_intensity, ms1_m1_intensity,
     # ms1_m0_mass_err_ppm, ms1_m1_to_m0_ratio, ms1_m1_to_m0_pred). Done
@@ -232,7 +252,7 @@ function process_file!(
     # precursor-sorted input. The per-precursor chromatogram-feature passes
     # (ms1_corr_*, frag_*) run later in process_search_results! after the
     # precursor sort, since they group by :precursor_idx.
-    t_ms1 = @elapsed add_ms1_lookup_features!(psms, spectra, search_context, ms_file_idx)
+    t_ms1 = @elapsed @alloc_bucket "ms1_lookup_features" add_ms1_lookup_features!(psms, spectra, search_context, ms_file_idx)
 
     # Sort the deconv-output DataFrame by :precursor_idx once. Downstream
     # passes (chrom features, best-per-precursor) can then fast-path their
@@ -240,7 +260,7 @@ function process_file!(
     # for any per-precursor parallelism. We use a hand-rolled in-place
     # column permute rather than `sort!(df, :col)` because DataFrames.sort!
     # is ~4× slower on this shape (measured 2026-05-19).
-    t_sort = @elapsed permute_psms_by_precursor_idx!(psms)
+    t_sort = @elapsed @alloc_bucket "permute_by_precursor" permute_psms_by_precursor_idx!(psms)
 
     results.psms[] = psms
 
@@ -273,7 +293,7 @@ function process_search_results!(
     isolation_widths = getIsolationWidthMzs(spectra)
 
     # Compute prescore features
-    t_prepare = @elapsed prepare_psm_features!(psms, params, search_context, ms_file_idx, spectra)
+    t_prepare = @elapsed @alloc_bucket "prepare_psm_features" prepare_psm_features!(psms, params, search_context, ms_file_idx, spectra)
     t_features = time()
 
     if nrow(psms) == 0
@@ -305,7 +325,7 @@ function process_search_results!(
     # sort) so the per-chunk MS1 cache exploits contiguous-by-scan input.
     # Only the precursor/window chromatogram features still run here.
     bitvec_rank_table = getBitVecExcessRanks(search_context, Int64(ms_file_idx))
-    t_ms1 = @elapsed add_chromatogram_features!(
+    t_ms1 = @elapsed @alloc_bucket "chromatogram_features" add_chromatogram_features!(
         psms,
         spectra;
         bitvec_rank_table = bitvec_rank_table,
@@ -317,7 +337,7 @@ function process_search_results!(
     Pioneer.DIAG_DUMP_FILE_IDX[] = 0
     t_lgbm_start = time()
     best_psms, scores, lgbm_timings, lgbm_predictor =
-        train_lgbm_and_select_best(
+        @alloc_bucket "train_lgbm_and_select_best" train_lgbm_and_select_best(
             psms;
             center_mzs = center_mzs,
             isolation_widths = isolation_widths,

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
@@ -1322,10 +1322,25 @@ function _add_fragment_chromatogram_features!(psms::DataFrame;
     n_prec = length(starts)
     rank_weights = _fragment_rank_weights(8)
 
+    # Per-thread reusable scratch (resized per precursor) so the per-precursor
+    # chromatogram extraction below does not allocate ~10 small vectors on every
+    # iteration. Safe under :static scheduling: threadid() is stable within an
+    # iteration and no two concurrent iterations share a thread. Size by
+    # maxthreadid() (not nthreads()) because threadid() can exceed the default
+    # pool size when an interactive threadpool is present.
+    nthr = Threads.maxthreadid()
+    F_scratch    = [[Float32[] for _ in 1:8] for _ in 1:nthr]
+    W_scratch    = [Float32[] for _ in 1:nthr]
+    IRT_scratch  = [Float32[] for _ in 1:nthr]
+    cfw_scratch  = [Vector{Float32}(undef, 8) for _ in 1:nthr]
+    vm0_scratch  = [Float32[] for _ in 1:nthr]
+    apex_scratch = [Float32[] for _ in 1:nthr]
+
     # Parallel per-precursor walk. Each precursor writes to disjoint row indices
     # in the output columns; all input arrays are read-only.
     Threads.@threads :static for p in 1:n_prec
         @inbounds begin
+            tid = Threads.threadid()
             i_start = Int(starts[p])
             i_end   = Int(ends[p])
             npts    = i_end - i_start + 1
@@ -1339,17 +1354,19 @@ function _add_fragment_chromatogram_features!(psms::DataFrame;
             end
             npts < 2 && continue
 
-            # Extract chromatograms for the 8 fragments + weight + iRT
-            F = Vector{Vector{Float32}}(undef, 8)
+            # Extract chromatograms for the 8 fragments + weight + iRT into
+            # per-thread scratch (resized to this precursor's npts, fully
+            # overwritten below — no stale data is read).
+            F = F_scratch[tid]
             for r in 1:8
-                v = Vector{Float32}(undef, npts)
+                v = F[r]
+                resize!(v, npts)
                 for k in 1:npts
                     v[k] = Float32(f[r][perm[i_start + k - 1]])
                 end
-                F[r] = v
             end
-            W   = Vector{Float32}(undef, npts)
-            IRT = Vector{Float32}(undef, npts)
+            W   = W_scratch[tid];   resize!(W, npts)
+            IRT = IRT_scratch[tid]; resize!(IRT, npts)
             for k in 1:npts
                 i_orig = perm[i_start + k - 1]
                 W[k]   = Float32(weight[i_orig])
@@ -1359,7 +1376,7 @@ function _add_fragment_chromatogram_features!(psms::DataFrame;
             has_signal = ntuple(r -> maximum(F[r]) > 0, 8)
 
             # Apex dispersion across fragments with signal (also feeds delta_frame).
-            apex_irts = Float32[]
+            apex_irts = apex_scratch[tid]; empty!(apex_irts)
             for r in 1:8
                 has_signal[r] || continue
                 ai = 1; vmax = F[r][1]
@@ -1389,7 +1406,7 @@ function _add_fragment_chromatogram_features!(psms::DataFrame;
             # 2026-05-15: replaced n_correlated_fragments_90 (>0.9) — 0.7 threshold
             # was ~11× more informative in ScoringSearch Pass-1 LGBM gain on
             # 23-file Olsen.
-            c_fw = Vector{Float32}(undef, 8)
+            c_fw = cfw_scratch[tid]   # length 8, fully overwritten below
             for r in 1:8
                 c_fw[r] = has_signal[r] ? _frag_pcor(F[r], W) : 0f0
             end
@@ -1425,7 +1442,7 @@ function _add_fragment_chromatogram_features!(psms::DataFrame;
             end
             c_best_m0 = 0f0
             if best_r > 0 && has_m0
-                v_m0 = Vector{Float32}(undef, npts)
+                v_m0 = vm0_scratch[tid]; resize!(v_m0, npts)
                 for k in 1:npts
                     v_m0[k] = Float32(m0_int[perm[i_start + k - 1]])
                 end

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
@@ -987,6 +987,16 @@ function _add_ms1_chromatogram_features!(psms::DataFrame;
         groups
     n_prec = length(starts)
 
+    # Per-thread scratch reused across precursors (matches the fragment path):
+    # avoids 4 fresh Vector allocations per precursor (millions of small allocs).
+    # maxthreadid() (not nthreads()) because threadid() can exceed the default
+    # pool size; safe under :static where threadid() is stable within the body.
+    nthr = Threads.maxthreadid()
+    vm0_scratch  = [Float32[] for _ in 1:nthr]
+    vm1_scratch  = [Float32[] for _ in 1:nthr]
+    vw_scratch   = [Float32[] for _ in 1:nthr]
+    virt_scratch = [Float32[] for _ in 1:nthr]
+
     Threads.@threads :static for p in 1:n_prec
         @inbounds begin
             i_start = Int(starts[p])
@@ -994,11 +1004,13 @@ function _add_ms1_chromatogram_features!(psms::DataFrame;
             npts    = i_end - i_start + 1
             npts < 2 && continue
 
-            # Extract per-precursor chromatograms (m0, m1, weight, iRT)
-            v_m0  = Vector{Float32}(undef, npts)
-            v_m1  = Vector{Float32}(undef, npts)
-            v_w   = Vector{Float32}(undef, npts)
-            v_irt = Vector{Float32}(undef, npts)
+            # Extract per-precursor chromatograms (m0, m1, weight, iRT) into
+            # reused per-thread scratch.
+            tid = Threads.threadid()
+            v_m0  = vm0_scratch[tid];  resize!(v_m0, npts)
+            v_m1  = vm1_scratch[tid];  resize!(v_m1, npts)
+            v_w   = vw_scratch[tid];   resize!(v_w, npts)
+            v_irt = virt_scratch[tid]; resize!(v_irt, npts)
             for k in 1:npts
                 i_orig = perm[i_start + k - 1]
                 v_m0[k]  = m0[i_orig]

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/irt_refinement.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/irt_refinement.jl
@@ -45,8 +45,12 @@ function _precursor_token_counts(
     sequence::AbstractString,
     structural_mods::Union{Missing, AbstractString},
 )
+    # NOTE: deliberately no sizehint! here. Downstream (`fit_irt_refinement_model`)
+    # assigns design-matrix columns by `keys(counts)` iteration order, so the dict's
+    # hash-slot layout is load-bearing — sizehint! changes the capacity and thus the
+    # iteration order, which permutes X's columns and perturbs the least-squares fit
+    # (verified: ~0.8% PSM-count shift on YeastStandard3M). Keep default growth.
     counts = Dict{String, Float32}()
-    sizehint!(counts, length(sequence) + 4)
     # Allocated lazily: only sequences with residue-localized modifications need it.
     position_mods = nothing
 

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/irt_refinement.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/irt_refinement.jl
@@ -10,7 +10,7 @@ struct MainSearchIrtCorrectionModel
     intercept::Float32
     irt_pred_coefficient::Float32
     irt_pred_squared_coefficient::Float32
-    coefficients::Dict{String, Float32}
+    coefficients::Vector{Float32}   # indexed by token id (1..N_IRT_TOKENS); 0 if absent from the fit
 end
 
 struct MainSearchIrtRefinement{P<:LibraryPrecursors, S, M}
@@ -40,86 +40,131 @@ end
     return x, x * x
 end
 
-# Cached single-character residue tokens. `sequence` carries plain amino acids
-# (modifications live in `structural_mods`), so each residue token is one ASCII
-# byte from a tiny alphabet. Caching avoids a fresh `string(aa)` heap allocation
-# for every residue of every precursor (previously the single hottest alloc site).
-const _AA_TOKEN    = String[string(Char(c)) for c in 0:127]
-const _NTERM_TOKEN = String["NTERM|" * string(Char(c)) for c in 0:127]
-const _CTERM_TOKEN = String["CTERM|" * string(Char(c)) for c in 0:127]
-@inline _aa_token(aa::Char) = (b = UInt32(aa); b < 0x80 ? @inbounds(_AA_TOKEN[b + 1]) : string(aa))
+# ============================================================================
+# Hardcoded peptide-composition token table for iRT refinement.
+#
+# `sequence` holds the 20 canonical amino acids; the only modifications the
+# library admits are carbamidomethyl on C (Unimod:4) and oxidation on M
+# (Unimod:35). The entire token universe is therefore a fixed set of 66 ids, so
+# token counting is pure integer arithmetic — no per-precursor Dict, no token
+# strings (previously the single largest allocation cluster in SearchDIA). The
+# id scheme was verified to reproduce the previous string-keyed counts for every
+# precursor in the benchmark library.
+#
+# Layout (k = residue-token index, 1..22):
+#   1..20  plain residue, alphabetical: A C D E F G H I K L M N P Q R S T V W Y
+#   21     C|Unimod:4          22     M|Unimod:35
+#   NTERM token id = 22 + k         CTERM token id = 44 + k
+#
+# Column order in the design matrix is the ascending id of tokens present in a
+# fold — fixed by this table, not by Dict hash order, so the fit is
+# deterministic (no hash-layout sensitivity). If the library ever admits new
+# residues/mods, extend _IRT_AA_K / _residue_token_k and N_IRT_TOKENS;
+# unrecognized tokens are dropped (and warned once) rather than misbinned.
+# ============================================================================
+const _IRT_AA_LETTERS = collect("ACDEFGHIKLMNPQRSTVWY")
+const _IRT_AA_K = let v = zeros(Int, 128)
+    for (i, c) in enumerate(_IRT_AA_LETTERS)
+        v[Int(c) + 1] = i
+    end
+    v
+end
+const _IRT_K_MODC = 21          # C|Unimod:4
+const _IRT_K_MODM = 22          # M|Unimod:35
+const N_IRT_TOKENS = 66         # 22 residue tokens + 22 NTERM + 22 CTERM
+const _IRT_MOD_REGEX = r"\((\d+),([A-Z]|[nc]),([^,\)]+)\)"
 
-function _precursor_token_counts(
+# Reusable per-thread scratch: token counts indexed by id, plus the list of
+# touched ids so reset/iteration is O(peptide length), not O(N_IRT_TOKENS).
+struct IrtCountScratch
+    counts::Vector{Float32}
+    touched::Vector{Int}
+end
+IrtCountScratch() = IrtCountScratch(zeros(Float32, N_IRT_TOKENS), Int[])
+
+@inline function _reset!(s::IrtCountScratch)
+    @inbounds for id in s.touched
+        s.counts[id] = 0.0f0
+    end
+    empty!(s.touched)
+    return s
+end
+
+@inline function _add!(s::IrtCountScratch, id::Int)
+    (id < 1 || id > N_IRT_TOKENS) && return
+    @inbounds begin
+        s.counts[id] == 0.0f0 && push!(s.touched, id)
+        s.counts[id] += 1.0f0
+    end
+    return
+end
+
+# Residue-token index k (1..22), or 0 if the residue/modification is unrecognized.
+@inline function _residue_token_k(aa::Char, mods_here)
+    if mods_here === nothing || isempty(mods_here)
+        b = UInt32(aa)
+        return b <= 0x7f ? @inbounds(_IRT_AA_K[b + 1]) : 0
+    elseif length(mods_here) == 1
+        mn = mods_here[1]
+        aa == 'C' && mn == "Unimod:4"  && return _IRT_K_MODC
+        aa == 'M' && mn == "Unimod:35" && return _IRT_K_MODM
+    end
+    return 0
+end
+
+# Fill `scratch` with token-id counts for one peptide; returns `scratch`.
+function count_token_ids!(
+    scratch::IrtCountScratch,
     sequence::AbstractString,
     structural_mods::Union{Missing, AbstractString},
 )
-    # NOTE: deliberately no sizehint! here. Downstream (`fit_irt_refinement_model`)
-    # assigns design-matrix columns by `keys(counts)` iteration order, so the dict's
-    # hash-slot layout is load-bearing — sizehint! changes the capacity and thus the
-    # iteration order, which permutes X's columns and perturbs the least-squares fit
-    # (verified: ~0.8% PSM-count shift on YeastStandard3M). Keep default growth.
-    counts = Dict{String, Float32}()
+    _reset!(scratch)
+
     # Allocated lazily: only sequences with residue-localized modifications need it.
     position_mods = nothing
-
     if !ismissing(structural_mods) && !isempty(structural_mods)
-        mod_regex = r"\((\d+),([A-Z]|[nc]),([^,\)]+)\)"
-        for m in eachmatch(mod_regex, structural_mods)
+        for m in eachmatch(_IRT_MOD_REGEX, structural_mods)
             position = parse(Int, m.captures[1])
             site = only(m.captures[2])
             mod_name = m.captures[3]
-
             if site == 'n' || site == 'c'
-                token = string(site, "|", mod_name)
-                counts[token] = get(counts, token, 0.0f0) + 1.0f0
+                @warn "iRT refinement: unhandled terminal modification token $(site)|$(mod_name) (ignored)" maxlog = 1
             elseif 1 <= position <= length(sequence)
                 position_mods === nothing && (position_mods = Dict{Int, Vector{String}}())
-                push!(get!(position_mods, position, String[]), mod_name)
+                push!(get!(position_mods, position, String[]), String(mod_name))
             end
         end
     end
 
-    # Only the first and last residue tokens are needed (for the NTERM/CTERM
-    # tokens), so we track them directly instead of materializing a vector of
-    # every residue token.
-    first_token = ""
-    last_token = ""
+    first_k = 0
+    last_k = 0
     have_any = false
     for (position, aa) in enumerate(sequence)
         mods_here = position_mods === nothing ? nothing : get(position_mods, position, nothing)
-        token = if isnothing(mods_here) || isempty(mods_here)
-            _aa_token(aa)
-        else
-            string(aa, "|", join(sort(mods_here), "&"))
+        k = _residue_token_k(aa, mods_here)
+        if k == 0
+            @warn "iRT refinement: unhandled residue token for '$(aa)' (ignored)" maxlog = 1
+            continue
         end
-        have_any || (first_token = token; have_any = true)
-        last_token = token
-        counts[token] = get(counts, token, 0.0f0) + 1.0f0
+        _add!(scratch, k)
+        have_any || (first_k = k; have_any = true)
+        last_k = k
     end
-
     if have_any
-        nterm = ncodeunits(first_token) == 1 ?
-            @inbounds(_NTERM_TOKEN[codeunit(first_token, 1) + 1]) : "NTERM|" * first_token
-        cterm = ncodeunits(last_token) == 1 ?
-            @inbounds(_CTERM_TOKEN[codeunit(last_token, 1) + 1]) : "CTERM|" * last_token
-        counts[nterm] = get(counts, nterm, 0.0f0) + 1.0f0
-        counts[cterm] = get(counts, cterm, 0.0f0) + 1.0f0
+        _add!(scratch, 22 + first_k)   # NTERM|<first residue token>
+        _add!(scratch, 44 + last_k)    # CTERM|<last residue token>
     end
-
-    return counts
+    return scratch
 end
 
-function precursor_token_counts(
+# Fill `scratch` for a library precursor (columns cached on the strategy).
+@inline function count_token_ids!(
+    scratch::IrtCountScratch,
     strategy::MainSearchIrtRefinement,
     precursor_idx::Integer,
 )
     pid = UInt32(precursor_idx)
-    # Index the columns cached on the strategy (fetched once at construction)
-    # rather than re-fetching getSequence/getStructuralMods per precursor. The
-    # element is already an AbstractString, so no String() copy is needed.
-    sequence = strategy.sequences[pid]
-    structural_mods = strategy.structural_mods[pid]
-    return _precursor_token_counts(sequence, structural_mods)
+    return count_token_ids!(scratch, strategy.sequences[pid], strategy.structural_mods[pid])
 end
 
 function _unique_sorted_precursor_ids(precursor_idx::AbstractVector)
@@ -176,33 +221,40 @@ function fit_irt_refinement_model(
         return nothing
     end
 
-    token_to_col = Dict{String, Int}()
-    precursor_counts = Vector{Dict{String, Float32}}(undef, n)
+    scratch = IrtCountScratch()
 
-    for i in eachindex(precursor_ids)
-        counts = precursor_token_counts(strategy, precursor_ids[i])
-        precursor_counts[i] = counts
-        for token in keys(counts)
-            if !haskey(token_to_col, token)
-                token_to_col[token] = length(token_to_col) + 1
-            end
+    # Pass 1: which token ids occur in this fold. Column order is the ascending
+    # id (capacity-independent, deterministic) of the tokens that actually
+    # appear, so X has no all-zero columns and the solve stays well-posed.
+    present = falses(N_IRT_TOKENS)
+    for pid in precursor_ids
+        count_token_ids!(scratch, strategy, pid)
+        for id in scratch.touched
+            present[id] = true
         end
     end
-    isempty(token_to_col) && return nothing
+    present_ids = findall(present)
+    isempty(present_ids) && return nothing
+    col_of = zeros(Int, N_IRT_TOKENS)
+    for (j, id) in enumerate(present_ids)
+        col_of[id] = j
+    end
 
+    # Pass 2: build the design matrix (counting is allocation-free, so recomputing
+    # per precursor is cheap relative to the least-squares solve).
     use_quadratic_basis = n >= 3
     irt_basis_cols = use_quadratic_basis ? 2 : 1
-    X = zeros(Float64, n, length(token_to_col) + 1 + irt_basis_cols)
+    X = zeros(Float64, n, length(present_ids) + 1 + irt_basis_cols)
     X[:, 1] .= 1.0
-
-    for i in eachindex(precursor_counts)
+    for i in eachindex(precursor_ids)
         linear_term, quadratic_term = _irt_pred_basis(irt_pred_inputs[i])
         X[i, 2] = linear_term
         if use_quadratic_basis
             X[i, 3] = quadratic_term
         end
-        for (token, count) in precursor_counts[i]
-            X[i, token_to_col[token] + 1 + irt_basis_cols] = Float64(count)
+        count_token_ids!(scratch, strategy, precursor_ids[i])
+        for id in scratch.touched
+            X[i, col_of[id] + 1 + irt_basis_cols] = Float64(scratch.counts[id])
         end
     end
 
@@ -213,9 +265,10 @@ function fit_irt_refinement_model(
         return nothing
     end
 
-    coefficients = Dict{String, Float32}()
-    for (token, col_idx) in token_to_col
-        coefficients[token] = Float32(beta[col_idx + 1 + irt_basis_cols])
+    # Dense coefficient vector indexed by token id; 0 for ids absent from this fold.
+    coefficients = zeros(Float32, N_IRT_TOKENS)
+    for (j, id) in enumerate(present_ids)
+        coefficients[id] = Float32(beta[j + 1 + irt_basis_cols])
     end
 
     return MainSearchIrtCorrectionModel(
@@ -228,30 +281,29 @@ end
 
 function predict_irt_refinement(
     model::MainSearchIrtCorrectionModel,
-    counts::Dict{String, Float32},
+    scratch::IrtCountScratch,
     current_irt_pred::Float32,
 )
     linear_term, quadratic_term = _irt_pred_basis(current_irt_pred)
     prediction = model.intercept +
                  model.irt_pred_coefficient * Float32(linear_term) +
                  model.irt_pred_squared_coefficient * Float32(quadratic_term)
-    for (token, count) in counts
-        prediction += get(model.coefficients, token, 0.0f0) * count
+    coef = model.coefficients
+    @inbounds for id in scratch.touched
+        prediction += coef[id] * scratch.counts[id]
     end
     return prediction
 end
 
 function predict_irt_refinement(
+    scratch::IrtCountScratch,
     strategy::MainSearchIrtRefinement,
     model::MainSearchIrtCorrectionModel,
     precursor_idx::Integer,
     current_irt_pred::Float32,
 )
-    return predict_irt_refinement(
-        model,
-        precursor_token_counts(strategy, precursor_idx),
-        current_irt_pred,
-    )
+    count_token_ids!(scratch, strategy, precursor_idx)
+    return predict_irt_refinement(model, scratch, current_irt_pred)
 end
 
 function _refresh_predicted_irt_dependent_features!(psms::DataFrame)
@@ -283,10 +335,12 @@ function apply_mainsearch_irt_refinement_model!(
     n = nrow(psms)
     nt = Threads.nthreads()
     chunk = max(1, cld(n, nt))
+    scratches = [IrtCountScratch() for _ in 1:nt]   # one reusable buffer per task
     @sync for t in 1:nt
         c_start = (t - 1) * chunk + 1
         c_start > n && break
         c_end = min(t * chunk, n)
+        scratch = scratches[t]
         Threads.@spawn begin
             last_pid = UInt32(0)
             last_corr = 0f0
@@ -294,7 +348,7 @@ function apply_mainsearch_irt_refinement_model!(
             @inbounds for row_idx in c_start:c_end
                 pid = UInt32(prec_idx[row_idx])
                 if pid != last_pid || !have_corr
-                    corr = predict_irt_refinement(strategy, model, pid, current_pred[row_idx])
+                    corr = predict_irt_refinement(scratch, strategy, model, pid, current_pred[row_idx])
                     last_corr = isfinite(corr) ? Float32(corr) : 0f0
                     last_pid = pid
                     have_corr = true
@@ -329,11 +383,13 @@ function apply_mainsearch_irt_refinement_model!(
     n = nrow(psms)
     nt = Threads.nthreads()
     chunk = max(1, cld(n, nt))
+    scratches = [IrtCountScratch() for _ in 1:nt]   # one reusable buffer per task
     t_loop = time()
     @sync for t in 1:nt
         c_start = (t - 1) * chunk + 1
         c_start > n && break
         c_end = min(t * chunk, n)
+        scratch = scratches[t]
         Threads.@spawn begin
             last_pid = UInt32(0)
             last_corr = 0f0
@@ -345,7 +401,7 @@ function apply_mainsearch_irt_refinement_model!(
                     if isnothing(model)
                         last_corr = 0f0
                     else
-                        corr = predict_irt_refinement(strategy, model, pid, current_pred[row_idx])
+                        corr = predict_irt_refinement(scratch, strategy, model, pid, current_pred[row_idx])
                         last_corr = isfinite(corr) ? Float32(corr) : 0f0
                     end
                     last_pid = pid

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/irt_refinement.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/irt_refinement.jl
@@ -32,13 +32,23 @@ end
     return x, x * x
 end
 
+# Cached single-character residue tokens. `sequence` carries plain amino acids
+# (modifications live in `structural_mods`), so each residue token is one ASCII
+# byte from a tiny alphabet. Caching avoids a fresh `string(aa)` heap allocation
+# for every residue of every precursor (previously the single hottest alloc site).
+const _AA_TOKEN    = String[string(Char(c)) for c in 0:127]
+const _NTERM_TOKEN = String["NTERM|" * string(Char(c)) for c in 0:127]
+const _CTERM_TOKEN = String["CTERM|" * string(Char(c)) for c in 0:127]
+@inline _aa_token(aa::Char) = (b = UInt32(aa); b < 0x80 ? @inbounds(_AA_TOKEN[b + 1]) : string(aa))
+
 function _precursor_token_counts(
     sequence::AbstractString,
     structural_mods::Union{Missing, AbstractString},
 )
     counts = Dict{String, Float32}()
-    position_mods = Dict{Int, Vector{String}}()
-    residue_tokens = String[]
+    sizehint!(counts, length(sequence) + 4)
+    # Allocated lazily: only sequences with residue-localized modifications need it.
+    position_mods = nothing
 
     if !ismissing(structural_mods) && !isempty(structural_mods)
         mod_regex = r"\((\d+),([A-Z]|[nc]),([^,\)]+)\)"
@@ -51,25 +61,37 @@ function _precursor_token_counts(
                 token = string(site, "|", mod_name)
                 counts[token] = get(counts, token, 0.0f0) + 1.0f0
             elseif 1 <= position <= length(sequence)
+                position_mods === nothing && (position_mods = Dict{Int, Vector{String}}())
                 push!(get!(position_mods, position, String[]), mod_name)
             end
         end
     end
 
+    # Only the first and last residue tokens are needed (for the NTERM/CTERM
+    # tokens), so we track them directly instead of materializing a vector of
+    # every residue token.
+    first_token = ""
+    last_token = ""
+    have_any = false
     for (position, aa) in enumerate(sequence)
-        mods_here = get(position_mods, position, nothing)
+        mods_here = position_mods === nothing ? nothing : get(position_mods, position, nothing)
         token = if isnothing(mods_here) || isempty(mods_here)
-            string(aa)
+            _aa_token(aa)
         else
             string(aa, "|", join(sort(mods_here), "&"))
         end
-        push!(residue_tokens, token)
+        have_any || (first_token = token; have_any = true)
+        last_token = token
         counts[token] = get(counts, token, 0.0f0) + 1.0f0
     end
 
-    if !isempty(residue_tokens)
-        counts["NTERM|" * first(residue_tokens)] = get(counts, "NTERM|" * first(residue_tokens), 0.0f0) + 1.0f0
-        counts["CTERM|" * last(residue_tokens)] = get(counts, "CTERM|" * last(residue_tokens), 0.0f0) + 1.0f0
+    if have_any
+        nterm = ncodeunits(first_token) == 1 ?
+            @inbounds(_NTERM_TOKEN[codeunit(first_token, 1) + 1]) : "NTERM|" * first_token
+        cterm = ncodeunits(last_token) == 1 ?
+            @inbounds(_CTERM_TOKEN[codeunit(last_token, 1) + 1]) : "CTERM|" * last_token
+        counts[nterm] = get(counts, nterm, 0.0f0) + 1.0f0
+        counts[cterm] = get(counts, cterm, 0.0f0) + 1.0f0
     end
 
     return counts

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/irt_refinement.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/irt_refinement.jl
@@ -13,8 +13,10 @@ struct MainSearchIrtCorrectionModel
     coefficients::Dict{String, Float32}
 end
 
-struct MainSearchIrtRefinement{P<:LibraryPrecursors}
+struct MainSearchIrtRefinement{P<:LibraryPrecursors, S, M}
     precursors::P
+    sequences::S          # getSequence(precursors), fetched once (vs per-precursor)
+    structural_mods::M    # getStructuralMods(precursors), fetched once
     q_value_threshold::Float32
     min_precursors::Int
 end
@@ -24,7 +26,13 @@ function MainSearchIrtRefinement(
     q_value_threshold::Float32 = PRESCORE_QVALUE_THRESHOLD,
     min_precursors::Int = 250,
 )
-    return MainSearchIrtRefinement(precursors, q_value_threshold, min_precursors)
+    return MainSearchIrtRefinement(
+        precursors,
+        getSequence(precursors),
+        getStructuralMods(precursors),
+        q_value_threshold,
+        min_precursors,
+    )
 end
 
 @inline function _irt_pred_basis(current_irt_pred::Float32)
@@ -106,8 +114,11 @@ function precursor_token_counts(
     precursor_idx::Integer,
 )
     pid = UInt32(precursor_idx)
-    sequence = String(getSequence(strategy.precursors)[pid])
-    structural_mods = getStructuralMods(strategy.precursors)[pid]
+    # Index the columns cached on the strategy (fetched once at construction)
+    # rather than re-fetching getSequence/getStructuralMods per precursor. The
+    # element is already an AbstractString, so no String() copy is needed.
+    sequence = strategy.sequences[pid]
+    structural_mods = strategy.structural_mods[pid]
     return _precursor_token_counts(sequence, structural_mods)
 end
 

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/irt_refinement.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/irt_refinement.jl
@@ -72,15 +72,16 @@ end
 const _IRT_K_MODC = 21          # C|Unimod:4
 const _IRT_K_MODM = 22          # M|Unimod:35
 const N_IRT_TOKENS = 66         # 22 residue tokens + 22 NTERM + 22 CTERM
-const _IRT_MOD_REGEX = r"\((\d+),([A-Z]|[nc]),([^,\)]+)\)"
 
-# Reusable per-thread scratch: token counts indexed by id, plus the list of
-# touched ids so reset/iteration is O(peptide length), not O(N_IRT_TOKENS).
+# Reusable per-thread scratch: token counts indexed by id, the list of touched
+# ids (so reset/iteration is O(peptide length), not O(N_IRT_TOKENS)), and a
+# residue-position -> mod-code buffer filled by the structural_mods parser.
 struct IrtCountScratch
     counts::Vector{Float32}
     touched::Vector{Int}
+    mod_at_pos::Vector{Int8}    # 0 none, 1 Unimod:4, 2 Unimod:35, -1 unrecognized
 end
-IrtCountScratch() = IrtCountScratch(zeros(Float32, N_IRT_TOKENS), Int[])
+IrtCountScratch() = IrtCountScratch(zeros(Float32, N_IRT_TOKENS), Int[], Int8[])
 
 @inline function _reset!(s::IrtCountScratch)
     @inbounds for id in s.touched
@@ -99,15 +100,76 @@ end
     return
 end
 
+# Compare the codeunit range str[lo:hi] against a literal, allocation-free.
+@inline function _name_is(str, lo::Int, hi::Int, lit::String)
+    ncodeunits(lit) == (hi - lo + 1) || return false
+    @inbounds for k in 1:ncodeunits(lit)
+        codeunit(str, lo + k - 1) != codeunit(lit, k) && return false
+    end
+    return true
+end
+
+# Mod-name codeunit range -> code (1 Unimod:4, 2 Unimod:35, -1 otherwise).
+@inline function _mod_name_code(str, lo::Int, hi::Int)
+    _name_is(str, lo, hi, "Unimod:4")  && return Int8(1)
+    _name_is(str, lo, hi, "Unimod:35") && return Int8(2)
+    return Int8(-1)
+end
+
+# Parse `structural_mods` ("(pos,site,modname)...") into scratch.mod_at_pos[1:L]
+# by scanning codeunits — no regex, no per-mod String/Dict allocation. Terminal
+# (n/c) mods are ignored (warned). A second mod at one position -> -1 (matches the
+# old multi-mod path: no combined token exists, so it is treated as unrecognized).
+function _parse_residue_mods!(s::IrtCountScratch, structural_mods, L::Int)
+    length(s.mod_at_pos) < L && resize!(s.mod_at_pos, L)
+    @inbounds for i in 1:L
+        s.mod_at_pos[i] = Int8(0)
+    end
+    (ismissing(structural_mods) || isempty(structural_mods)) && return
+    str = structural_mods
+    n = ncodeunits(str)
+    i = 1
+    @inbounds while i <= n
+        if codeunit(str, i) != UInt8('(')
+            i += 1
+            continue
+        end
+        i += 1
+        pos = 0
+        while i <= n && (b = codeunit(str, i)) >= UInt8('0') && b <= UInt8('9')
+            pos = pos * 10 + Int(b - UInt8('0'))
+            i += 1
+        end
+        (i <= n && codeunit(str, i) == UInt8(',')) || break
+        i += 1
+        site = codeunit(str, i); i += 1
+        (i <= n && codeunit(str, i) == UInt8(',')) || break
+        i += 1
+        mstart = i
+        while i <= n && codeunit(str, i) != UInt8(')')
+            i += 1
+        end
+        mend = i - 1
+        i += 1   # past ')'
+        if site == UInt8('n') || site == UInt8('c')
+            @warn "iRT refinement: unhandled terminal modification (ignored)" maxlog = 1
+        elseif 1 <= pos <= L
+            code = _mod_name_code(str, mstart, mend)
+            s.mod_at_pos[pos] = (s.mod_at_pos[pos] == 0) ? code : Int8(-1)
+        end
+    end
+    return
+end
+
 # Residue-token index k (1..22), or 0 if the residue/modification is unrecognized.
-@inline function _residue_token_k(aa::Char, mods_here)
-    if mods_here === nothing || isempty(mods_here)
+@inline function _residue_token_k(aa::Char, code::Integer)
+    if code == 0
         b = UInt32(aa)
         return b <= 0x7f ? @inbounds(_IRT_AA_K[b + 1]) : 0
-    elseif length(mods_here) == 1
-        mn = mods_here[1]
-        aa == 'C' && mn == "Unimod:4"  && return _IRT_K_MODC
-        aa == 'M' && mn == "Unimod:35" && return _IRT_K_MODM
+    elseif code == 1
+        return aa == 'C' ? _IRT_K_MODC : 0
+    elseif code == 2
+        return aa == 'M' ? _IRT_K_MODM : 0
     end
     return 0
 end
@@ -119,29 +181,15 @@ function count_token_ids!(
     structural_mods::Union{Missing, AbstractString},
 )
     _reset!(scratch)
-
-    # Allocated lazily: only sequences with residue-localized modifications need it.
-    position_mods = nothing
-    if !ismissing(structural_mods) && !isempty(structural_mods)
-        for m in eachmatch(_IRT_MOD_REGEX, structural_mods)
-            position = parse(Int, m.captures[1])
-            site = only(m.captures[2])
-            mod_name = m.captures[3]
-            if site == 'n' || site == 'c'
-                @warn "iRT refinement: unhandled terminal modification token $(site)|$(mod_name) (ignored)" maxlog = 1
-            elseif 1 <= position <= length(sequence)
-                position_mods === nothing && (position_mods = Dict{Int, Vector{String}}())
-                push!(get!(position_mods, position, String[]), String(mod_name))
-            end
-        end
-    end
+    L = length(sequence)
+    _parse_residue_mods!(scratch, structural_mods, L)
 
     first_k = 0
     last_k = 0
     have_any = false
     for (position, aa) in enumerate(sequence)
-        mods_here = position_mods === nothing ? nothing : get(position_mods, position, nothing)
-        k = _residue_token_k(aa, mods_here)
+        code = position <= length(scratch.mod_at_pos) ? scratch.mod_at_pos[position] : Int8(0)
+        k = _residue_token_k(aa, code)
         if k == 0
             @warn "iRT refinement: unhandled residue token for '$(aa)' (ignored)" maxlog = 1
             continue

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/pass1_oom.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/pass1_oom.jl
@@ -162,21 +162,36 @@ function _sample_both_folds(
     # of thread, so all threads write disjoint matrix locations.
     Threads.@threads for j in 1:nfeat
         for file_idx in 1:n_files
-            col = all_feat_cols[file_idx][j]
-            p0 = plan0[file_idx]
-            @inbounds for k in eachindex(p0)
-                src_i, dst_i = p0[k]
-                X0[dst_i, j] = Float32(col[src_i])
-            end
-            p1 = plan1[file_idx]
-            @inbounds for k in eachindex(p1)
-                src_i, dst_i = p1[k]
-                X1[dst_i, j] = Float32(col[src_i])
-            end
+            # Function barrier: `all_feat_cols[file_idx]` is a Vector{AbstractVector}
+            # (heterogeneous feature column types), so `col` has an abstract static
+            # type and indexing it boxes a value per element. Passing it to a method
+            # specializes the copy loop on the concrete column type, eliminating the
+            # per-element boxing in this hot loop.
+            _copy_sampled_column!(X0, X1, all_feat_cols[file_idx][j],
+                                  plan0[file_idx], plan1[file_idx], j)
         end
     end
 
     return X0, y0, X1, y1
+end
+
+# Copy planned (src_row -> dst_row) values from one feature column into the
+# sampled fold matrices. Isolated as its own method to act as a function barrier:
+# `col` is specialized to its concrete type here, so `Float32(col[src_i])` does
+# not box (see caller).
+@inline function _copy_sampled_column!(
+    X0::Matrix{Float32}, X1::Matrix{Float32}, col::AbstractVector,
+    p0::Vector{Tuple{Int32, Int32}}, p1::Vector{Tuple{Int32, Int32}}, j::Int,
+)
+    @inbounds for k in eachindex(p0)
+        src_i, dst_i = p0[k]
+        X0[dst_i, j] = Float32(col[src_i])
+    end
+    @inbounds for k in eachindex(p1)
+        src_i, dst_i = p1[k]
+        X1[dst_i, j] = Float32(col[src_i])
+    end
+    return
 end
 
 # Fit a LightGBM classifier on the sampled (X, y). Returns the booster.

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/wide_window_features.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/wide_window_features.jl
@@ -484,12 +484,15 @@ struct FlankingWindowGroupBuffer
     core_fragments::NTuple{8, Float32}
     ms1_target::Float32
     # Top-8 fragments precomputed once at group-build time and sorted by m/z so
-    # the per-scan fill can thread a monotonic bsearch cursor (Opt 1). Each entry
-    # s maps to original intensity-rank `sorted_ranks[s]` (the column to write).
-    sorted_ranks::Vector{Int}
-    sorted_targets::Vector{Float32}
-    sorted_lows::Vector{Float32}
-    sorted_highs::Vector{Float32}
+    # the per-scan fill can thread a monotonic bsearch cursor (Opt 1). Stored as
+    # fixed NTuples (inline, no per-group heap allocation); only entries
+    # 1:n_frags are valid. Entry s maps to original intensity-rank
+    # `sorted_ranks[s]` (the column to write).
+    n_frags::Int
+    sorted_ranks::NTuple{8, Int}
+    sorted_targets::NTuple{8, Float32}
+    sorted_lows::NTuple{8, Float32}
+    sorted_highs::NTuple{8, Float32}
     ms1_m0::Vector{Float32}
     fragments::Matrix{Float32}
 end
@@ -498,37 +501,51 @@ end
     _wide_group_fragment_windows(frag_idxs, frag_list, mem)
 
 From the rank-indexed `frag_idxs` (0 = absent), build the match windows for the
-valid fragments and return them sorted by ascending target m/z. `mem` supplies
-the (m/z-only, scan-invariant) half-width, so `(target, low, high)` are computed
-once per group instead of once per (scan x fragment). Returns parallel vectors
-`(ranks, targets, lows, highs)` where `ranks[s]` is the original intensity rank.
+valid fragments sorted by ascending target m/z. `mem` supplies the (m/z-only,
+scan-invariant) half-width, so `(target, low, high)` are computed once per group
+instead of once per (scan x fragment). Returns `(n, ranks, targets, lows, highs)`
+as fixed `NTuple{8}`s (only entries `1:n` are valid); `ranks[s]` is the original
+intensity rank. `@inline` + non-escaping `MVector` stack scratch + in-place
+insertion sort => no per-group heap allocation at the (inlined) call site.
 """
-function _wide_group_fragment_windows(
+@inline function _wide_group_fragment_windows(
     frag_idxs::Vector{UInt64},
     frag_list,
     mem::AbstractMassErrorModel,
 )
-    ranks = Int[]
-    targets = Float32[]
+    ranks = zero(MVector{8, Int})
+    targets = zero(MVector{8, Float32})
+    lows = zero(MVector{8, Float32})
+    highs = zero(MVector{8, Float32})
+    n = 0
     @inbounds for rank in 1:8
         fi = frag_idxs[rank]
         fi > 0 || continue
-        push!(ranks, rank)
-        push!(targets, Float32(getMz(frag_list[Int(fi)])))
+        n += 1
+        ranks[n] = rank
+        targets[n] = Float32(getMz(frag_list[Int(fi)]))
     end
-    order = sortperm(targets)
-    sorted_ranks = ranks[order]
-    sorted_targets = targets[order]
-    n = length(sorted_targets)
-    sorted_lows = Vector{Float32}(undef, n)
-    sorted_highs = Vector{Float32}(undef, n)
+    # Insertion sort the first n entries (n <= 8) by ascending target m/z,
+    # carrying the original rank alongside. Stable; allocation-free.
+    @inbounds for i in 2:n
+        tv = targets[i]
+        rv = ranks[i]
+        j = i - 1
+        while j >= 1 && targets[j] > tv
+            targets[j + 1] = targets[j]
+            ranks[j + 1] = ranks[j]
+            j -= 1
+        end
+        targets[j + 1] = tv
+        ranks[j + 1] = rv
+    end
     @inbounds for s in 1:n
-        hw = conservative_half_width(mem, sorted_targets[s])
-        lo, hi = match_window(sorted_targets[s], hw)
-        sorted_lows[s] = lo
-        sorted_highs[s] = hi
+        hw = conservative_half_width(mem, targets[s])
+        lo, hi = match_window(targets[s], hw)
+        lows[s] = lo
+        highs[s] = hi
     end
-    return sorted_ranks, sorted_targets, sorted_lows, sorted_highs
+    return n, Tuple(ranks), Tuple(targets), Tuple(lows), Tuple(highs)
 end
 
 function _wide_add_group_ms2_work!(
@@ -609,6 +626,7 @@ function _wide_fill_scan_centric_fragments!(
 
         @inbounds for (group_idx, flank_pos) in work_items
             group = groups[group_idx]
+            n_frags = group.n_frags
             sorted_ranks = group.sorted_ranks
             sorted_targets = group.sorted_targets
             sorted_lows = group.sorted_lows
@@ -619,7 +637,7 @@ function _wide_fill_scan_centric_fragments!(
             # range only ever shrinks, and the result is identical to searching
             # [1, n_peaks] every time (low_{s+1} >= low_s).
             start_idx = 1
-            for s in eachindex(sorted_targets)
+            for s in 1:n_frags
                 start_idx = bsearch_hybrid(
                     scan_corrected_mz, sorted_lows[s], start_idx, n_peaks,
                 )
@@ -819,7 +837,7 @@ function add_wide_window_features_to_fold_file!(
             prec_charge,
             prec_mz,
         )
-        sorted_ranks, sorted_targets, sorted_lows, sorted_highs =
+        n_frags, sorted_ranks, sorted_targets, sorted_lows, sorted_highs =
             _wide_group_fragment_windows(fragment_idxs, frag_list, frag_mem)
         ms1_m0 = zeros(Float32, length(flank_scans))
         ms1_target = prec_mz * (1f0 + ms1_ppm_offset * 1f-6)
@@ -833,6 +851,7 @@ function add_wide_window_features_to_fold_file!(
                 core_frag_signal,
                 core_fragments,
                 ms1_target,
+                n_frags,
                 sorted_ranks,
                 sorted_targets,
                 sorted_lows,

--- a/src/Routines/SearchDIA/process_scans_fused.jl
+++ b/src/Routines/SearchDIA/process_scans_fused.jl
@@ -90,10 +90,12 @@ function process_scans_fused!(
         prec_range = get_prec_range(prec_index, scan_idx)
         precs_vec  = get_precursors(prec_index)
 
-        # Run deconv pipeline for one prec subset (per-scan slice).
-        # Returns updated last_val. The PSMs from this call accumulate in scored_psms.
-        function _run_subset!(sub_indices)
-            isempty(sub_indices) && return last_val
+        # Run deconv pipeline for this scan's precursor subset. Inlined: this was
+        # previously a closure (`_run_subset!`) defined inside the loop and called
+        # once per scan, which allocated a capture object every iteration and boxed
+        # the reassigned `last_val`. Inlining preserves the exact control flow.
+        sub_indices = collect(Int64, prec_range)
+        if !isempty(sub_indices)
             nmatches, nmisses = run_fused!(
                 kind,
                 Hs, unscored_psms, id_to_col, fused_scratch,
@@ -111,22 +113,19 @@ function process_scans_fused!(
             )
             if nmatches ≤ 2
                 reset_scan_arrays!(id_to_col, Hs, unscored_psms)
-                return last_val
+            else
+                resize_if_needed!(search_data, params)
+                converged = post_design_matrix!(search_data, Hs, params)
+                if !converged
+                    reset_scan_arrays!(id_to_col, Hs, unscored_psms)
+                else
+                    compute_distance_metrics!(Hs, search_data, params)
+                    last_val = score_psms!(search_data, params, Hs, scan_idx, nmatches, nmisses,
+                                          spectra, last_val, ms_file_idx, cycle_idx; mem=mem)
+                    reset_scan_arrays!(id_to_col, Hs, unscored_psms)
+                end
             end
-            resize_if_needed!(search_data, params)
-            converged = post_design_matrix!(search_data, Hs, params)
-            if !converged
-                reset_scan_arrays!(id_to_col, Hs, unscored_psms)
-                return last_val
-            end
-            compute_distance_metrics!(Hs, search_data, params)
-            new_last_val = score_psms!(search_data, params, Hs, scan_idx, nmatches, nmisses,
-                                  spectra, last_val, ms_file_idx, cycle_idx; mem=mem)
-            reset_scan_arrays!(id_to_col, Hs, unscored_psms)
-            return new_last_val
         end
-
-        last_val = _run_subset!(collect(Int64, prec_range))
     end
 
     return DataFrame(@view(get_scored_psms(search_data, params)[1:last_val]))

--- a/src/structs/Counter.jl
+++ b/src/structs/Counter.jl
@@ -81,14 +81,14 @@ Accumulates bitmask pattern counts (target/decoy × 256 bins) directly in the
 fragment index scoring loop. One pair of vectors per thread to avoid contention.
 Created once, reused across files — no per-scan allocation.
 """
-struct PatternAccumulator
+struct PatternAccumulator{D<:AbstractVector{Bool}}
     thread_tc::Vector{Vector{Int}}  # thread_tc[tid][score+1]
     thread_dc::Vector{Vector{Int}}
-    is_decoy::AbstractVector{Bool}  # indexed by global precursor_idx
+    is_decoy::D                     # indexed by global precursor_idx (concrete: avoids boxing in accumulate!)
     min_score::UInt8
 
     function PatternAccumulator(n_threads::Int, is_decoy::AbstractVector{Bool}; min_score::UInt8 = UInt8(2))
-        new(
+        new{typeof(is_decoy)}(
             [zeros(Int, 256) for _ in 1:n_threads],
             [zeros(Int, 256) for _ in 1:n_threads],
             is_decoy, min_score)

--- a/src/structs/MassSpecData/getters.jl
+++ b/src/structs/MassSpecData/getters.jl
@@ -13,8 +13,8 @@
 Singular getters (per-scan access)
 ==========================================================#
 
-getMzArray(ms_data::NonIonMobilityData{T}, scan_idx::Integer) where T = getMzArrays(ms_data)[scan_idx]
-getIntensityArray(ms_data::NonIonMobilityData{T}, scan_idx::Integer) where T = getIntensityArrays(ms_data)[scan_idx]
+getMzArray(ms_data::NonIonMobilityData{T}, scan_idx::Integer) where T = getMzArrays(ms_data)[scan_idx]::SubArray{Union{Missing,T},1,Arrow.Primitive{Union{Missing,T},Vector{T}},Tuple{UnitRange{Int64}},true}
+getIntensityArray(ms_data::NonIonMobilityData{T}, scan_idx::Integer) where T = getIntensityArrays(ms_data)[scan_idx]::SubArray{Union{Missing,T},1,Arrow.Primitive{Union{Missing,T},Vector{T}},Tuple{UnitRange{Int64}},true}
 getRetentionTime(ms_data::NonIonMobilityData{T}, scan_idx::Integer) where T = getRetentionTimes(ms_data)[scan_idx]
 getLowMz(ms_data::NonIonMobilityData{T}, scan_idx::Integer) where T = getLowMzs(ms_data)[scan_idx]
 getHighMz(ms_data::NonIonMobilityData{T}, scan_idx::Integer) where T = getHighMzs(ms_data)[scan_idx]

--- a/src/structs/SpectralLibrary/PartitionedFragmentIndex/search.jl
+++ b/src/structs/SpectralLibrary/PartitionedFragmentIndex/search.jl
@@ -306,9 +306,9 @@ end
 """
 Emit to pattern accumulator for BitVecCalibration. Applies prec_mz + iRT filtering.
 """
-struct EmitToAccumulator <: FragIndexEmitStrategy
-    acc::PatternAccumulator
-    precursor_irts::AbstractVector{Float32}
+struct EmitToAccumulator{A<:PatternAccumulator, V<:AbstractVector{Float32}} <: FragIndexEmitStrategy
+    acc::A
+    precursor_irts::V               # concrete element/array type: avoids per-candidate boxing in emit_candidates!
     irt_tol::Float32
 end
 


### PR DESCRIPTION
## Summary

Combined allocation-reduction work for SearchDIA. Measured **warm, 2-file MTAC, vs pre-effort develop (`bcfae03f8`)**:

| | Baseline | This branch | Δ |
|---|---:|---:|---:|
| **Total allocation** | 146.9 GB | 58.1 GB | **−60%** |
| Main Search | 59.6 GB | 29.4 GB | −51% |
| Precursor Scoring | 58.9 GB | 7.4 GB | −87% |
| Parameter Tuning | 3.4 GB | 1.5 GB | −55% |
| GC time | 6.80 s | 4.11 s | −40% |
| **Total runtime (warm)** | 102.0 s | 91.3 s | **−10%** |

> ⚠️ **This branch includes `feature/reduce-allocations` in full** (merged throughout), so it overlaps that branch. Review the two together, or treat this as the integration view.

## What changed

**Allocation/perf fixes (this effort):**
- `getMzArray`/`getIntensityArray` type-stabilization — kill boxed dynamic dispatch from `Arrow.Table` `Any` column access
- `growScoredPSMs!` → `resize!` — drop a throwaway 500k-element temp Vector per growth (−765 MB on `score_psms!`)
- skip the redundant single-NCE outer `vcat` in `library_search` (−674 MB/file)
- MS1 chromatogram features: per-thread scratch reuse (−620 MB)
- wide-window flanking features: monotonic bsearch cursor + `NTuple{8}` fragment windows (Precursor Scoring −87%; bit-identical)
- hoist per-row column accessors out of output-build loops
- **+ the `feature/reduce-allocations` series**: iRT byte-level mods parser / token-id map / column cache, `EmitToAccumulator`/`Counter` type-stab, per-scan closure inline, fragment-corr scratch reuse, pass1 function barrier

**Diagnostics (env-gated, zero-cost off):** `@alloc_bucket` around Main Search sub-steps, PSM-table footprint logging. *Candidates to strip before merge if you don't want them in `develop`.*

**Docs:** CLAUDE.md Julia performance & memory-discipline section.

## Result-equivalence note

All of *my* fixes are verified **bit-identical** (counts unchanged in per-fix A/B). The branch as a whole is **not** strictly bit-identical to develop: counts are **211921 / 21985** vs baseline **212012 / 22052** (−91 precursors / −67 PGs, ~0.04% / 0.3%). This comes entirely from the iRT refinement redesign, which deliberately replaces fragile **dict-hash** design-matrix column ordering with **deterministic token-id** ordering — an improvement, but the iRT fit is column-order-sensitive so borderline results shift slightly. Flagging so it's a conscious decision.

## Verification update (regression report + SCIEX runtime)

- **Full regression report** for `c6e5b76a8` (current vs `develop`): IDs, quant (median CV), entrapment/FTR, and fold-change error all show **negligible divergence** — confirms result-neutrality at scale (the deliberate iRT shift is <1% across the 42-dataset suite).
- The report's **SCIEX_3P "+28.9% runtime"** did **not** reproduce in a controlled local warm A/B (3 Sciex files, three-proteome lib, sequential): develop **357.05 s** vs branch **325.28 s → −9%** (branch faster), with total allocation **224 → 141 GB (−37%)** and Main Search **170 → 105 GB (−38%)**. The report value was single-run CI timing noise. IDs 265304/25204 → 264189/25249 (−0.42% / +0.18%, within the iRT-rebaseline tolerance).

## Test plan
- [x] Per-fix bit-identical A/B (MTAC precursor/PG counts) for each allocation fix
- [x] Allocation + runtime measured warm vs `bcfae03f8` baseline (table above)
- [x] Audited `reduce-allocations` commits — no bugs found; token counts reproduced for all 1.24M library precursors
- [x] Full regression suite (current vs `develop`): result-neutral across 42 datasets; SCIEX runtime "regression" confirmed to be CI noise via local warm A/B (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
