### PR TITLE
Add main-search mass missing features

### DIFF
--- a/src/Routines/SearchDIA/CommonSearchUtils/fusedMatch.jl
+++ b/src/Routines/SearchDIA/CommonSearchUtils/fusedMatch.jl
@@ -199,7 +199,8 @@ end
 
 """
     record_match!(kind, unscored_psms, col, frag, iso_idx, intensity,
-                   ppm_err, m_rank, prec_idx, pred_int, trace_intensity_match)
+                   ppm_err, mass_tol_ppm, m_rank, prec_idx, pred_int,
+                   trace_intensity_match)
 
 Per-match inline scoring hook, dispatched on `(kind, eltype(unscored_psms))`.
 
@@ -233,11 +234,11 @@ end
 @inline function record_match!(::FusedStandard,
         unscored_psms::Vector{MainUnscoredPSM{Float32}}, col::Int, frag,
         iso_idx::UInt8, intensity::Float32, ppm_err::Float32,
-        m_rank::Int64, prec_idx::UInt32, pred_int::Float32,
+        mass_tol_ppm::Float32, m_rank::Int64, prec_idx::UInt32, pred_int::Float32,
         trace_intensity_match::Bool)
     ensure_unscored_capacity!(unscored_psms, col)
     apply_main_scoring!(unscored_psms, col, frag, iso_idx,
-                            intensity, ppm_err, m_rank, prec_idx, pred_int,
+                            intensity, ppm_err, m_rank, prec_idx, pred_int, mass_tol_ppm,
                             trace_intensity_match)
     return nothing
 end
@@ -245,7 +246,7 @@ end
 @inline function record_match!(::FusedStandard,
         unscored_psms::Vector{TuningUnscoredPSM{Float32}}, col::Int, frag,
         iso_idx::UInt8, intensity::Float32, ppm_err::Float32,
-        m_rank::Int64, prec_idx::UInt32, ::Float32, ::Bool)
+        ::Float32, m_rank::Int64, prec_idx::UInt32, ::Float32, ::Bool)
     ensure_unscored_capacity!(unscored_psms, col)
     apply_tuning_scoring!(unscored_psms, col, frag, iso_idx,
                             intensity, ppm_err, m_rank, prec_idx)
@@ -253,12 +254,68 @@ end
 end
 
 @inline record_match!(::FusedQuadEst, ::AbstractVector{<:UnscoredPSM},
-        ::Int, _, ::UInt8, ::Float32, ::Float32, ::Int64, ::UInt32,
+        ::Int, _, ::UInt8, ::Float32, ::Float32, ::Float32, ::Int64, ::UInt32,
         ::Float32, ::Bool) = nothing
 
 @inline record_match!(::FusedRTIndexed, ::AbstractVector{<:UnscoredPSM},
-        ::Int, _, ::UInt8, ::Float32, ::Float32, ::Int64, ::UInt32,
+        ::Int, _, ::UInt8, ::Float32, ::Float32, ::Float32, ::Int64, ::UInt32,
         ::Float32, ::Bool) = nothing
+
+@inline function _mass_missing_hellinger_score(scratch::FusedScratch)
+    pred_sum = 0f0
+    obs_sum = 0f0
+    bc_sum = 0f0
+    @inbounds for i in 1:scratch.n
+        scratch.isotope[i] == UInt8(0) || continue
+        pred = scratch.nzval[i]
+        obs = scratch.x[i]
+        pred_sum += pred
+        obs_sum += obs
+        bc_sum += sqrt(pred * obs)
+    end
+
+    denom = sqrt(pred_sum * obs_sum)
+    base_hsq = denom > 0f0 ? 1f0 - bc_sum / denom : 1f0
+    mass_hsq = base_hsq
+    @inbounds for i in 1:scratch.n
+        scratch.isotope[i] == UInt8(0) || continue
+        obs_without = obs_sum - scratch.x[i]
+        bc_without = bc_sum - sqrt(scratch.nzval[i] * scratch.x[i])
+        denom_without = sqrt(pred_sum * obs_without)
+        hsq_without = denom_without > 0f0 ? 1f0 - bc_without / denom_without : 1f0
+        delta = hsq_without - base_hsq
+        delta > 0f0 && (mass_hsq += scratch.mass_risk[i] * delta)
+    end
+    mass_hsq = min(max(mass_hsq, 0f0), 1f0)
+    return Float32(-log2(max(mass_hsq, 1f-10)))
+end
+
+@inline function record_mass_missing_hellinger!(
+        ::FusedStandard,
+        unscored::Vector{MainUnscoredPSM{Float32}},
+        col::Int,
+        scratch::FusedScratch)
+    score = unscored[col]
+    unscored[col] = MainUnscoredPSM{Float32}(
+        score.best_rank,
+        score.longest_y, score.longest_b, score.longest_y_iso,
+        score.isotope_count,
+        score.b_count, score.b_int,
+        score.y_count, score.y_int,
+        score.y_count_iso,
+        score.p_count, score.non_cannonical_count,
+        score.error,
+        score.frag1_int, score.frag2_int, score.frag3_int, score.frag4_int,
+        score.frag5_int, score.frag6_int, score.frag7_int, score.frag8_int,
+        score.top3_abs_ppm_err_sum, score.top3_ppm_err_count,
+        score.pred_int_sum_m0, score.expected_missing_pred_int_sum_m0,
+        _mass_missing_hellinger_score(scratch),
+        score.precursor_idx, score.ms_file_idx)
+    return nothing
+end
+
+@inline record_mass_missing_hellinger!(
+    ::FusedSearchKind, ::AbstractVector{<:UnscoredPSM}, ::Int, ::FusedScratch) = nothing
 
 #==========================================================
 Inline scoring for the fused path — mirrors ModifyFeatures!(MainUnscoredPSM, …)
@@ -268,7 +325,8 @@ FragmentMatch object (since the fused path never constructs matches).
 
 """
     apply_main_scoring!(unscored, col, frag, iso_idx, intensity, ppm_err,
-                        m_rank, prec_idx, pred_int, trace_intensity_match)
+                        m_rank, prec_idx, pred_int, mass_tol_ppm,
+                        trace_intensity_match)
 
 Update `unscored[col]` with one (fragment, isotope) match. Equivalent to
 `ModifyFeatures!(score::MainUnscoredPSM, …)` called from classic's
