### PR TITLE
[codex] Add file-aware MBR decoys

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/mbr_pairing.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/mbr_pairing.jl
@@ -5,16 +5,15 @@
 
 # MBR pairing.
 #
-# Builds the experiment-global counterfactual-partner map used by MBR
+# Builds experiment-global counterfactual-partner pools used by MBR
 # Batch F. For every unique `precursor_idx` observed across the per-file
-# second-pass Arrow tables, assigns exactly one partner of the OPPOSITE
-# target/decoy class — the one whose predicted iRT is closest within the
-# same (cv_fold × prec_mz decile) stratum.
+# second-pass Arrow tables, stores the OPPOSITE-class iRT pools needed to
+# choose the nearest valid counterfactual partner for each receiver file.
 #
-# The result is a `Dict{UInt32, UInt32}` (pid → partner_pid) consumed by
-# the MBR streaming feature compute as the lookup for each row's _false
-# donor (see mbr_streaming.jl). Nothing here mutates the spectral library
-# or any PSM column.
+# MBR streaming resolves the partner against donor availability: first the
+# nearest opposite-class precursor in the same cv_fold × prec_mz decile that
+# has a cross-file donor, then same-fold, then global. Nothing here mutates
+# the spectral library or any PSM column.
 #
 # Memory: streams the per-file Arrow tables read-only — never materialises
 # a concatenated PSM DataFrame. Only (:precursor_idx, :target, :cv_fold)
