### PR TITLE
perf: allocation reductions (fragindex, quant, protein-scoring, type-stability, scoring working-set)

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/HuberTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/HuberTuningSearch/utils.jl
@@ -76,7 +76,7 @@ function perform_huber_calibration_search(
     thread_tasks = partition_scans(spectra, Threads.nthreads(), ms_order_select = 2)
     scan_to_prec = huber_scan_precursor_mapping(calibration_psms)
     precursor_rt_map = huber_precursor_rt_map(calibration_psms)
-    precursor_sets = [Set(calibration_psms[!, :precursor_idx]) for _ in 1:Threads.nthreads()]
+    precursor_set = Set(calibration_psms[!, :precursor_idx])  # shared read-only across threads (was N copies)
 
     tasks = map(thread_tasks) do thread_task
         Threads.@spawn begin
@@ -84,7 +84,7 @@ function perform_huber_calibration_search(
             search_data = getSearchData(search_context)[thread_id]
             return process_huber_calibration_scans!(
                 last(thread_task),
-                precursor_sets[thread_id],
+                precursor_set,
                 precursor_rt_map,
                 scan_to_prec,
                 rt_index,

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
@@ -655,7 +655,7 @@ function extract_chromatograms(
 
     # Pre-create Sets for each thread to avoid concurrent DataFrame access
     # This eliminates race conditions when multiple threads call passing_psms[!, :precursor_idx]
-    precursor_sets = [Set(passing_psms[!, :precursor_idx]) for _ in 1:Threads.nthreads()]
+    precursor_set = Set(passing_psms[!, :precursor_idx])  # shared read-only across threads (was N copies)
 
     # Build precursor RT map for per-precursor symmetric window filtering
     _pids = passing_psms[!, :precursor_idx]::Vector{UInt32}
@@ -674,7 +674,7 @@ function extract_chromatograms(
             return build_chromatograms(
                 spectra,
                 last(thread_task),
-                precursor_sets[thread_id],
+                precursor_set,
                 precursor_rt_map,
                 rt_index,
                 search_context,

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
@@ -29,6 +29,19 @@ function add_psm_features!(psms::DataFrame,
                            search_context::SearchContext,
                            spectra::MassSpecData,
                            ms_file_idx::Integer)
+    # Function barrier: rt_to_irt is an abstract RtConversionModel (per-file
+    # polymorphic), so calling it inside the per-PSM closure dynamically dispatches
+    # and boxes the result every row. Resolve it once here, then run the body in a
+    # method specialized on the concrete model type.
+    rt_to_irt = getRtIrtModel(search_context, ms_file_idx)
+    return _add_psm_features!(psms, search_context, spectra, ms_file_idx, rt_to_irt)
+end
+
+function _add_psm_features!(psms::DataFrame,
+                            search_context::SearchContext,
+                            spectra::MassSpecData,
+                            ms_file_idx::Integer,
+                            rt_to_irt::RtConversionModel)
     precursors_lib   = getPrecursors(getSpecLib(search_context))
     prec_is_decoy    = getIsDecoy(precursors_lib)
     prec_charge      = getCharge(precursors_lib)
@@ -39,7 +52,6 @@ function add_psm_features!(psms::DataFrame,
     prec_missed_clv  = getMissedCleavages(precursors_lib)
     scan_rts         = getRetentionTimes(spectra)
     masses           = getMzArrays(spectra)
-    rt_to_irt        = getRtIrtModel(search_context, ms_file_idx)
 
     N = nrow(psms)
 

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
@@ -600,7 +600,7 @@ function _ms1_lookup_scan_runs!(psms, spectra,
                                 competition_inputs)
     scan_idxs::Vector{UInt32} = psms[!, :scan_idx]
     precursor_idxs::Vector{UInt32} = psms[!, :precursor_idx]
-    log2_intensity_explained = psms[!, :log2_intensity_explained]
+    log2_intensity_explained::Vector{Float16} = psms[!, :log2_intensity_explained]
 
     ms1_m0_mass_err_ppm::Vector{Float32} = psms[!, :ms1_m0_mass_err_ppm]
     ms1_m0_intensity::Vector{Float32} = psms[!, :ms1_m0_intensity]
@@ -1037,13 +1037,19 @@ function _add_ms1_chromatogram_features!(psms::DataFrame;
             irt_apex_w  = v_irt[ai_w]
             weight_apex_to_m0 = abs(irt_apex_w - irt_apex_m0)
 
-            # Scatter outputs back to original row indices
+            # Scatter outputs back to original row indices. Bind the columns to
+            # typed locals first — `psms.col` is type-unstable, so writing through
+            # it boxes a value per row.
+            out_wm0  = psms.ms1_corr_weight_m0::Vector{Float32}
+            out_m01  = psms.ms1_corr_m0_m1::Vector{Float32}
+            out_aoff = psms.ms1_apex_offset_irt::Vector{Float32}
+            out_w2m0 = psms.ms1_weight_apex_to_m0_apex_irt::Vector{Float32}
             for k in 1:npts
                 i_orig = perm[i_start + k - 1]
-                psms.ms1_corr_weight_m0[i_orig]             = c_wm0
-                psms.ms1_corr_m0_m1[i_orig]                 = c_m01
-                psms.ms1_apex_offset_irt[i_orig]            = abs(v_irt[k] - irt_apex_m0)
-                psms.ms1_weight_apex_to_m0_apex_irt[i_orig] = weight_apex_to_m0
+                out_wm0[i_orig]  = c_wm0
+                out_m01[i_orig]  = c_m01
+                out_aoff[i_orig] = abs(v_irt[k] - irt_apex_m0)
+                out_w2m0[i_orig] = weight_apex_to_m0
             end
         end
     end
@@ -1463,16 +1469,25 @@ function _add_fragment_chromatogram_features!(psms::DataFrame;
                 end
             end
 
-            # Scatter outputs to original row indices
+            # Scatter outputs to original row indices. Bind the columns to typed
+            # locals first — `psms.col` is type-unstable, so writing through it
+            # boxes a value per row.
+            out_disp   = psms.frag_apex_dispersion_irt::Vector{Float32}
+            out_ncorr  = psms.n_correlated_fragments::Vector{UInt8}
+            out_rank   = psms.n_correlated_fragments_bitvec_rank::Vector{UInt16}
+            out_str    = psms.frag_corr_strength::Vector{Float32}
+            out_effn   = psms.frag_corr_effective_n::Vector{Float32}
+            out_bestm0 = psms.frag_corr_best_m0::Vector{Float32}
+            out_dframe = psms.delta_frame_peak_center::Vector{Float32}
             for k in 1:npts
                 i_orig = perm[i_start + k - 1]
-                psms.frag_apex_dispersion_irt[i_orig] = apex_disp
-                psms.n_correlated_fragments[i_orig]    = n_corr_70
-                psms.n_correlated_fragments_bitvec_rank[i_orig] = corr_rank
-                psms.frag_corr_strength[i_orig]        = corr_strength
-                psms.frag_corr_effective_n[i_orig]     = corr_effective_n
-                psms.frag_corr_best_m0[i_orig]         = c_best_m0
-                psms.delta_frame_peak_center[i_orig]   = delta_frame
+                out_disp[i_orig]   = apex_disp
+                out_ncorr[i_orig]  = n_corr_70
+                out_rank[i_orig]   = corr_rank
+                out_str[i_orig]    = corr_strength
+                out_effn[i_orig]   = corr_effective_n
+                out_bestm0[i_orig] = c_best_m0
+                out_dframe[i_orig] = delta_frame
             end
         end
     end

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/score_psms.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/score_psms.jl
@@ -391,6 +391,8 @@ function _score_precursor_isotope_traces_no_mbr(
     end
 
     write_scored_psms_to_files!(best_psms, file_paths)
+    best_psms = DataFrame()  # drop full-experiment table before returning (mirrors MBR path)
+    GC.gc()
     return nothing
 end
 

--- a/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/protein_inference_pipeline.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/protein_inference_pipeline.jl
@@ -403,16 +403,78 @@ end
 end
 
 """
-    _build_protein_rollup(gdf, quant_mask, prob_col)
+Reusable scratch for `_build_protein_rollup`. One dedup `Dict` per roll-up level
+(precursor_idx / mod-key / sequence -> row index) plus parallel arrays for the
+fields, all reused across protein groups via `_reset_rollup_scratch!` (so the
+14 `Dict`s previously allocated per group become 3 reused dedup `Dict`s + reused
+arrays). The dedup `Dict`s are used only for lookup, never iterated, so output
+order is the deterministic first-seen (array) order — independent of `Dict`
+capacity, hence stable across runs.
+"""
+mutable struct ProteinRollupScratch
+    # precursor level (dedup by precursor_idx)
+    prec_pos::Dict{UInt32, Int}
+    prec_id::Vector{UInt32}
+    prec_prob::Vector{Float32}
+    prec_peak::Vector{Float32}
+    prec_basepep::Vector{UInt32}
+    prec_seq::Vector{String}
+    prec_charge::Vector{UInt8}
+    prec_smods::Vector{String}
+    prec_imods::Vector{String}
+    # modified-peptide level (dedup by (base_pep_id, structural_mods, isotopic_mods))
+    mod_pos::Dict{Tuple{UInt32, String, String}, Int}
+    mod_key::Vector{Tuple{UInt32, String, String}}
+    mod_logsum::Vector{Float64}
+    mod_peak::Vector{Float32}
+    mod_seq::Vector{String}
+    mod_count::Vector{Int32}
+    # peptide level (dedup by sequence)
+    pep_pos::Dict{String, Int}
+    pep_seq::Vector{String}
+    pep_logsum::Vector{Float64}
+    pep_peak::Vector{Float32}
+    pep_count::Vector{Int32}
+end
+
+ProteinRollupScratch() = ProteinRollupScratch(
+    Dict{UInt32, Int}(), UInt32[], Float32[], Float32[], UInt32[], String[], UInt8[], String[], String[],
+    Dict{Tuple{UInt32, String, String}, Int}(), Tuple{UInt32, String, String}[], Float64[], Float32[], String[], Int32[],
+    Dict{String, Int}(), String[], Float64[], Float32[], Int32[],
+)
+
+function _reset_rollup_scratch!(s::ProteinRollupScratch)
+    empty!(s.prec_pos); empty!(s.prec_id); empty!(s.prec_prob); empty!(s.prec_peak)
+    empty!(s.prec_basepep); empty!(s.prec_seq); empty!(s.prec_charge)
+    empty!(s.prec_smods); empty!(s.prec_imods)
+    empty!(s.mod_pos); empty!(s.mod_key); empty!(s.mod_logsum)
+    empty!(s.mod_peak); empty!(s.mod_seq); empty!(s.mod_count)
+    empty!(s.pep_pos); empty!(s.pep_seq); empty!(s.pep_logsum)
+    empty!(s.pep_peak); empty!(s.pep_count)
+    return s
+end
+
+@inline function _rollup_mods_or_empty(gdf, col::Symbol, i::Int)
+    (hasproperty(gdf, col) && !ismissing(gdf[!, col][i])) ? String(gdf[!, col][i]) : ""
+end
+
+"""
+    _build_protein_rollup(gdf, quant_mask, prob_col[, scratch])
 
 Roll up precursor-level probability evidence to modified peptides, then
 peptides, and return the peptide-level protein score plus reusable
-intermediate rows.
+intermediate rows. Output rows are emitted in first-seen (deterministic) order.
+The 3-arg form allocates a fresh `ProteinRollupScratch`; pass a reused one (4-arg)
+to avoid per-group allocation.
 """
+_build_protein_rollup(gdf::AbstractDataFrame, quant_mask::AbstractVector{Bool}, prob_col::Symbol) =
+    _build_protein_rollup(gdf, quant_mask, prob_col, ProteinRollupScratch())
+
 function _build_protein_rollup(
     gdf::AbstractDataFrame,
     quant_mask::AbstractVector{Bool},
-    prob_col::Symbol
+    prob_col::Symbol,
+    s::ProteinRollupScratch,
 )
     if !hasproperty(gdf, prob_col)
         error("Missing required $(prob_col) column for protein roll-up")
@@ -424,14 +486,9 @@ function _build_protein_rollup(
         error("Missing required :base_pep_id column for protein roll-up")
     end
 
-    prob_by_precursor = Dict{UInt32, Float32}()
-    best_peak_area_by_precursor = Dict{UInt32, Float32}()
-    base_pep_id_by_precursor = Dict{UInt32, UInt32}()
-    sequence_by_precursor = Dict{UInt32, String}()
-    charge_by_precursor = Dict{UInt32, UInt8}()
-    structural_mods_by_precursor = Dict{UInt32, String}()
-    isotopic_mods_by_precursor = Dict{UInt32, String}()
+    _reset_rollup_scratch!(s)
 
+    # Precursor level: dedup by precursor_idx into parallel arrays (first-seen order).
     @inbounds for i in eachindex(quant_mask)
         quant_mask[i] || continue
 
@@ -439,42 +496,43 @@ function _build_protein_rollup(
         prob_val = _sanitize_rollup_probability(gdf[!, prob_col][i])
         peak_area_val = Float32(gdf.peak_area[i])
 
-        if haskey(prob_by_precursor, precursor_idx)
-            prob_by_precursor[precursor_idx] = max(prob_by_precursor[precursor_idx], prob_val)
-            if peak_area_val > best_peak_area_by_precursor[precursor_idx]
-                best_peak_area_by_precursor[precursor_idx] = peak_area_val
-            end
+        pos = get(s.prec_pos, precursor_idx, 0)
+        if pos == 0
+            push!(s.prec_id, precursor_idx)
+            push!(s.prec_prob, prob_val)
+            push!(s.prec_peak, peak_area_val)
+            push!(s.prec_basepep, UInt32(gdf.base_pep_id[i]))
+            push!(s.prec_seq, String(gdf.sequence[i]))
+            push!(s.prec_charge, hasproperty(gdf, :charge) ? UInt8(gdf.charge[i]) : UInt8(0))
+            push!(s.prec_smods, _rollup_mods_or_empty(gdf, :structural_mods, i))
+            push!(s.prec_imods, _rollup_mods_or_empty(gdf, :isotopic_mods, i))
+            s.prec_pos[precursor_idx] = length(s.prec_id)
         else
-            prob_by_precursor[precursor_idx] = prob_val
-            best_peak_area_by_precursor[precursor_idx] = peak_area_val
-            base_pep_id_by_precursor[precursor_idx] = UInt32(gdf.base_pep_id[i])
-            sequence_by_precursor[precursor_idx] = String(gdf.sequence[i])
-            charge_by_precursor[precursor_idx] =
-                hasproperty(gdf, :charge) ? UInt8(gdf.charge[i]) : UInt8(0)
-            structural_mods_by_precursor[precursor_idx] =
-                hasproperty(gdf, :structural_mods) && !ismissing(gdf.structural_mods[i]) ? String(gdf.structural_mods[i]) : ""
-            isotopic_mods_by_precursor[precursor_idx] =
-                hasproperty(gdf, :isotopic_mods) && !ismissing(gdf.isotopic_mods[i]) ? String(gdf.isotopic_mods[i]) : ""
+            s.prec_prob[pos] = max(s.prec_prob[pos], prob_val)
+            if peak_area_val > s.prec_peak[pos]
+                s.prec_peak[pos] = peak_area_val
+            end
         end
     end
 
+    nprec = length(s.prec_id)
     precursor_rows = ProteinRollupPrecursorRow[]
-    sizehint!(precursor_rows, length(prob_by_precursor))
-    for precursor_idx in keys(prob_by_precursor)
-        prob_val = prob_by_precursor[precursor_idx]
+    sizehint!(precursor_rows, nprec)
+    @inbounds for p in 1:nprec
+        prob_val = s.prec_prob[p]
         none_prob_val = Float32(1.0f0 - prob_val)
         score_val = Float32(-log(none_prob_val))
         push!(precursor_rows, (
-            precursor_idx = precursor_idx,
-            base_pep_id = base_pep_id_by_precursor[precursor_idx],
-            sequence = sequence_by_precursor[precursor_idx],
-            charge = charge_by_precursor[precursor_idx],
-            structural_mods = structural_mods_by_precursor[precursor_idx],
-            isotopic_mods = isotopic_mods_by_precursor[precursor_idx],
+            precursor_idx = s.prec_id[p],
+            base_pep_id = s.prec_basepep[p],
+            sequence = s.prec_seq[p],
+            charge = s.prec_charge[p],
+            structural_mods = s.prec_smods[p],
+            isotopic_mods = s.prec_imods[p],
             pep = none_prob_val,
             prob = prob_val,
             score = score_val,
-            best_peak_area = best_peak_area_by_precursor[precursor_idx]
+            best_peak_area = s.prec_peak[p]
         ))
     end
 
@@ -490,67 +548,83 @@ function _build_protein_rollup(
         )
     end
 
-    modified_log_none_sum = Dict{Tuple{UInt32, String, String}, Float64}()
-    modified_best_peak_area = Dict{Tuple{UInt32, String, String}, Float32}()
-    modified_sequence = Dict{Tuple{UInt32, String, String}, String}()
-    modified_precursor_count = Dict{Tuple{UInt32, String, String}, Int32}()
-
+    # Modified-peptide level: dedup by (base_pep_id, structural_mods, isotopic_mods).
     for precursor_row in precursor_rows
         mod_key = (
             precursor_row.base_pep_id,
             precursor_row.structural_mods,
             precursor_row.isotopic_mods
         )
-        modified_log_none_sum[mod_key] = get(modified_log_none_sum, mod_key, 0.0) + _precursor_log_none_for_rollup(precursor_row.prob)
-        modified_best_peak_area[mod_key] = max(
-            get(modified_best_peak_area, mod_key, 0.0f0),
-            precursor_row.best_peak_area
-        )
-        modified_sequence[mod_key] = precursor_row.sequence
-        modified_precursor_count[mod_key] = get(modified_precursor_count, mod_key, Int32(0)) + Int32(1)
+        log_none = _precursor_log_none_for_rollup(precursor_row.prob)
+        mpos = get(s.mod_pos, mod_key, 0)
+        if mpos == 0
+            push!(s.mod_key, mod_key)
+            push!(s.mod_logsum, log_none)
+            push!(s.mod_peak, precursor_row.best_peak_area)
+            push!(s.mod_seq, precursor_row.sequence)
+            push!(s.mod_count, Int32(1))
+            s.mod_pos[mod_key] = length(s.mod_key)
+        else
+            s.mod_logsum[mpos] += log_none
+            if precursor_row.best_peak_area > s.mod_peak[mpos]
+                s.mod_peak[mpos] = precursor_row.best_peak_area
+            end
+            s.mod_seq[mpos] = precursor_row.sequence
+            s.mod_count[mpos] += Int32(1)
+        end
     end
 
+    nmod = length(s.mod_key)
     modified_peptide_rows = ProteinRollupModifiedPeptideRow[]
-    sizehint!(modified_peptide_rows, length(modified_log_none_sum))
-    for (mod_key, log_none_sum) in modified_log_none_sum
+    sizehint!(modified_peptide_rows, nmod)
+    @inbounds for m in 1:nmod
+        log_none_sum = s.mod_logsum[m]
         push!(modified_peptide_rows, (
-            base_pep_id = mod_key[1],
-            sequence = modified_sequence[mod_key],
-            structural_mods = mod_key[2],
-            isotopic_mods = mod_key[3],
+            base_pep_id = s.mod_key[m][1],
+            sequence = s.mod_seq[m],
+            structural_mods = s.mod_key[m][2],
+            isotopic_mods = s.mod_key[m][3],
             log_none_sum = log_none_sum,
             pep = _none_probability_from_log_none_sum(log_none_sum),
             prob = _probability_from_log_none_sum(log_none_sum),
             score = _score_from_log_none_sum(log_none_sum),
-            best_peak_area = modified_best_peak_area[mod_key],
-            precursor_count = modified_precursor_count[mod_key]
+            best_peak_area = s.mod_peak[m],
+            precursor_count = s.mod_count[m]
         ))
     end
-    peptide_log_none_sum = Dict{String, Float64}()
-    peptide_best_peak_area = Dict{String, Float32}()
-    peptide_modified_count = Dict{String, Int32}()
 
+    # Peptide level: dedup by sequence.
     for modified_row in modified_peptide_rows
         peptide_key = modified_row.sequence
-        peptide_log_none_sum[peptide_key] = get(peptide_log_none_sum, peptide_key, 0.0) + modified_row.log_none_sum
-        peptide_best_peak_area[peptide_key] = max(
-            get(peptide_best_peak_area, peptide_key, 0.0f0),
-            modified_row.best_peak_area
-        )
-        peptide_modified_count[peptide_key] = get(peptide_modified_count, peptide_key, Int32(0)) + Int32(1)
+        ppos = get(s.pep_pos, peptide_key, 0)
+        if ppos == 0
+            push!(s.pep_seq, peptide_key)
+            push!(s.pep_logsum, modified_row.log_none_sum)
+            push!(s.pep_peak, modified_row.best_peak_area)
+            push!(s.pep_count, Int32(1))
+            s.pep_pos[peptide_key] = length(s.pep_seq)
+        else
+            s.pep_logsum[ppos] += modified_row.log_none_sum
+            if modified_row.best_peak_area > s.pep_peak[ppos]
+                s.pep_peak[ppos] = modified_row.best_peak_area
+            end
+            s.pep_count[ppos] += Int32(1)
+        end
     end
 
+    npep = length(s.pep_seq)
     peptide_rows = ProteinRollupPeptideRow[]
-    sizehint!(peptide_rows, length(peptide_log_none_sum))
-    for (sequence, log_none_sum) in peptide_log_none_sum
+    sizehint!(peptide_rows, npep)
+    @inbounds for q in 1:npep
+        log_none_sum = s.pep_logsum[q]
         push!(peptide_rows, (
-            sequence = sequence,
+            sequence = s.pep_seq[q],
             log_none_sum = log_none_sum,
             pep = _none_probability_from_log_none_sum(log_none_sum),
             prob = _probability_from_log_none_sum(log_none_sum),
             score = _score_from_log_none_sum(log_none_sum),
-            best_peak_area = peptide_best_peak_area[sequence],
-            modified_peptide_count = peptide_modified_count[sequence]
+            best_peak_area = s.pep_peak[q],
+            modified_peptide_count = s.pep_count[q]
         ))
     end
     pg_score = isempty(peptide_rows) ? 0.0f0 : Float32(sum(row.score for row in peptide_rows))
@@ -652,6 +726,7 @@ function build_precursor_consensus(
     protein_run_votes = Dict{Tuple{String, Bool, UInt8}, Vector{ConsensusRunVote}}()
     protein_observed_run_count = Dict{Tuple{String, Bool, UInt8}, Int32}()
     max_candidate_runs = _consensus_candidate_runs_to_keep(length(psm_refs))
+    rollup_scratch = ProteinRollupScratch()   # reused across all groups (sequential loop)
 
     for (run_order, psm_ref) in enumerate(psm_refs)
         if !exists(psm_ref)
@@ -663,7 +738,7 @@ function build_precursor_consensus(
 
         for gdf in groupby(df, [:inferred_protein_group, :target, :entrap_id])
             quant_mask = _protein_rollup_quant_mask(gdf; q_value_threshold = q_value_threshold)
-            rollup = _build_protein_rollup(gdf, quant_mask, prob_col)
+            rollup = _build_protein_rollup(gdf, quant_mask, prob_col, rollup_scratch)
 
             if isempty(rollup.precursor_rows)
                 continue
@@ -1119,11 +1194,16 @@ function group_psms_by_protein(
     prob_col = _protein_group_probability_column(df)
     # Group by protein
     grouped = groupby(df, [:inferred_protein_group, :target, :entrap_id])
-    
-    # Aggregate to protein groups
+
+    # Aggregate to protein groups. combine() runs the do-block multi-threaded
+    # (threads=true default), so use one scratch per thread. The do-block is pure
+    # compute (no yield/I/O), so the task does not migrate threads and threadid()
+    # is stable for the call; sized by maxthreadid() (threadid() can exceed
+    # nthreads() with an interactive threadpool).
+    rollup_scratches = [ProteinRollupScratch() for _ in 1:Threads.maxthreadid()]
     protein_groups = combine(grouped) do gdf
         quant_mask = _protein_rollup_quant_mask(gdf; q_value_threshold = q_value_threshold)
-        rollup = _build_protein_rollup(gdf, quant_mask, prob_col)
+        rollup = _build_protein_rollup(gdf, quant_mask, prob_col, rollup_scratches[Threads.threadid()])
         n_peptides = rollup.n_peptides
         pg_score = rollup.pg_score
         top_pep_peak_area = rollup.top_pep_peak_area

--- a/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/run_protein_scoring.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/run_protein_scoring.jl
@@ -35,17 +35,30 @@ function count_protein_peptides(precursors::LibraryPrecursors)
     all_entrap_ids = getEntrapmentGroupId(precursors)
     n_precursors = length(all_accession_numbers)
 
+    # Each precursor's sequence must be added to its protein(s)' peptide set, so rows
+    # can't be skipped wholesale — but the (accession_string, target, entrap_id) tuple
+    # repeats across the ~6.8M precursors (only ~tens of thousands are distinct). Cache
+    # the destination Set vector per distinct tuple: a cache hit skips the split, the
+    # per-token String() interning, and the NamedTuple-key dict lookups, leaving only
+    # the unavoidable push! of the sequence. Bit-identical (same sets, same members).
+    set_cache = Dict{Tuple{String, Bool, UInt8}, Vector{Set{String}}}()
     for i in 1:n_precursors
-        protein_names = split(all_accession_numbers[i], ';')
         is_decoy = all_decoys[i]
         entrap_id = all_entrap_ids[i]
+        target = !is_decoy
 
-        for protein_name in protein_names
-            key = (protein_name = String(protein_name), target = !is_decoy, entrap_id = entrap_id)
-            if !haskey(protein_to_possible_peptides, key)
-                protein_to_possible_peptides[key] = Set{String}()
+        target_sets = get!(set_cache, (all_accession_numbers[i], target, entrap_id)) do
+            sets = Vector{Set{String}}()
+            for protein_name in split(all_accession_numbers[i], ';')
+                key = (protein_name = String(protein_name), target = target, entrap_id = entrap_id)
+                push!(sets, get!(() -> Set{String}(), protein_to_possible_peptides, key))
             end
-            push!(protein_to_possible_peptides[key], all_sequences[i])
+            sets
+        end
+
+        seq = all_sequences[i]
+        for s in target_sets
+            push!(s, seq)
         end
     end
 

--- a/src/Routines/SearchDIA/process_scans_fused.jl
+++ b/src/Routines/SearchDIA/process_scans_fused.jl
@@ -94,7 +94,11 @@ function process_scans_fused!(
         # previously a closure (`_run_subset!`) defined inside the loop and called
         # once per scan, which allocated a capture object every iteration and boxed
         # the reassigned `last_val`. Inlining preserves the exact control flow.
-        sub_indices = collect(Int64, prec_range)
+        # Pass the precursor range directly. `prec_range` is a UnitRange{Int64}
+        # (non-missing guaranteed by the ismissing guard above); run_fused! only
+        # iterates it, so the previous `collect(Int64, ...)` per-scan Vector was
+        # pure waste (~0.2 GB/file). Type-assert narrows the Union for dispatch.
+        sub_indices = prec_range::UnitRange{Int64}
         if !isempty(sub_indices)
             nmatches, nmisses = run_fused!(
                 kind,

--- a/src/structs/RetentionTimeConversionModel.jl
+++ b/src/structs/RetentionTimeConversionModel.jl
@@ -34,8 +34,11 @@ struct SplineRtConversionModel <: RtConversionModel
 end
 (s::SplineRtConversionModel)(x::AbstractFloat) = s.model(x)
 
-struct InterpolationRtConversionModel <: RtConversionModel
-    model::Interpolations.Extrapolation
+# Parametrized on the concrete extrapolation type: an abstract
+# `model::Interpolations.Extrapolation` field made `s.model(x)` type-unstable,
+# boxing a value on every RT->iRT conversion (millions per file).
+struct InterpolationRtConversionModel{M<:Interpolations.Extrapolation} <: RtConversionModel
+    model::M
 end
 (s::InterpolationRtConversionModel)(x::AbstractFloat) = s.model(x)
 

--- a/src/structs/SpectralLibrary/PartitionedFragmentIndex/search.jl
+++ b/src/structs/SpectralLibrary/PartitionedFragmentIndex/search.jl
@@ -411,7 +411,12 @@ function searchFragmentIndexPartitionMajorHinted(
     partition_to_scans = _build_partition_scan_mapping(pfi, scan_prec_min, scan_prec_max, n_scans)
 
     # ── 3. Per-thread buffers (reused via FragIndexScratch when supplied) ──
-    est_per_thread = max(n_scans * 200, 100_000)
+    # Per-thread initial guess: n_scans*200 estimates TOTAL emitted candidates,
+    # but each thread only handles a fraction, so divide by n_threads. The emit
+    # buffers grow in place (doubling) if a thread exceeds this, and FragIndexScratch
+    # is grow-only across files, so a low first-file guess self-corrects to the
+    # true high-water-mark. Avoids ~3-20x per-thread over-provisioning (worst on SCP).
+    est_per_thread = max(div(n_scans * 200, n_threads), 100_000)
     max_local = maximum(p -> Int(p.n_local_precs), getPartitions(pfi); init=0)
     int_buf_size = max_peaks > 0 ?
         maximum(si -> length(getMzArray(spectra, all_scan_idxs[si])),

--- a/src/utils/maxLFQ.jl
+++ b/src/utils/maxLFQ.jl
@@ -649,17 +649,28 @@ function build_accession_to_species(precursors)
     accs = getAccessionNumbers(precursors)
     proteomes = getProteomeIdentifiers(precursors)
     accession_to_species = Dict{String, String}()
+    # 6.8M precursors map to only ~tens of thousands of distinct accession strings,
+    # so memoize processed strings and skip duplicates wholesale — avoids re-splitting
+    # and re-interning for the ~99.5% of rows that repeat. Bit-identical: a repeated
+    # accession string yields the same tokens, and get!/first-wins means re-processing
+    # cannot change the dict. `haskey` on a SubString is allocation-free, so tokens are
+    # interned only on genuine insert. `seen` is updated only after the length guard
+    # passes, so a row first seen with a mismatched proteome string can still be
+    # processed later with a matching one.
+    seen = Set{String}()
     @inbounds for i in eachindex(accs, proteomes)
-        a_str = String(accs[i])
-        p_str = String(proteomes[i])
+        a_str = accs[i]
+        (a_str in seen) && continue
+        p_str = proteomes[i]
         a_toks = split(a_str, ';')
         p_toks = split(p_str, ';')
         length(a_toks) == length(p_toks) || continue
+        push!(seen, String(a_str))
         for k in eachindex(a_toks)
-            ak = String(a_toks[k])
-            pk = String(p_toks[k])
+            ak = a_toks[k]
             isempty(ak) && continue
-            get!(accession_to_species, ak, pk)
+            haskey(accession_to_species, ak) && continue
+            accession_to_species[String(ak)] = String(p_toks[k])
         end
     end
     return accession_to_species


### PR DESCRIPTION
Allocation / performance optimizations from the recent profiling effort, cherry-picked clean onto `develop`. **No diagnostics, no design docs** — only the verified perf changes (the env-gated `PIONEER_DIAG_*` scaffolding and the investigation PDFs/tex were deliberately left off this branch).

## Changes (8 commits)
| Commit | What | Win |
|---|---|---|
| `b12c96e` | fragindex: size per-thread emit buffer by `candidates/n_threads` | −3.4 GB on 3-file SCP; bit-identical |
| `4f92414` | mainsearch: drop per-scan `collect()` of precursor range (pass `UnitRange` directly) | −0.2 GB/file, scales with scans×files; bit-identical |
| `3196a39` | quant: dedup accession strings in `build_accession_to_species` | 3.06→0.24 GB (−92%) on the build; bit-identical |
| `d88c0f4` | protein-scoring: per-tuple set-list cache in `count_protein_peptides` | 2.04→0.92 GB (−55%) on the build; bit-identical |
| `570570` | protein: reusable scratch in `_build_protein_rollup` (14 Dicts/group → 3 + arrays) | per-group allocation cut; ID-neutral (see verification) |
| `1705bd6` | mainsearch: type-stabilize `features.jl` hot column reads/writes | latency; bit-identical |
| `12ab1a9` | mainsearch: type-stabilize rt→iRT conversion (parametrize model + function barrier) | latency; bit-identical |
| `2989d84` | scoring: share precursor `Set` across threads + free `best_psms` (working-set Stage 0) | removes per-thread Set duplication (scales with thread count) + frees the no-MBR experiment table earlier; bit-identical |

## Verification (1-file MTAC, vs `develop`)
- **Precursor table byte-identical**; identical IDs/counts (102,623 precursors, 11,065 protein groups — none added/removed).
- The only value difference is in protein-group score columns (`pg_score`/`pg_qval`/`pg_pep`), max |Δ| ≈ **1.5e-4** — float reassociation from the `_build_protein_rollup` scratch reuse (`570570`). **ID-neutral.**
- Each of the other 7 commits was verified byte-identical (or measured) individually; cumulatively the precursor output is unchanged.

If strict byte-identity to `develop` is preferred over the `_build_protein_rollup` allocation win, that one commit (`570570`) can be dropped — everything else is fully byte-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)