@@ -285,6 +343,7 @@ error accumulation.
                                          m_rank::Int64,
                                          prec_idx::UInt32,
                                          pred_int::Float32,
+                                         mass_tol_ppm::Float32,
                                          trace_intensity_match::Bool)
     @inbounds score = unscored[col]
 
@@ -316,6 +375,8 @@ error accumulation.
     top3_abs_ppm_err_sum = score.top3_abs_ppm_err_sum
     top3_ppm_err_count   = score.top3_ppm_err_count
     pred_int_sum_m0 = score.pred_int_sum_m0
+    expected_missing_pred_int_sum_m0 = score.expected_missing_pred_int_sum_m0
+    mass_missing_hellinger = score.mass_missing_hellinger
 
     if iso_idx != UInt8(0)
         isotope_count += UInt8(1)
@@ -333,6 +394,8 @@ error accumulation.
         end
         # E3: matched-fragment predicted-intensity sum (M0 only, all ranks)
         pred_int_sum_m0 += pred_int
+        mass_risk = min((abs(ppm_err) / mass_tol_ppm)^2, 1f0)
+        expected_missing_pred_int_sum_m0 += mass_risk * pred_int
         if rank < best_rank
             best_rank = rank
         end
@@ -381,7 +444,8 @@ error accumulation.
         frag1_int, frag2_int, frag3_int, frag4_int, frag5_int, frag6_int,
         frag7_int, frag8_int,
         top3_abs_ppm_err_sum, top3_ppm_err_count,
-        pred_int_sum_m0,
+        pred_int_sum_m0, expected_missing_pred_int_sum_m0,
+        mass_missing_hellinger,
         prec_idx, ms_file_idx)
     return nothing
 end