@@ -86,6 +85,19 @@ const _IrtPool = NamedTuple{(:pids, :irts), Tuple{Vector{UInt32}, Vector{Float32
 
 _empty_pool() = (pids = UInt32[], irts = Float32[])
 
+struct _CounterfactualPartnerPools
+    target_by_pid::Vector{Bool}
+    fold_by_pid::Vector{UInt8}
+    mz_bin_by_pid::Vector{UInt8}
+    irt_by_pid::Vector{Float32}
+    pools_t::Dict{Tuple{Int, Int}, _IrtPool}
+    pools_d::Dict{Tuple{Int, Int}, _IrtPool}
+    fold_pool_t::Dict{Int, _IrtPool}
+    fold_pool_d::Dict{Int, _IrtPool}
+    global_pool_t::_IrtPool
+    global_pool_d::_IrtPool
+end
+
 # Build a sorted pool from a list of (irt, pid) tuples — sort by irt
 # (tiebreak by pid for determinism), then split.
 function _sort_to_pool(pairs::Vector{Tuple{Float32, UInt32}})::_IrtPool
@@ -136,75 +148,33 @@ function _build_global_pool(fold_pools::Dict{Int, _IrtPool})::_IrtPool
     return _sort_to_pool(pairs)
 end
 
-# Binary-search the pool for the pid whose irt is closest to `target_irt`.
-# Returns UInt32(0) if the pool is empty.
-@inline function _nearest_pid(pool::_IrtPool, target_irt::Float32)
-    n = length(pool.irts)
-    n == 0 && return UInt32(0)
-    idx = searchsortedfirst(pool.irts, target_irt)
-    if idx > n
-        return pool.pids[n]
-    elseif idx == 1
-        return pool.pids[1]
-    else
-        d_left  = abs(target_irt - pool.irts[idx - 1])
-        d_right = abs(pool.irts[idx] - target_irt)
-        return d_left <= d_right ? pool.pids[idx - 1] : pool.pids[idx]
-    end
-end
-
-# Three-tier nearest-iRT fallback: in-stratum → same fold (any mz) →
-# experiment-global. Returns (partner_pid, tier) where tier ∈ (:stratum,
-# :fb_fold, :fb_global). Throws if no opposite-class precursor exists
-# anywhere — that experiment is degenerate.
-function _assign_partner_with_fallback(
-    my_pid::UInt32, my_irt::Float32, my_fold::Int, my_mz::Int, is_target::Bool,
-    pools_t::Dict, pools_d::Dict,
-    fold_pool_t::Dict, fold_pool_d::Dict,
-    global_pool_t::_IrtPool, global_pool_d::_IrtPool,
-)
-    opp_local  = is_target ?
-        get(pools_d, (my_fold, my_mz), _empty_pool()) :
-        get(pools_t, (my_fold, my_mz), _empty_pool())
-    partner = _nearest_pid(opp_local, my_irt)
-    partner != UInt32(0) && return (partner, :stratum)
-
-    opp_fold = is_target ? fold_pool_d[my_fold] : fold_pool_t[my_fold]
-    partner = _nearest_pid(opp_fold, my_irt)
-    partner != UInt32(0) && return (partner, :fb_fold)
-
-    opp_global = is_target ? global_pool_d : global_pool_t
-    partner = _nearest_pid(opp_global, my_irt)
-    partner == UInt32(0) && error(
-        "build_counterfactual_partner_map: no opposite-class partner anywhere " *
-        "for pid=$my_pid (target=$is_target)."
-    )
-    return (partner, :fb_global)
-end
-
 """
-    build_counterfactual_partner_map(file_paths, precursors) -> Dict{UInt32, UInt32}
+    build_counterfactual_partner_pools(file_paths, precursors) -> _CounterfactualPartnerPools
 
-MBR Batch F: build the experiment-global pid → counterfactual_partner_pid
-map by streaming the per-file Arrow tables (no DataFrame materialised).
+MBR Batch F: build the precursor-indexed metadata and sorted opposite-class
+iRT pools needed for deterministic, file-aware counterfactual partner
+resolution.
 
-For every unique `precursor_idx` observed across `file_paths`, the partner
-is the OPPOSITE-class precursor whose predicted iRT is closest within the
-same (cv_fold × prec_mz decile) stratum. Falls back to same-fold-any-mz
-and then experiment-global if a stratum is one-sided. Errors if no
-opposite-class precursor exists anywhere.
-
-Returns the partner map (consumed by mbr_streaming.jl for each row's
-_false donor lookup). Hard requirement: every observed pid gets a
-partner (asserted).
+For each receiver row, MBR streaming chooses the nearest opposite-class
+precursor by predicted iRT that has a donor in a file other than the receiver
+file, checking same (cv_fold × prec_mz decile), then same-fold, then global.
 """
-function build_counterfactual_partner_map(
+function build_counterfactual_partner_pools(
     file_paths::Vector{String},
     precursors::LibraryPrecursors,
 )
-    t0 = time()
     unique = _collect_unique_precursors_streaming(file_paths, precursors)
     n_precs = length(unique.pids)
+    if n_precs == 0
+        empty_stratum = Dict{Tuple{Int, Int}, _IrtPool}()
+        empty_fold = Dict{Int, _IrtPool}(0 => _empty_pool(), 1 => _empty_pool())
+        return _CounterfactualPartnerPools(
+            Bool[], UInt8[], UInt8[], Float32[],
+            empty_stratum, empty_stratum,
+            empty_fold, empty_fold,
+            _empty_pool(), _empty_pool(),
+        )
+    end
 
     bin_mz = _compute_mz_deciles(unique.mz)
     pools_t, pools_d = _build_stratum_pools(
@@ -224,36 +194,30 @@ function build_counterfactual_partner_map(
     global_pool_t = _build_global_pool(fold_pool_t)
     global_pool_d = _build_global_pool(fold_pool_d)
 
-    pid_to_partner = Dict{UInt32, UInt32}()
-    sizehint!(pid_to_partner, n_precs)
-    n_stratum = 0; n_fb_fold = 0; n_fb_global = 0
+    max_pid = Int(maximum(unique.pids))
+    target_by_pid = falses(max_pid)
+    fold_by_pid = zeros(UInt8, max_pid)
+    mz_bin_by_pid = zeros(UInt8, max_pid)
+    irt_by_pid = zeros(Float32, max_pid)
+
     @inbounds for i in 1:n_precs
-        partner, tier = _assign_partner_with_fallback(
-            unique.pids[i], unique.irt[i],
-            Int(unique.fold[i]), bin_mz[i], unique.target[i],
-            pools_t, pools_d, fold_pool_t, fold_pool_d,
-            global_pool_t, global_pool_d,
-        )
-        pid_to_partner[unique.pids[i]] = partner
-        tier === :stratum   ? (n_stratum   += 1) :
-        tier === :fb_fold   ? (n_fb_fold   += 1) : (n_fb_global += 1)
+        pid = Int(unique.pids[i])
+        target_by_pid[pid] = unique.target[i]
+        fold_by_pid[pid] = unique.fold[i]
+        mz_bin_by_pid[pid] = UInt8(bin_mz[i])
+        irt_by_pid[pid] = unique.irt[i]
     end
 
-    elapsed = time() - t0
-    pct_strat = round(100 * n_stratum   / max(n_precs, 1), digits = 2)
-    pct_fbf   = round(100 * n_fb_fold   / max(n_precs, 1), digits = 3)
-    pct_fbg   = round(100 * n_fb_global / max(n_precs, 1), digits = 3)
-
-    @debug_l1 "MBR Batch F (iRT-NN) — counterfactual partner map:"
-    @debug_l1 "  unique precursors: $n_precs"
-    @debug_l1 "  partner = closest-pred-iRT opposite within (cv_fold × mz_decile)"
-    @debug_l1 "  in stratum:                     $n_stratum ($pct_strat%)"
-    @debug_l1 "  fallback (cv_fold, any mz):     $n_fb_fold ($pct_fbf%)"
-    @debug_l1 "  fallback (experiment-global):   $n_fb_global ($pct_fbg%)"
-    @debug_l1 "  total partnered: $(length(pid_to_partner)) / $n_precs"
-    @debug_l1 "  build_counterfactual_partner_map elapsed: $(round(elapsed, digits = 2))s"
-
-    @assert length(pid_to_partner) == n_precs "Counterfactual partner map missing $(n_precs - length(pid_to_partner)) precursors"
-
-    return pid_to_partner
+    return _CounterfactualPartnerPools(
+        target_by_pid,
+        fold_by_pid,
+        mz_bin_by_pid,
+        irt_by_pid,
+        pools_t,
+        pools_d,
+        fold_pool_t,
+        fold_pool_d,
+        global_pool_t,
+        global_pool_d,
+    )
 end

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/mbr_streaming.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/mbr_streaming.jl
@@ -14,10 +14,10 @@
 #
 # Two main-file sweeps drive MBR feature compute:
 #   Sweep 1 (build_mbr_donor_dict_streaming_with_pass1)
-#     Streams each (main + pass1 sidecar) pair to build the top-2 donor dict
-#     keyed by precursor_idx. Top-2 (not top-1) covers the same-file fallback
-#     in `_donor_for` — top-1 might be the recipient's own file.
-#     Memory: ~50k pids × 2 entries × ~40 B ≈ a few MB.
+#     Streams each (main + pass1 sidecar) pair to build the donor dict keyed
+#     by precursor_idx. Each pid keeps the two best donor rows from distinct
+#     files, sorted by score, so `_donor_for_pid` can choose the best cross-file
+#     donor without storage growing with file count.
 #
 #   Sweep 2 (compute_mbr_features_per_file_to_sidecar_with_pass1!)
 #     Loads ONE file's main + pass1 sidecar at a time, computes the MBR_*
@@ -35,8 +35,7 @@
 
 # A single cross-run donor entry: one row's score + the per-row donor
 # features we need to compute MBR features for a recipient row in
-# another file. Holds the bare minimum so the donor dict stays small
-# (each entry is ~40 bytes; ~50k pids × 2 ≈ a few MB).
+# another file. Holds the bare minimum so the donor dict stays small.
 struct _MBRDonorEntry
     trace_prob::Float32
     weight::Float32
@@ -50,6 +49,7 @@ struct _MBRDonorEntry
 end
 
 const MBR_SIDECAR_SUFFIX = ".mbr_sidecar.arrow"
+const MBR_MAX_DONOR_FILES_PER_PRECURSOR = 2
 
 # Columns the donor dict reads from each (main + pass1 sidecar) pair.
 # Listed once so reader and consumer stay in sync. `is_decoy` is hardcoded
@@ -181,6 +181,21 @@ function write_pass1_score_sidecars!(best_psms::DataFrame, file_paths::Vector{St
     return n_written
 end
 
+function _insert_sorted_donor_entry!(
+    entries::Vector{_MBRDonorEntry},
+    entry::_MBRDonorEntry,
+)
+    insert_idx = length(entries) + 1
+    @inbounds for idx in eachindex(entries)
+        if entry.trace_prob > entries[idx].trace_prob
+            insert_idx = idx
+            break
+        end
+    end
+    insert!(entries, insert_idx, entry)
+    return nothing
+end
+
 # Inner per-file row loop for build_mbr_donor_dict_streaming_with_pass1.
 # Extracted so Julia specializes on the concrete Arrow column types and the
 # Union{Nothing, ...} branch on logby_c / rt_c becomes a one-time call-site
@@ -202,7 +217,6 @@ end
     side_path::String,
 )
     n = length(pid_c)
-    K = 2
     has_logby = logby_c !== nothing
     has_rt    = rt_c    !== nothing
     @inbounds for i in 1:n
@@ -219,17 +233,19 @@ end
             fidx_c[i], false,
         )
         entries = get!(() -> _MBRDonorEntry[], all_entries, pid)
-        if length(entries) < K
-            push!(entries, e)
-            if length(entries) > 1 && entries[end-1].trace_prob < e.trace_prob
-                entries[end-1], entries[end] = entries[end], entries[end-1]
-            end
-        elseif e.trace_prob > entries[end].trace_prob
-            entries[end] = e
-            if entries[1].trace_prob < e.trace_prob
-                entries[1], entries[end] = entries[end], entries[1]
+        same_file_idx = 0
+        for idx in eachindex(entries)
+            if entries[idx].ms_file_idx == e.ms_file_idx
+                same_file_idx = idx
+                break
             end
         end
+        if same_file_idx != 0
+            e.trace_prob > entries[same_file_idx].trace_prob || continue
+            deleteat!(entries, same_file_idx)
+        end
+        _insert_sorted_donor_entry!(entries, e)
+        length(entries) > MBR_MAX_DONOR_FILES_PER_PRECURSOR && pop!(entries)
     end
     return nothing
 end
@@ -277,6 +293,84 @@ end
     return nothing
 end
 
+@inline function _nearest_cross_file_donor(
+    donor_dict::Dict{UInt32, Vector{_MBRDonorEntry}},
+    pool::_IrtPool,
+    target_irt::Float32,
+    my_file::UInt32,
+)
+    n = length(pool.irts)
+    n == 0 && return nothing
+
+    right = searchsortedfirst(pool.irts, target_irt)
+    left = right - 1
+    @inbounds while left >= 1 || right <= n
+        use_left = if right > n
+            true
+        elseif left < 1
+            false
+        else
+            abs(target_irt - pool.irts[left]) <= abs(pool.irts[right] - target_irt)
+        end
+        pool_idx = use_left ? left : right
+        use_left ? (left -= 1) : (right += 1)
+        donor = _donor_for_pid(donor_dict, pool.pids[pool_idx], my_file)
+        donor !== nothing && return donor
+    end
+    return nothing
+end
+
+@inline function _resolve_false_donor_for_pid(
+    donor_dict::Dict{UInt32, Vector{_MBRDonorEntry}},
+    partner_pools::_CounterfactualPartnerPools,
+    my_pid::UInt32,
+    my_file::UInt32,
+)
+    pid_idx = Int(my_pid)
+    my_irt = partner_pools.irt_by_pid[pid_idx]
+    my_fold = Int(partner_pools.fold_by_pid[pid_idx])
+    my_mz = Int(partner_pools.mz_bin_by_pid[pid_idx])
+
+    if partner_pools.target_by_pid[pid_idx]
+        donor = _nearest_cross_file_donor(
+            donor_dict,
+            get(partner_pools.pools_d, (my_fold, my_mz), _empty_pool()),
+            my_irt,
+            my_file,
+        )
+        donor !== nothing && return donor
+        donor = _nearest_cross_file_donor(donor_dict, partner_pools.fold_pool_d[my_fold], my_irt, my_file)
+        donor !== nothing && return donor
+        return _nearest_cross_file_donor(donor_dict, partner_pools.global_pool_d, my_irt, my_file)
+    else
+        donor = _nearest_cross_file_donor(
+            donor_dict,
+            get(partner_pools.pools_t, (my_fold, my_mz), _empty_pool()),
+            my_irt,
+            my_file,
+        )
+        donor !== nothing && return donor
+        donor = _nearest_cross_file_donor(donor_dict, partner_pools.fold_pool_t[my_fold], my_irt, my_file)
+        donor !== nothing && return donor
+        return _nearest_cross_file_donor(donor_dict, partner_pools.global_pool_t, my_irt, my_file)
+    end
+end
+
+@inline function _false_donor_for_pid(
+    false_donor_cache::Dict{UInt32, Union{Nothing, _MBRDonorEntry}},
+    donor_dict::Dict{UInt32, Vector{_MBRDonorEntry}},
+    partner_pools::_CounterfactualPartnerPools,
+    my_pid::UInt32,
+    my_file::UInt32,
+)
+    if haskey(false_donor_cache, my_pid)
+        return false_donor_cache[my_pid]
+    end
+    donor = _resolve_false_donor_for_pid(donor_dict, partner_pools, my_pid, my_file)
+    false_donor_cache[my_pid] = donor
+    return donor
+end
+
 # Inner per-row MBR-feature compute. Extracted from
 # compute_mbr_features_per_file_to_sidecar_with_pass1! so Julia specializes
 # on the concrete column types (Arrow.Primitive{T} or Vector{T}) and the
@@ -299,16 +393,15 @@ end
     logby_v::Union{Nothing, AbstractVector{Float16}},
     rt_v::Union{Nothing, AbstractVector{Float32}},
     donor_dict::Dict{UInt32, Vector{_MBRDonorEntry}},
-    partner_col::Vector{UInt32},
+    partner_pools::_CounterfactualPartnerPools,
+    false_donor_cache::Dict{UInt32, Union{Nothing, _MBRDonorEntry}},
 )
     n = length(pid_v)
-    plen = length(partner_col)
     has_logby = logby_v !== nothing
     has_rt    = rt_v    !== nothing
     @inbounds for i in 1:n
         my_file = file_v[i]
         my_pid  = pid_v[i]
-        my_partner = my_pid <= UInt32(plen) ? partner_col[Int(my_pid)] : UInt32(0)
 
         donor_t = _donor_for_pid(donor_dict, my_pid, my_file)
         if donor_t !== nothing
@@ -327,24 +420,22 @@ end
             end
             out_miss_t[i] = false
         end
-        if my_partner != UInt32(0)
-            donor_f = _donor_for_pid(donor_dict, my_partner, my_file)
-            if donor_f !== nothing
-                out_max_f[i] = donor_f.trace_prob
-                wi = weight_v[i]
-                if donor_f.weight > 0 && wi > 0
-                    out_lw_f[i] = log2(wi / donor_f.weight)
-                end
-                out_le_f[i] = Float32(l2ie_v[i]) - donor_f.log2_intensity_explained
-                out_ir_f[i] = abs((irtp_v[i] - irto_v[i]) - donor_f.irt_residual)
-                if has_logby
-                    out_log_by_f[i] = Float32(logby_v[i]) - donor_f.log_by_ratio
-                end
-                if has_rt
-                    out_rt_f[i] = abs(rt_v[i] - donor_f.rt_obs)
-                end
-                out_miss_f[i] = false
+        donor_f = _false_donor_for_pid(false_donor_cache, donor_dict, partner_pools, my_pid, my_file)
+        if donor_f !== nothing
+            out_max_f[i] = donor_f.trace_prob
+            wi = weight_v[i]
+            if donor_f.weight > 0 && wi > 0
+                out_lw_f[i] = log2(wi / donor_f.weight)
             end
+            out_le_f[i] = Float32(l2ie_v[i]) - donor_f.log2_intensity_explained
+            out_ir_f[i] = abs((irtp_v[i] - irto_v[i]) - donor_f.irt_residual)
+            if has_logby
+                out_log_by_f[i] = Float32(logby_v[i]) - donor_f.log_by_ratio
+            end
+            if has_rt
+                out_rt_f[i] = abs(rt_v[i] - donor_f.rt_obs)
+            end
+            out_miss_f[i] = false
         end
     end
     return nothing
@@ -356,7 +447,7 @@ end
 function compute_mbr_features_per_file_to_sidecar_with_pass1!(
         main_path::AbstractString,
         donor_dict::Dict{UInt32, Vector{_MBRDonorEntry}},
-        partner_col::Vector{UInt32})
+        partner_pools::_CounterfactualPartnerPools)
     pass1_path = main_path * PASS1_SIDECAR_SUFFIX
     isfile(pass1_path) || error("Missing Pass-1 sidecar at $pass1_path")
     main = Arrow.Table(main_path)
@@ -387,6 +478,7 @@ function compute_mbr_features_per_file_to_sidecar_with_pass1!(
     out_miss_t = trues(n);     out_miss_f = trues(n)
     out_log_by_t = fill(-1f0, n); out_log_by_f = fill(-1f0, n)
     out_rt_t = fill(-1f0, n); out_rt_f = fill(-1f0, n)
+    false_donor_cache = Dict{UInt32, Union{Nothing, _MBRDonorEntry}}()
 
     _compute_mbr_inner!(
         out_max_t, out_max_f, out_lw_t, out_lw_f,
@@ -395,7 +487,7 @@ function compute_mbr_features_per_file_to_sidecar_with_pass1!(
         out_log_by_t, out_log_by_f, out_rt_t, out_rt_f,
         pid_v, file_v, weight_v, l2ie_v, irtp_v, irto_v,
         logby_v, rt_v,
-        donor_dict, partner_col,
+        donor_dict, partner_pools, false_donor_cache,
     )
 
     side_path = main_path * MBR_SIDECAR_SUFFIX
@@ -592,4 +684,3 @@ function merge_mbr_sidecars_into_main!(file_paths::Vector{String}; cleanup::Bool
     @debug_l1 "  Wrote $n_merged consolidated mbr_outputs sidecars"
     return n_merged
 end
-

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/score_psms.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/score_psms.jl
@@ -262,8 +262,8 @@ end
 function _score_precursor_isotope_traces_mbr(
     file_paths::Vector{String}, precursors::LibraryPrecursors,
 )
-    # 1. pid → counterfactual_partner_pid map (streaming over Arrow tables).
-    cf_partner_dict = build_counterfactual_partner_map(file_paths, precursors)
+    # 1. Counterfactual iRT pools for deterministic file-aware partner resolution.
+    cf_partner_pools = build_counterfactual_partner_pools(file_paths, precursors)
 
     # 2. Feature list. _qbin variants in ADVANCED_FEATURE_SET are commented
     # out, so no quantile-binned features need pre-computing.
@@ -294,49 +294,43 @@ function _score_precursor_isotope_traces_mbr(
         end
     end
 
-    # 5. Collapse the partner Dict to a pid-indexed Vector. The MBR feature
-    # compute does a Vector index per inner-loop iteration; that's cheaper
-    # than a Dict.get and the Vector is bounded by max observed pid (few MB).
-    max_pid = isempty(cf_partner_dict) ? UInt32(0) : maximum(keys(cf_partner_dict))
-    cf_partner_vec = zeros(UInt32, Int(max_pid))
-    for (pid, partner) in cf_partner_dict
-        cf_partner_vec[Int(pid)] = partner
-    end
-    cf_partner_dict = Dict{UInt32, UInt32}()
-
-    # 6. MBR donor dict (sweep-1) → per-file MBR sidecars (sweep-2).
+    # 5. MBR donor dict (sweep-1) → per-file MBR sidecars (sweep-2).
     @debug_l1 "MBR Batch F: building donor dict via sweep-1..."
     donor_dict = build_mbr_donor_dict_streaming_with_pass1(file_paths)
     @debug_l1 "  donor dict pids: $(length(donor_dict))"
 
     # Parallelize the per-file MBR feature compute + sidecar write across
-    # files. donor_dict and cf_partner_vec are read-only across this loop
+    # files. donor_dict and cf_partner_pools are read-only across this loop
     # (built before, not mutated by the per-file function), and each file
     # reads/writes a disjoint path. Mirrors the Pass-3 sidecar threading.
     @debug_l1 "MBR Batch F: writing per-file MBR sidecars..."
     parallel_foreach!(length(file_paths)) do chunk
         for f_idx in chunk
-            compute_mbr_features_per_file_to_sidecar_with_pass1!(file_paths[f_idx], donor_dict, cf_partner_vec)
+            compute_mbr_features_per_file_to_sidecar_with_pass1!(
+                file_paths[f_idx],
+                donor_dict,
+                cf_partner_pools,
+            )
         end
     end
 
     donor_dict = Dict{UInt32, Vector{_MBRDonorEntry}}()
-    cf_partner_vec = UInt32[]
+    cf_partner_pools = nothing
     GC.gc()
 
-    # 7. Slim FTR DataFrame (~10 cols) reconstituted from main + sidecars,
+    # 6. Slim FTR DataFrame (~10 cols) reconstituted from main + sidecars,
     # only as wide as the FTR controller needs.
     @debug_l1 "MBR Batch F: loading slim FTR DataFrame..."
     psms = load_ftr_slim_dataframe(file_paths)
     @debug_l1 "  slim FTR rows: $(nrow(psms))"
 
-    # 8. `trace_prob` (downstream qval pipeline) = Pass-1 OOF score.
+    # 7. `trace_prob` (downstream qval pipeline) = Pass-1 OOF score.
     psms[!, :trace_prob] = psms[!, :trace_prob_prepass]
 
-    # 9. Paired-counterfactual FTR.
+    # 8. Paired-counterfactual FTR.
     apply_mbr_filter_paired!(psms; alpha = 0.01f0, q_thresh = 0.01f0)
 
-    # 10. Recovery sidecars + final merge — folds (Pass-1 + MBR + recovery)
+    # 9. Recovery sidecars + final merge — folds (Pass-1 + MBR + recovery)
     # back into each main file in one pass.
     @debug_l1 "MBR Batch F: writing recovery sidecars..."
     write_recovery_sidecars(psms, file_paths)

--- a/test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_file_aware_decoys.jl
+++ b/test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_file_aware_decoys.jl
@@ -1,0 +1,92 @@
+using Test
+using Pioneer
+
+function _test_mbr_donor(prob::Float32, file_idx::UInt32)
+    return Pioneer._MBRDonorEntry(
+        prob,
+        1.0f0,
+        0.25f0,
+        0.5f0,
+        12.0f0,
+        0.1f0,
+        24.0f0,
+        file_idx,
+        false,
+    )
+end
+
+function _test_partner_pools_for_receiver()
+    target_by_pid = falses(11)
+    target_by_pid[1] = true
+    fold_by_pid = zeros(UInt8, 11)
+    mz_bin_by_pid = ones(UInt8, 11)
+    irt_by_pid = zeros(Float32, 11)
+    irt_by_pid[1] = 10.0f0
+
+    decoy_pool = (pids = UInt32.(2:11), irts = Float32[10.01, 10.02, 10.03, 10.04, 10.05, 10.06, 10.07, 10.08, 10.09, 10.10])
+    empty_pool = (pids = UInt32[], irts = Float32[])
+
+    return Pioneer._CounterfactualPartnerPools(
+        target_by_pid,
+        fold_by_pid,
+        mz_bin_by_pid,
+        irt_by_pid,
+        Dict{Tuple{Int, Int}, Pioneer._IrtPool}(),
+        Dict{Tuple{Int, Int}, Pioneer._IrtPool}((0, 1) => decoy_pool),
+        Dict{Int, Pioneer._IrtPool}(0 => empty_pool, 1 => empty_pool),
+        Dict{Int, Pioneer._IrtPool}(0 => decoy_pool, 1 => empty_pool),
+        empty_pool,
+        decoy_pool,
+    )
+end
+
+@testset "MBR donor dictionary keeps top two distinct-file donors" begin
+    donor_dict = Dict{UInt32, Vector{Pioneer._MBRDonorEntry}}()
+
+    Pioneer._accumulate_donor_entries!(
+        donor_dict,
+        UInt32[1, 1, 1, 1, 1],
+        UInt32[1, 1, 1, 1, 1],
+        UInt32[10, 11, 12, 13, 14],
+        UInt32[10, 11, 12, 13, 14],
+        Float32[0.95, 0.90, 0.70, 0.60, 0.98],
+        Float32[1, 1, 1, 1, 1],
+        Float16[0.5, 0.5, 0.5, 0.5, 0.5],
+        Float32[12, 12, 12, 12, 12],
+        Float32[11, 11, 11, 11, 11],
+        nothing,
+        nothing,
+        UInt32[10, 10, 20, 30, 40],
+        "unit-test",
+    )
+
+    entries = donor_dict[UInt32(1)]
+
+    @test length(entries) == 2
+    @test [entry.ms_file_idx for entry in entries] == UInt32[40, 10]
+    @test [entry.trace_prob for entry in entries] == Float32[0.98, 0.95]
+    @test Pioneer._donor_for_pid(donor_dict, UInt32(1), UInt32(40)).ms_file_idx == UInt32(10)
+    @test Pioneer._donor_for_pid(donor_dict, UInt32(1), UInt32(10)).ms_file_idx == UInt32(40)
+end
+
+@testset "MBR false donor selection uses nearest cross-file iRT partner" begin
+    donor_dict = Dict{UInt32, Vector{Pioneer._MBRDonorEntry}}()
+    for pid in UInt32(2):UInt32(10)
+        donor_dict[pid] = [_test_mbr_donor(0.20f0 + 0.01f0 * Float32(pid), UInt32(10))]
+    end
+    donor_dict[UInt32(11)] = [_test_mbr_donor(0.55f0, UInt32(20))]
+
+    cache = Dict{UInt32, Union{Nothing, Pioneer._MBRDonorEntry}}()
+    donor = Pioneer._false_donor_for_pid(
+        cache,
+        donor_dict,
+        _test_partner_pools_for_receiver(),
+        UInt32(1),
+        UInt32(10),
+    )
+
+    @test donor !== nothing
+    @test donor.trace_prob == 0.55f0
+    @test donor.ms_file_idx == UInt32(20)
+    @test haskey(cache, UInt32(1))
+end

--- a/test/runtests_part3_units.jl
+++ b/test/runtests_part3_units.jl
@@ -81,6 +81,7 @@ include("./UnitTests/test_summarize_precursor.jl")
 # PrecursorScoringSearch
 include("./Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_scoring_interface.jl")
 include("./Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_wide_window_features.jl")
+include("./Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_file_aware_decoys.jl")
 include("./UnitTests/test_mainsearch_irt_refinement.jl")
 include("./UnitTests/test_scoring_semisupervised.jl")
 


### PR DESCRIPTION
## Summary
- Make MBR counterfactual donor pairing file-aware and deterministic.
- Keep only the top two distinct-file donor rows per precursor, so donor storage stays bounded as file count grows.
- Resolve false donors by nearest opposite-class iRT partner with stratum, same-fold, then global fallback, requiring an available cross-file donor.
- Add focused unit coverage for top-two donor retention and nearest cross-file counterfactual selection.

## Validation
- `julia --project=. test/runtests_part3_units.jl`
- `git diff --check`