### PR TITLE
[codex] Speed up flanking feature computation

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/MainSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/MainSearch.jl
@@ -23,7 +23,7 @@ Fragment index search, spectral deconvolution, and LightGBM prescore search.
 Pipeline:
 1. process_file!: Run fragment index search, deconvolve with prescore fragment settings
 2. process_search_results!: Compute prescore features, train LightGBM, select best scan per precursor
-3. summarize_results!: Global prescore aggregation, write fold-split second_pass_psms for ScoringSearch
+3. summarize_results!: Global prescore aggregation, register fold-split second_pass_psms for ScoringSearch
 """
 # Per-file PEP threshold applied to best-per-precursor PSMs. Precursors with
 # PEP > MAIN_PEP_FILTER_THR are dropped before being written to the second-pass
@@ -446,13 +446,28 @@ function process_search_results!(
     # Drop vector columns that can't be serialized to Arrow
     dropVectorColumns!(best_psms)
 
-    # Write per-fold main_search_psms (used by both aggregate_prescore_globally! and summarize_results!)
     precursors = getPrecursors(getSpecLib(search_context))
+    frag_lookup = getFragmentLookupTable(getSpecLib(search_context))
+    nce_model = getNceModel(search_context, ms_file_idx)
+    add_wide_window_features_to_table!(
+        best_psms,
+        spectra,
+        search_context,
+        ms_file_idx,
+        precursors,
+        frag_lookup,
+        nce_model,
+    )
+
+    # Write per-fold main_search_psms.
     main_search_psms_dir = joinpath(getDataOutDir(search_context), "temp_data", "main_search_psms")
     best_cv_fold = UInt8[getCvFold(precursors, pid) for pid in best_psms.precursor_idx]
     for fold in UInt8[0, 1]
         fold_mask = best_cv_fold .== fold
-        any(fold_mask) && writeArrow(joinpath(main_search_psms_dir, "$(file_name)_fold$(fold).arrow"), best_psms[fold_mask, :])
+        if any(fold_mask)
+            fold_path = joinpath(main_search_psms_dir, "$(file_name)_fold$(fold).arrow")
+            writeArrow(fold_path, best_psms[fold_mask, :])
+        end
     end
     t_write = time()
 
@@ -478,7 +493,7 @@ function process_search_results!(
                "    features=$(r(dur_features))s [prep=$(r(t_prepare))s competition=$(r(t_competition))s ms1=$(r(t_ms1))s]\n" *
                "    lgbm=$(r(dur_lgbm))s [train_cv=$(r(lgbm_timings.train_cv))s best_per_prec=$(r(lgbm_timings.best))s]  " *
                "pep_filter=$(r(dur_pep))s\n" *
-               "    recal=$(r(dur_recal))s  phase2=$(r(dur_phase2))s  write=$(r(dur_write))s  " *
+               "    recal=$(r(dur_recal))s  phase2=$(r(dur_phase2))s  fold_write+flanking=$(r(dur_write))s  " *
                "overhead=$(r(dur_overhead))s"
 
     return nothing

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/PrecursorScoringSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/PrecursorScoringSearch.jl
@@ -196,8 +196,6 @@ function summarize_results!(
         return nothing
     end
 
-    add_wide_window_features_to_fold_files!(search_context, Int.(valid_file_indices))
-
     step1_time = @elapsed begin
         max_psms = estimate_max_rows(params.max_psm_memory_mb, first(valid_fold_paths))
         @debug_l1 "Memory budget $(params.max_psm_memory_mb) MB → max_psms = $max_psms"

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/wide_window_features.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/wide_window_features.jl
@@ -1,5 +1,11 @@
 const WIDE_WINDOW_CYCLE_MARGIN = 3
 const FLANKING_SCAN_CENTRIC_BATCH_SIZE = 50000
+const FLANKING_WINDOW_TEMP_COLUMNS = [
+    :flanking_core_scan_min,
+    :flanking_core_scan_max,
+    :flanking_core_ms1_m0_signal,
+    :flanking_core_frag_signal,
+]
 
 @inline function _wide_window_pcor(x::AbstractVector, y::AbstractVector)
     n = length(x)
@@ -570,7 +576,10 @@ function _wide_fill_scan_centric_ms1_m0!(
     spectra,
     ms1_ppm_tol::Float32,
 )
-    for (ms1_i32, work_items) in ms1_work
+    ms1_keys = collect(keys(ms1_work))
+    Threads.@threads for key_idx in eachindex(ms1_keys)
+        ms1_i32 = ms1_keys[key_idx]
+        work_items = ms1_work[ms1_i32]
         mz = getMzArray(spectra, Int(ms1_i32))
         intensities = getIntensityArray(spectra, Int(ms1_i32))
 
@@ -594,19 +603,24 @@ function _wide_fill_scan_centric_fragments!(
     frag_list,
     frag_mem::AbstractMassErrorModel,
 )
-    scan_corrected_mz = Float32[]
-    scan_obs_low = Float32[]
-    scan_obs_high = Float32[]
+    scan_keys = collect(keys(ms2_work))
+    max_thread_id = Threads.maxthreadid()
+    scan_corrected_mz = [Float32[] for _ in 1:max_thread_id]
+    scan_obs_low = [Float32[] for _ in 1:max_thread_id]
+    scan_obs_high = [Float32[] for _ in 1:max_thread_id]
 
-    for (scan_i32, work_items) in ms2_work
+    Threads.@threads for key_idx in eachindex(scan_keys)
+        scan_i32 = scan_keys[key_idx]
+        work_items = ms2_work[scan_i32]
         scan_idx = Int(scan_i32)
         mz = getMzArray(spectra, scan_idx)
         intensities = getIntensityArray(spectra, scan_idx)
         scan_rt = Float32(getRetentionTime(spectra, scan_idx))
+        thread_idx = Threads.threadid()
         n_peaks = prepare_scan_peaks!(
-            scan_corrected_mz,
-            scan_obs_low,
-            scan_obs_high,
+            scan_corrected_mz[thread_idx],
+            scan_obs_low[thread_idx],
+            scan_obs_high[thread_idx],
             frag_mem,
             mz,
             intensities,
@@ -628,12 +642,12 @@ function _wide_fill_scan_centric_fragments!(
             start_idx = 1
             for s in 1:n_frags
                 start_idx = bsearch_hybrid(
-                    scan_corrected_mz, sorted_lows[s], start_idx, n_peaks,
+                    scan_corrected_mz[thread_idx], sorted_lows[s], start_idx, n_peaks,
                 )
                 best_peak, _, _ = scan_for_nearest_in_window(
-                    scan_corrected_mz,
-                    scan_obs_low,
-                    scan_obs_high,
+                    scan_corrected_mz[thread_idx],
+                    scan_obs_low[thread_idx],
+                    scan_obs_high[thread_idx],
                     start_idx,
                     n_peaks,
                     sorted_targets[s],
@@ -646,6 +660,22 @@ function _wide_fill_scan_centric_fragments!(
                 end
             end
         end
+    end
+    return nothing
+end
+
+function _wide_reduce_scan_centric_group_batch!(columns, groups, bitvec_rank_table)
+    Threads.@threads for group_idx in eachindex(groups)
+        group = groups[group_idx]
+        features = _wide_flank_feature_values(
+            group.core_ms1_m0_signal,
+            group.core_frag_signal,
+            group.core_fragments,
+            group.ms1_m0,
+            group.fragments;
+            bitvec_rank_table = bitvec_rank_table,
+        )
+        _wide_scatter_features!(columns, group.group_start, group.group_stop, features)
     end
     return nothing
 end
@@ -675,17 +705,7 @@ function _wide_flush_scan_centric_group_batch!(
         frag_mem,
     )
 
-    @inbounds for group in groups
-        features = _wide_flank_feature_values(
-            group.core_ms1_m0_signal,
-            group.core_frag_signal,
-            group.core_fragments,
-            group.ms1_m0,
-            group.fragments;
-            bitvec_rank_table = bitvec_rank_table,
-        )
-        _wide_scatter_features!(columns, group.group_start, group.group_stop, features)
-    end
+    _wide_reduce_scan_centric_group_batch!(columns, groups, bitvec_rank_table)
     empty!(groups)
     empty!(ms1_work)
     empty!(ms2_work)
@@ -707,16 +727,15 @@ function _wide_scatter_features!(columns, group_start::Int, group_stop::Int, fea
     return nothing
 end
 
-function add_wide_window_features_to_fold_file!(
-    fpath::String,
+function add_wide_window_features_to_table!(
+    tbl::DataFrame,
     spectra,
-    search_context::SearchContext,
+    search_context,
     ms_file_idx::Integer,
-    precursors::LibraryPrecursors,
-    frag_lookup::LibraryFragmentLookup,
+    precursors,
+    frag_lookup,
     nce_model,
 )
-    tbl = DataFrame(Tables.columntable(Arrow.Table(fpath)); copycols = true)
     n = nrow(tbl)
 
     flanking_ms1_m0_candidate_fraction = zeros(Float32, n)
@@ -740,7 +759,7 @@ function add_wide_window_features_to_fold_file!(
     tbl[!, :frag_apex_gt2x_flank_bitvec_rank] = frag_apex_gt2x_flank_bitvec_rank
 
     if n == 0
-        writeArrow(fpath, tbl)
+        select!(tbl, Not(FLANKING_WINDOW_TEMP_COLUMNS))
         return n
     end
 
@@ -871,44 +890,6 @@ function add_wide_window_features_to_fold_file!(
         bitvec_rank_table,
     )
 
-    select!(tbl, Not([:flanking_core_ms1_m0_signal, :flanking_core_frag_signal]))
-    writeArrow(fpath, tbl)
+    select!(tbl, Not(FLANKING_WINDOW_TEMP_COLUMNS))
     return n
-end
-
-function add_wide_window_features_to_fold_files!(
-    search_context::SearchContext,
-    valid_file_indices::Vector{Int},
-)
-    isempty(valid_file_indices) && return nothing
-
-    ms_ref = getMSData(search_context)
-    spec_lib = getSpecLib(search_context)
-    precursors = getPrecursors(spec_lib)
-    frag_lookup = getFragmentLookupTable(spec_lib)
-    n_files = 0
-    n_rows = 0
-
-    for ms_file_idx in valid_file_indices
-        spectra = getMSData(ms_ref, ms_file_idx)
-        nce_model = getNceModel(search_context, ms_file_idx)
-        for fold in UInt8[0, 1]
-            fpath = getSecondPassPsmsFold(ms_ref, ms_file_idx, fold)
-            (isempty(fpath) || !isfile(fpath)) && continue
-            n_rows += add_wide_window_features_to_fold_file!(
-                fpath,
-                spectra,
-                search_context,
-                ms_file_idx,
-                precursors,
-                frag_lookup,
-                nce_model,
-            )
-            n_files += 1
-        end
-    end
-
-    @debug_l1 "Flanking-window cross-run features: added $(length(FLANKING_WINDOW_FEATURES)) features " *
-              "to $n_files fold files ($n_rows rows)"
-    return nothing
 end

--- a/test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_wide_window_features.jl
+++ b/test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_wide_window_features.jl
@@ -182,6 +182,58 @@ function _reference_flanking_feature_values(
     )
 end
 
+function _test_flanking_columns(n_rows::Int)
+    return (
+        ms1_candidate = zeros(Float32, n_rows),
+        frag_candidate = zeros(Float32, n_rows),
+        ms1_frag_corr = zeros(Float32, n_rows),
+        frag_corr_mean = zeros(Float32, n_rows),
+        corr_strength = zeros(Float32, n_rows),
+        corr_effective_n = zeros(Float32, n_rows),
+        best_m0 = zeros(Float32, n_rows),
+        signal_support = zeros(Float32, n_rows),
+        apex_gt2x_rank = zeros(UInt16, n_rows),
+    )
+end
+
+function _test_flanking_group(
+    group_start::Int,
+    group_stop::Int,
+    core_ms1::Float32,
+    core_frag_signal::Float32,
+    core_fragments::NTuple{8, Float32},
+    ms1_m0::Vector{Float32},
+    fragments::Matrix{Float32},
+)
+    return Pioneer.FlankingWindowGroupBuffer(
+        group_start,
+        group_stop,
+        core_ms1,
+        core_frag_signal,
+        core_fragments,
+        0f0,
+        8,
+        ntuple(identity, 8),
+        ntuple(_ -> 0f0, 8),
+        ntuple(_ -> 0f0, 8),
+        ntuple(_ -> 0f0, 8),
+        ms1_m0,
+        fragments,
+    )
+end
+
+function _test_rows_match_features(columns, rows, expected)
+    @test all(columns.ms1_candidate[rows] .≈ expected.flanking_ms1_m0_candidate_fraction)
+    @test all(columns.frag_candidate[rows] .≈ expected.flanking_frag_candidate_fraction)
+    @test all(columns.ms1_frag_corr[rows] .≈ expected.flanking_ms1_frag_sum_corr)
+    @test all(columns.frag_corr_mean[rows] .≈ expected.flanking_frag_corr_mean)
+    @test all(columns.corr_strength[rows] .≈ expected.flanking_frag_corr_strength)
+    @test all(columns.corr_effective_n[rows] .≈ expected.flanking_frag_corr_effective_n)
+    @test all(columns.best_m0[rows] .≈ expected.flanking_frag_corr_best_m0)
+    @test all(columns.signal_support[rows] .≈ expected.flanking_signal_support)
+    @test all(columns.apex_gt2x_rank[rows] .== expected.frag_apex_gt2x_flank_bitvec_rank)
+end
+
 @testset "flanking-window features are cross-run only" begin
     @test all(feature -> feature in Pioneer.ADVANCED_FEATURE_SET, TEST_FLANKING_WINDOW_FEATURES)
     @test all(feature -> !(feature in Pioneer.PRESCORE_FEATURES), TEST_FLANKING_WINDOW_FEATURES)
@@ -190,6 +242,67 @@ end
     @test :flanking_n_correlated_fragments_bitvec_rank ∉ Pioneer.FLANKING_WINDOW_FEATURES
     @test :flanking_n_correlated_fragments ∉ Pioneer.ADVANCED_FEATURE_SET
     @test :flanking_n_correlated_fragments_bitvec_rank ∉ Pioneer.ADVANCED_FEATURE_SET
+end
+
+@testset "flanking-window table helper mutates rows before Arrow write" begin
+    tbl = DataFrame(
+        precursor_idx = UInt32[],
+        scan_idx = UInt32[],
+        flanking_core_scan_min = UInt32[],
+        flanking_core_scan_max = UInt32[],
+        n_contiguous_scans = UInt16[],
+        flanking_core_ms1_m0_signal = Float32[],
+        flanking_core_frag_signal = Float32[],
+    )
+    for col in Pioneer.SMOOTHED_FRAGMENT_INTENSITY_COLUMNS
+        tbl[!, col] = Float32[]
+    end
+
+    n = Pioneer.add_wide_window_features_to_table!(
+        tbl,
+        nothing,
+        nothing,
+        1,
+        nothing,
+        nothing,
+        nothing,
+    )
+
+    @test n == 0
+    @test all(feature -> hasproperty(tbl, feature), TEST_FLANKING_WINDOW_FEATURES)
+    @test !hasproperty(tbl, :flanking_core_scan_min)
+    @test !hasproperty(tbl, :flanking_core_scan_max)
+    @test !hasproperty(tbl, :flanking_core_ms1_m0_signal)
+    @test !hasproperty(tbl, :flanking_core_frag_signal)
+end
+
+@testset "flanking-window group reduction scatters disjoint row ranges" begin
+    columns = _test_flanking_columns(5)
+    core_fragments_1 = (12f0, 10f0, 8f0, 6f0, 4f0, 2f0, 1f0, 0.5f0)
+    ms1_m0_1 = Float32[4, 8, 12]
+    fragments_1 = Float32[
+        1 2 3 4 5 6 7 8
+        2 4 6 8 10 12 14 16
+        3 6 9 12 15 18 21 24
+    ]
+    core_fragments_2 = (2f0, 4f0, 6f0, 8f0, 10f0, 12f0, 14f0, 16f0)
+    ms1_m0_2 = Float32[5, 0, 10]
+    fragments_2 = Float32[
+        4 0 2 0 1 0 3 0
+        0 0 0 0 0 0 0 0
+        8 0 4 0 2 0 6 0
+    ]
+    groups = Pioneer.FlankingWindowGroupBuffer[
+        _test_flanking_group(1, 2, 20f0, 40f0, core_fragments_1, ms1_m0_1, fragments_1),
+        _test_flanking_group(3, 5, 10f0, 15f0, core_fragments_2, ms1_m0_2, fragments_2),
+    ]
+
+    Pioneer._wide_reduce_scan_centric_group_batch!(columns, groups, nothing)
+
+    expected_1 = _reference_flanking_feature_values(20f0, 40f0, core_fragments_1, ms1_m0_1, fragments_1)
+    expected_2 = _reference_flanking_feature_values(10f0, 15f0, core_fragments_2, ms1_m0_2, fragments_2)
+    _test_rows_match_features(columns, 1:2, expected_1)
+    _test_rows_match_features(columns, 3:5, expected_2)
 end
 
 @testset "flanking-core bounds use contiguous passing cycles around the selected PSM" begin


### PR DESCRIPTION
## Summary
- Compute flanking-window features during MainSearch before fold Arrow files are written.
- Remove the old PrecursorScoring fold-file reopen/mutate/rewrite pass for flanking features.
- Add threaded scan-centric MS1/MS2 lookup and threaded group reduction for flanking feature batches.
- Add focused unit coverage for the new table helper and parallel group scatter path.

## Validation
- `git diff --check`
- `julia --project=. test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_wide_window_features.jl`

## Notes
- Based on current `develop`; does not include the main-search mass-missing feature branch.