@@ -693,14 +757,15 @@ written into the scored PSM stays bit-identical.
     (theoretical_mz - observed_mz) / (theoretical_mz * 1f-6)
 
 """
-    push_match!(scratch, peak_row, pred_int, int_obs, iso_idx, rank)
+    push_match!(scratch, peak_row, pred_int, int_obs, iso_idx, rank, mass_risk)
 
 Append a matched-peak entry into `FusedScratch`, growing the backing arrays
 if necessary. Mirrors the inline form: row=UInt32(peak), nzval=pred_int,
-x=int_obs, isotope=UInt8(iso_idx), rank=UInt8(rank).
+x=int_obs, isotope=UInt8(iso_idx), rank=UInt8(rank), mass_risk=mass_risk.
 """
 @inline function push_match!(scratch::FusedScratch, peak_row::Integer,
-        pred_int::Float32, int_obs::Float32, iso_idx::Integer, rank::Integer)
+        pred_int::Float32, int_obs::Float32, iso_idx::Integer, rank::Integer,
+        mass_risk::Float32)
     if scratch.n + 1 > length(scratch.row)
         grow_fused_scratch!(scratch, scratch.n + 1)
     end
@@ -711,6 +776,7 @@ x=int_obs, isotope=UInt8(iso_idx), rank=UInt8(rank).
         scratch.x[scratch.n]       = int_obs
         scratch.isotope[scratch.n] = UInt8(iso_idx)
         scratch.rank[scratch.n]    = UInt8(rank)
+        scratch.mass_risk[scratch.n] = mass_risk
     end
     return nothing
 end
@@ -881,6 +947,7 @@ function run_fused!(
                 frag_charge_inv = 1f0 / Float32(getFragCharge(frag))
 
                 half_width = conservative_half_width(mem, frag_mz)
+                mass_tol_ppm = half_width / frag_mz * 1f6
 
                 # Tighten per-iso bsearch `lo`: iso k's target is strictly greater
                 # than iso k-1's, so k's first-matching-peak ≥ k-1's anchor.
@@ -914,13 +981,14 @@ function run_fused!(
                             col_started = true
                         end
 
-                        push_match!(scratch, best_peak, pred_int, int_obs, iso_idx, rank)
-
                         ppm_err = compute_ppm_err(iso_mz, best_mz)
+                        mass_risk = iso_idx == 0 ? min((abs(ppm_err) / mass_tol_ppm)^2, 1f0) : 0f0
+                        push_match!(scratch, best_peak, pred_int, int_obs, iso_idx, rank, mass_risk)
+
                         trace_intensity_match = capture_trace_intensity &&
                             fragment_trace_isotope_contributes(pred_int, trace_max_pred)
                         record_match!(kind, unscored_psms, Int(this_col),
-                            frag, UInt8(iso_idx), int_obs, ppm_err, m_rank, prec_idx,
+                            frag, UInt8(iso_idx), int_obs, ppm_err, mass_tol_ppm, m_rank, prec_idx,
                             pred_int, trace_intensity_match)
 
                         if iso_idx == 0
@@ -936,6 +1004,7 @@ function run_fused!(
             end  # frag_idx
 
             if col_started
+                record_mass_missing_hellinger!(kind, unscored_psms, Int(this_col), scratch)
                 entry, miss_row = finalize_column!(Hs, this_col, scratch, entry, miss_row)
             end
         end  # iso_pass

--- a/src/Routines/SearchDIA/CommonSearchUtils/fusedScan.jl
+++ b/src/Routines/SearchDIA/CommonSearchUtils/fusedScan.jl
@@ -26,6 +26,7 @@ mutable struct FusedScratch
     x::Vector{Float32}
     isotope::Vector{UInt8}
     rank::Vector{UInt8}
+    mass_risk::Vector{Float32}
     # Miss entries: buffered here and flushed alongside matches in finalize.
     # Misses from a precursor with zero matches are discarded.
     miss_nzval::Vector{Float32}
@@ -42,6 +43,7 @@ function FusedScratch(max_per_prec::Int)
         Vector{Float32}(undef, max_per_prec),
         Vector{UInt8}(undef, max_per_prec),
         Vector{UInt8}(undef, max_per_prec),
+        Vector{Float32}(undef, max_per_prec),
         Vector{Float32}(undef, max_per_prec),
         Vector{UInt8}(undef, max_per_prec),
         Vector{UInt8}(undef, max_per_prec),
@@ -68,6 +70,7 @@ function grow_fused_scratch!(s::FusedScratch, needed::Int)
         append!(s.x,            zeros(Float32, extra))
         append!(s.isotope,      zeros(UInt8, extra))
         append!(s.rank,         zeros(UInt8, extra))
+        append!(s.mass_risk,    zeros(Float32, extra))
         append!(s.miss_nzval,   zeros(Float32, extra))
         append!(s.miss_isotope, zeros(UInt8, extra))
         append!(s.miss_rank,    zeros(UInt8, extra))

--- a/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
+++ b/src/Routines/SearchDIA/PSMs/ScoredPSMs.jl
@@ -128,6 +128,8 @@ struct MainSearchScoredPSM{H,L<:AbstractFloat} <: ScoredPSM{H,L}
     # E7 (Batch E, 2026-05-12): mean |ppm_err| over matched M0 fragments at
     # ranks 1-3. Zero if no top-3 matches in this scan.
     top3_ms2_mass_error_mean::H
+    expected_predicted_missing_fraction::H
+    mass_missing_hellinger::H
 
     # E6 M0 (Batch E, 2026-05-12): log(b_int + 1) − log(y_int + 1). Real
     # peptides have characteristic b/y intensity ratios; chimeric hits don't.
@@ -238,6 +240,12 @@ function Score!(scored_psms::Vector{MainSearchScoredPSM{H, L}},
             H(unscored_PSMs[i].top3_ppm_err_count > 0 ?
                 unscored_PSMs[i].top3_abs_ppm_err_sum / unscored_PSMs[i].top3_ppm_err_count :
                 zero(H)),
+
+            H(unscored_PSMs[i].pred_int_sum_m0 > 0 ?
+                unscored_PSMs[i].expected_missing_pred_int_sum_m0 / unscored_PSMs[i].pred_int_sum_m0 :
+                zero(H)),
+
+            H(unscored_PSMs[i].mass_missing_hellinger),
 
             L(log(Float32(unscored_PSMs[i].b_int) + 1f0) -
               log(Float32(unscored_PSMs[i].y_int) + 1f0)),

--- a/src/Routines/SearchDIA/PSMs/UnscoredPSMs.jl
+++ b/src/Routines/SearchDIA/PSMs/UnscoredPSMs.jl
@@ -56,6 +56,8 @@ struct MainUnscoredPSM{T<:AbstractFloat} <: UnscoredPSM{T}
     # ALL matched M0 fragments (any rank). Paired with b_int + y_int to give
     # matched_ratio = log2((obs matched) / (pred matched)) in Score!.
     pred_int_sum_m0::T
+    expected_missing_pred_int_sum_m0::T
+    mass_missing_hellinger::T
     precursor_idx::UInt32
     ms_file_idx::UInt32
 end
@@ -68,6 +70,7 @@ MainUnscoredPSM{Float32}() = MainUnscoredPSM{Float32}(
     Float32(0), Float32(0), Float32(0), Float32(0),
     Float32(0), Float32(0), Float32(0), Float32(0),
     Float32(0), zero(UInt8), Float32(0),
+    Float32(0), Float32(0),
     UInt32(0), UInt32(0),
 )
 

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
@@ -175,6 +175,8 @@ const PRESCORE_FEATURES = [
 
     # Batch E features (E7, E14, E6 M0 kept; E1/E2 pred_obs dropped via composite)
     :top3_ms2_mass_error_mean,
+    :expected_predicted_missing_fraction,
+    :mass_missing_hellinger,
     :delta_frame_peak_center,
     :log_by_ratio_m0,
 

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/model_config.jl
@@ -117,6 +117,8 @@ const ADVANCED_FEATURE_SET = [
     :ms1_m0_peak_n_precursors,
     :scan_prec_mz_n_precursors,
     :top3_ms2_mass_error_mean,
+    :expected_predicted_missing_fraction,
+    :mass_missing_hellinger,
     :delta_frame_peak_center,
     :log_by_ratio_m0,
     :n_scans,

--- a/test/UnitTests/test_fragment_isotope_trace_intensities.jl
+++ b/test/UnitTests/test_fragment_isotope_trace_intensities.jl
@@ -9,11 +9,11 @@ using Pioneer
     unscored = [Pioneer.MainUnscoredPSM{Float32}()]
 
     Pioneer.apply_main_scoring!(
-        unscored, 1, frag, UInt8(0), 100.0f0, 0.0f0, 3, UInt32(1), 1.0f0, true)
+        unscored, 1, frag, UInt8(0), 100.0f0, 0.0f0, 3, UInt32(1), 1.0f0, 10.0f0, true)
     Pioneer.apply_main_scoring!(
-        unscored, 1, frag, UInt8(1), 50.0f0, 0.0f0, 3, UInt32(1), 0.3f0, true)
+        unscored, 1, frag, UInt8(1), 50.0f0, 0.0f0, 3, UInt32(1), 0.3f0, 10.0f0, true)
     Pioneer.apply_main_scoring!(
-        unscored, 1, frag, UInt8(2), 80.0f0, 0.0f0, 3, UInt32(1), 0.1f0, false)
+        unscored, 1, frag, UInt8(2), 80.0f0, 0.0f0, 3, UInt32(1), 0.1f0, 10.0f0, false)
 
     psm = unscored[1]
     @test psm.frag1_int === 150.0f0
@@ -21,6 +21,66 @@ using Pioneer
     @test psm.y_count_iso == UInt8(2)
     @test psm.y_count == UInt8(1)
     @test psm.pred_int_sum_m0 === 1.0f0
+end
+
+@testset "expected predicted missing fraction uses M0 mass-error risk" begin
+    frag = Pioneer.CompactFrag(
+        UInt32(1), 250.0f0, Float16(1000),
+        true, false, false, false,
+        UInt8(1), UInt8(4), UInt8(2), UInt8(1), UInt8(0))
+    unscored = [Pioneer.MainUnscoredPSM{Float32}()]
+
+    Pioneer.apply_main_scoring!(
+        unscored, 1, frag, UInt8(0), 100.0f0, 5.0f0, 3, UInt32(1), 4.0f0, 10.0f0, true)
+    Pioneer.apply_main_scoring!(
+        unscored, 1, frag, UInt8(0), 100.0f0, 20.0f0, 3, UInt32(1), 6.0f0, 10.0f0, true)
+    Pioneer.apply_main_scoring!(
+        unscored, 1, frag, UInt8(1), 100.0f0, 10.0f0, 3, UInt32(1), 100.0f0, 10.0f0, true)
+
+    scratch = Pioneer.FusedScratch(2)
+    Pioneer.push_match!(scratch, 1, 4.0f0, 100.0f0, 0, 1, 0.25f0)
+    Pioneer.push_match!(scratch, 2, 6.0f0, 100.0f0, 0, 1, 1.0f0)
+    Pioneer.record_mass_missing_hellinger!(
+        Pioneer.FusedStandard(Pioneer.FullPrecCapture(), UInt8(7)), unscored, 1, scratch)
+
+    psm = unscored[1]
+    @test psm.pred_int_sum_m0 === 10.0f0
+    @test psm.expected_missing_pred_int_sum_m0 ≈ 7.0f0
+    @test psm.expected_missing_pred_int_sum_m0 / psm.pred_int_sum_m0 ≈ 0.7f0
+
+    scored = Vector{Pioneer.MainSearchScoredPSM{Float32, Float16}}(undef, 1)
+    spectral_scores = [
+        Pioneer.SpectralScoresMainSearch{Float16, Float32}(
+            zero(Float16), zero(Float16), zero(Float16), zero(Float16), zero(Float16),
+            zeros(Float32, 16)...,
+        )
+    ]
+    id_to_col = Pioneer.DensePrecMap{UInt16}(8)
+    id_to_col[UInt32(1)] = UInt16(1)
+    result = Pioneer.Score!(
+        scored, unscored, spectral_scores, Float32[1], id_to_col,
+        1, 1, 1.0, 0, 1, 1000.0f0, 42)
+
+    @test result.last_val == 1
+    @test scored[1].expected_predicted_missing_fraction ≈ 0.7f0
+
+    pred = Float32[4, 6]
+    obs = Float32[100, 100]
+    risk = Float32[0.25, 1]
+    pred_sum = sum(pred)
+    obs_sum = sum(obs)
+    bc_sum = sum(sqrt.(pred .* obs))
+    base_hsq = 1f0 - bc_sum / sqrt(pred_sum * obs_sum)
+    expected_hsq = base_hsq
+    for i in eachindex(pred)
+        obs_without = obs_sum - obs[i]
+        bc_without = bc_sum - sqrt(pred[i] * obs[i])
+        hsq_without = obs_without > 0f0 ? 1f0 - bc_without / sqrt(pred_sum * obs_without) : 1f0
+        expected_hsq += risk[i] * max(hsq_without - base_hsq, 0f0)
+    end
+    expected_hsq = min(max(expected_hsq, 0f0), 1f0)
+    expected_score = -log2(max(expected_hsq, 1f-10))
+    @test scored[1].mass_missing_hellinger ≈ expected_score
 end
 
 @testset "rank 8 fragment trace intensity is captured" begin
@@ -31,7 +91,7 @@ end
     unscored = [Pioneer.MainUnscoredPSM{Float32}()]
 
     Pioneer.apply_main_scoring!(
-        unscored, 1, frag, UInt8(0), 42.0f0, 0.0f0, 3, UInt32(1), 1.0f0, true)
+        unscored, 1, frag, UInt8(0), 42.0f0, 0.0f0, 3, UInt32(1), 1.0f0, 10.0f0, true)
 
     @test unscored[1].frag8_int === 42.0f0
 end

--- a/test/UnitTests/test_fused_prec_filters.jl
+++ b/test/UnitTests/test_fused_prec_filters.jl
@@ -153,13 +153,14 @@ Pioneer.getPrecMaxBound(q::FixedQuadFunc) = q.hi
         s = FusedScratch(4)
         @test s.n == 0 && s.miss_n == 0
 
-        push_match!(s, 7, 1.5f0, 1000.0f0, 0, 3)
+        push_match!(s, 7, 1.5f0, 1000.0f0, 0, 3, 0.25f0)
         @test s.n == 1
         @test s.row[1]     === UInt32(7)
         @test s.nzval[1]   === 1.5f0
         @test s.x[1]       === 1000.0f0
         @test s.isotope[1] === UInt8(0)
         @test s.rank[1]    === UInt8(3)
+        @test s.mass_risk[1] === 0.25f0
 
         push_miss!(s, 0.25f0, 2, 4)
         @test s.miss_n == 1
@@ -169,13 +170,14 @@ Pioneer.getPrecMaxBound(q::FixedQuadFunc) = q.hi
 
         # Force grow on the match buffer (capacity 4 → push 5).
         for k in 2:5
-            push_match!(s, k * 10, Float32(k), Float32(k * 100), k - 1, k)
+            push_match!(s, k * 10, Float32(k), Float32(k * 100), k - 1, k, Float32(k) / 10f0)
         end
         @test s.n == 5
         @test length(s.row) >= 5
         @test s.row[5]     === UInt32(50)
         @test s.isotope[5] === UInt8(4)
         @test s.rank[5]    === UInt8(5)
+        @test s.mass_risk[5] === 0.5f0
 
         # Independent buffers — pushing matches doesn't change miss state.
         @test s.miss_n == 1


### PR DESCRIPTION
## Summary
- Add `expected_predicted_missing_fraction` and `mass_missing_hellinger` to the main-search and cross-run feature sets
- Carry M0 mass-error risk through fused matching via `FusedScratch.mass_risk`
- Compute expected predicted-missing fraction from clipped squared ppm/tolerance risk and compute mass-missing Hellinger once per fused PSM column
- Add focused unit coverage for the mass-risk accumulation, scored feature output, and scratch-buffer growth

## Tests
- `julia --project=. -e 'include("test/UnitTests/test_fragment_isotope_trace_intensities.jl"); include("test/UnitTests/test_fused_prec_filters.jl")'`
- `julia --project=. test/UnitTests/test_run_fused.jl`
- `git diff --check`