### PR TITLE
perf(buildlib): faster, leaner spectral-library build (type-stability + disk + fusion)

### DIFF
--- a/assets/example_config/defaultBuildLibParams.json
+++ b/assets/example_config/defaultBuildLibParams.json
@@ -2,6 +2,9 @@
     "comment_output": "=== Output library path ===",
     "library_path": "/path/to/output/my_library",
 
+    "comment_seed": "=== RNG seed for decoy/entrapment shuffling. Fixed seed => fully reproducible library; different seed => different shuffled decoy/entrapment sequences. ===",
+    "seed": 1844,
+
     "comment_calibration": "=== Calibration file for automatic detection of fragment and precursor m/z ranges (optional) ===",
     "comment_calibration": "=== Convert a representative RAW file to Arrow format and provide its path here ===",
     "calibration_raw_file": "/path/to/calibration/file.arrow",

--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -299,6 +299,13 @@ function BuildSpecLib(params_path::String)
                 N_DECOYS  = sum(precursors_table[:decoy])
                 N_TARGETS = N_PRECURSORS - N_DECOYS
                 fragments_table = nothing
+                # raw_fragments.arrow is fully consumed by parse_altimeter_fragments
+                # (process_spline_batch! decode + rebuild_prec_to_frag_index!); its
+                # mmap handle (fragments_table) is released just above. Delete it now —
+                # before the precursor DataFrame work + precursors_table.arrow write —
+                # so raw no longer coexists with fragments_table.arrow at the peak.
+                GC.gc()
+                safeRm(raw_fragments_arrow_path, nothing; force=true)
                 precursors_table = DataFrame(precursors_table)
                 rename!(precursors_table, [
                     :accession_number => :accession_numbers,
@@ -339,12 +346,11 @@ function BuildSpecLib(params_path::String)
                 )
 
                 GC.gc()
-                # raw_fragments.arrow + precursors.arrow are fully consumed by this
-                # stage (parse_altimeter_fragments + the precursor DataFrame copy).
-                # Delete them now — before buildPionLib + File Verification — so they
-                # don't coexist on disk with the final .poin outputs. Cuts peak disk
-                # by ~(raw + precursors); safeRm = GC + retry for the Windows mmap lock.
-                safeRm(raw_fragments_arrow_path, nothing; force=true)
+                # precursors.arrow is now fully materialized into precursors_table
+                # (DataFrame copy + Arrow.write above), so delete it before buildPionLib
+                # + File Verification. (raw_fragments.arrow was deleted earlier, right
+                # after parse_altimeter_fragments.) safeRm = GC + retry for the Windows
+                # mmap lock.
                 safeRm(precursors_arrow_path, nothing; force=true)
                 nothing
             end

--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -145,6 +145,11 @@ function BuildSpecLib(params_path::String)
         N_FRAGMENTS = 0
         N_TARGETS = 0
         N_DECOYS = 0
+        # In-memory handoff for the fused raw->detailed_frags path (set in the
+        # prediction block below). When predict_fragments is false (resume from
+        # existing files) they stay nothing and buildPionLib uses the disk path.
+        detailed_frags = nothing
+        pid_to_fid = nothing
         if params["predict_fragments"]
             # Fragment prediction workflow
             @user_info "Starting fragment prediction workflow..."
@@ -278,12 +283,15 @@ function BuildSpecLib(params_path::String)
                 )
                 ion_dictionary = get_altimeter_ion_dict(asset_path("ion_dictionary.txt"))
 
-                parse_altimeter_fragments(
+                # Fused: decode raw_fragments directly into the final
+                # Vector{SplineCompactFrag} + CSR, in memory, skipping the
+                # fragments_table.arrow re-encode/re-read. Handed to buildPionLib
+                # below without touching disk.
+                detailed_frags, pid_to_fid = build_detailed_frags_from_raw(
                     precursors_table,
                     fragments_table,
                     frag_annotation_type,
                     ion_dictionary,
-                    10000,
                     asset_path("immonium.txt"),
                     lib_dir,
                     Dict{String, Int8}(),
@@ -359,7 +367,12 @@ function BuildSpecLib(params_path::String)
 
         # Verify required files
         verify_timing = @timed begin
-            required_files = ["fragments_table.arrow", "prec_to_frag.arrow", "precursors_table.arrow", "proteins_table.arrow"]
+            # The fused path hands detailed_frags to buildPionLib in memory, so it
+            # needs only the precursor/protein tables. The disk path (resume with
+            # predict_fragments=false) still requires the fragment intermediates.
+            required_files = detailed_frags === nothing ?
+                ["fragments_table.arrow", "prec_to_frag.arrow", "precursors_table.arrow", "proteins_table.arrow"] :
+                ["precursors_table.arrow", "proteins_table.arrow"]
             if !all(isfile.(joinpath.(lib_dir, required_files)))
                 error("Missing required files in $lib_dir. Try running with predict_fragments=true")
             end
@@ -390,7 +403,9 @@ function BuildSpecLib(params_path::String)
                 Float32(get(_params.library_params, "frag_bin_tol_ppm", 0.0)),  # frag_bin_tol_ppm (0 = use mDa mode)
                 3.0f0,          # rt_bin_tol
                 koina_model_type;
-                frag_bin_tol_mda = Float32(get(_params.library_params, "frag_bin_tol_mda", 2.0))
+                frag_bin_tol_mda = Float32(get(_params.library_params, "frag_bin_tol_mda", 2.0)),
+                detailed_frags = detailed_frags,
+                pid_to_fid = pid_to_fid
             )
 
             nothing

--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -58,13 +58,19 @@ Output:
 function BuildSpecLib(params_path::String)
     # Clean up any old file handlers in case the program crashed
     GC.gc()
-    Random.seed!(1844)
     timings = Dict{String, Any}()
 
     # Read and validate parameters
     params_timing = @timed begin
         params_string = read(params_path, String)
         params = check_params_bsp(params_string)
+
+        # Deterministic RNG for decoy/entrapment shuffling. Configurable via the
+        # `seed` build param (default 1844, backward-compatible): a fixed seed
+        # makes the library fully reproducible; a different seed produces
+        # different shuffled decoy/entrapment sequences.
+        build_seed = Int(get(params, "seed", 1844))
+        Random.seed!(build_seed)
 
         # Get library directory (already has .poin extension added in check_params)
         lib_dir = params["_lib_dir"]
@@ -99,6 +105,7 @@ function BuildSpecLib(params_path::String)
         @user_print repeat("=", 90)
         @user_info "\nStarting library build at: $(Dates.now())"
         @user_info "Output directory: $lib_dir"
+        @user_info "RNG seed: $build_seed"
 
         # Create temporary chronologer directory
         setup_timing = @timed begin

--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -339,6 +339,13 @@ function BuildSpecLib(params_path::String)
                 )
 
                 GC.gc()
+                # raw_fragments.arrow + precursors.arrow are fully consumed by this
+                # stage (parse_altimeter_fragments + the precursor DataFrame copy).
+                # Delete them now — before buildPionLib + File Verification — so they
+                # don't coexist on disk with the final .poin outputs. Cuts peak disk
+                # by ~(raw + precursors); safeRm = GC + retry for the Windows mmap lock.
+                safeRm(raw_fragments_arrow_path, nothing; force=true)
+                safeRm(precursors_arrow_path, nothing; force=true)
                 nothing
             end
             timings["Prediction Processing"] = process_timing

--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -185,13 +185,16 @@ function BuildSpecLib(params_path::String)
                     3.0f0  # rt_bin_tol for precursor sorting (matches fragment index)
                 )
                 #println("precursors_arrow_path $precursors_arrow_path")
-                # Cleanup temporary files
+                # Cleanup temporary files. Use safeRm (GC + retry + rename
+                # fallback): on Windows the just-read Arrow files are still
+                # mmap-locked, so a plain rm() throws EACCES (GC.gc() alone is
+                # not enough to release the mapping).
                 GC.gc()
-                rm(chronologer_in_path, force=true)
-                rm(chronologer_out_path, force=true)
+                safeRm(chronologer_in_path, nothing; force=true)
+                safeRm(chronologer_out_path, nothing; force=true)
                 dir, filename = splitdir(precursors_arrow_path)
                 raw_fragments_arrow_path = joinpath(dir, "raw_fragments.arrow")
-                rm(raw_fragments_arrow_path, force=true)
+                safeRm(raw_fragments_arrow_path, nothing; force=true)
                 nothing
             end
             timings["Chronologer Output Processing"] = parse_timing

--- a/src/Routines/BuildSpecLib/build/build_poin_lib.jl
+++ b/src/Routines/BuildSpecLib/build/build_poin_lib.jl
@@ -183,6 +183,19 @@ function buildPionLib(spec_lib_path::String,
     model_type
     );
 
+    # fragments_table.arrow + prec_to_frag.arrow are now fully consumed —
+    # getDetailedFrags above is their only reader (pid_to_fid replaces
+    # prec_to_frag; it is serialized as precursor_to_fragment_indices.jls).
+    # Release the mmap handles and delete them now, before we serialize
+    # detailed_fragments.jls + the two index .jls files, so the ~57 MB
+    # fragments_table.arrow never coexists on disk with the final outputs.
+    # Cuts peak disk ~58 MB. safeRm = GC + retry for the Windows mmap lock.
+    fragments_table = nothing
+    prec_to_frag = nothing
+    GC.gc()
+    safeRm(joinpath(spec_lib_path, "fragments_table.arrow"), nothing; force=true)
+    safeRm(joinpath(spec_lib_path, "prec_to_frag.arrow"), nothing; force=true)
+
     # Build partitioned fragment indexes BEFORE sorting detailed_frags by m/z.
     # See sort_detailed_fragments_by_mz! for why the order matters.
     precursors_arrow = Arrow.Table(joinpath(spec_lib_path, "precursors_table.arrow"))

--- a/src/Routines/BuildSpecLib/build/build_poin_lib.jl
+++ b/src/Routines/BuildSpecLib/build/build_poin_lib.jl
@@ -131,6 +131,8 @@ function buildPionLib(spec_lib_path::String,
                       rt_bin_tol_ppm::Float32,
                       model_type::SplineCoefficientModel;
                       frag_bin_tol_mda::Float32 = 2.0f0,
+                      detailed_frags = nothing,
+                      pid_to_fid = nothing,
                       )
     validate_fragment_index_filters(
         y_start_index, y_start,
@@ -138,63 +140,65 @@ function buildPionLib(spec_lib_path::String,
         include_p_index, include_p,
     )
 
-    fragments_table, prec_to_frag, precursors_table = nothing, nothing, nothing
-    try
-        fragments_table = Arrow.Table(joinpath(spec_lib_path,"fragments_table.arrow"));
-        prec_to_frag = Arrow.Table(joinpath(spec_lib_path,"prec_to_frag.arrow"));
-        precursors_table = Arrow.Table(joinpath(spec_lib_path,"precursors_table.arrow"));
-    catch e 
-        @error "could not find library..."
-        return nothing
+    # Fused path (production): detailed_frags + pid_to_fid are handed in from
+    # build_detailed_frags_from_raw — no fragments_table.arrow round-trip.
+    # Disk path (resume with predict_fragments=false, and the unit tests): read
+    # fragments_table.arrow + prec_to_frag.arrow and decode via getDetailedFrags.
+    if detailed_frags === nothing
+        fragments_table, prec_to_frag, precursors_table = nothing, nothing, nothing
+        try
+            fragments_table = Arrow.Table(joinpath(spec_lib_path,"fragments_table.arrow"));
+            prec_to_frag = Arrow.Table(joinpath(spec_lib_path,"prec_to_frag.arrow"));
+            precursors_table = Arrow.Table(joinpath(spec_lib_path,"precursors_table.arrow"));
+        catch e
+            @error "could not find library..."
+            return nothing
+        end
+
+        #println("Get full fragments list...")
+        detailed_frags, pid_to_fid = getDetailedFrags(
+        fragments_table[:mz],
+        fragments_table[:coefficients],
+        fragments_table[:intensity],
+        fragments_table[:is_y],
+        fragments_table[:is_b],
+        fragments_table[:is_p],
+        fragments_table[:fragment_index],
+        fragments_table[:charge],
+        fragments_table[:sulfur_count],
+        fragments_table[:ion_type],
+        fragments_table[:isotope],
+        fragments_table[:is_internal],
+        fragments_table[:is_immonium],
+        fragments_table[:has_neutral_diff],
+        precursors_table[:mz],
+        precursors_table[:prec_charge],#:precursor_charge],
+        precursors_table[:length],
+        prec_to_frag[:start_idx],
+        y_start,
+        b_start,
+        include_p,
+        include_isotope,
+        include_immonium,
+        include_internal,
+        include_neutral_diff,
+        max_frag_charge,
+        frag_bounds,
+        max_frag_rank,
+        length_to_frag_count_multiple,
+        min_frag_intensity,
+        model_type
+        );
+
+        # fragments_table.arrow + prec_to_frag.arrow are now fully consumed —
+        # getDetailedFrags above is their only reader. Release the mmap handles
+        # and delete them before serializing the .jls outputs.
+        fragments_table = nothing
+        prec_to_frag = nothing
+        GC.gc()
+        safeRm(joinpath(spec_lib_path, "fragments_table.arrow"), nothing; force=true)
+        safeRm(joinpath(spec_lib_path, "prec_to_frag.arrow"), nothing; force=true)
     end
-
-    #println("Get full fragments list...")
-    detailed_frags, pid_to_fid = getDetailedFrags(
-    fragments_table[:mz],
-    fragments_table[:coefficients],
-    fragments_table[:intensity],
-    fragments_table[:is_y],
-    fragments_table[:is_b],
-    fragments_table[:is_p],
-    fragments_table[:fragment_index],
-    fragments_table[:charge],
-    fragments_table[:sulfur_count],
-    fragments_table[:ion_type],
-    fragments_table[:isotope],
-    fragments_table[:is_internal],
-    fragments_table[:is_immonium],
-    fragments_table[:has_neutral_diff],
-    precursors_table[:mz],
-    precursors_table[:prec_charge],#:precursor_charge],
-    precursors_table[:length],
-    prec_to_frag[:start_idx],
-    y_start,
-    b_start,
-    include_p,
-    include_isotope,
-    include_immonium,
-    include_internal,
-    include_neutral_diff,
-    max_frag_charge,
-    frag_bounds,
-    max_frag_rank,
-    length_to_frag_count_multiple,
-    min_frag_intensity,
-    model_type
-    );
-
-    # fragments_table.arrow + prec_to_frag.arrow are now fully consumed —
-    # getDetailedFrags above is their only reader (pid_to_fid replaces
-    # prec_to_frag; it is serialized as precursor_to_fragment_indices.jls).
-    # Release the mmap handles and delete them now, before we serialize
-    # detailed_fragments.jls + the two index .jls files, so the ~57 MB
-    # fragments_table.arrow never coexists on disk with the final outputs.
-    # Cuts peak disk ~58 MB. safeRm = GC + retry for the Windows mmap lock.
-    fragments_table = nothing
-    prec_to_frag = nothing
-    GC.gc()
-    safeRm(joinpath(spec_lib_path, "fragments_table.arrow"), nothing; force=true)
-    safeRm(joinpath(spec_lib_path, "prec_to_frag.arrow"), nothing; force=true)
 
     # Build partitioned fragment indexes BEFORE sorting detailed_frags by m/z.
     # See sort_detailed_fragments_by_mz! for why the order matters.

--- a/src/Routines/BuildSpecLib/build/build_poin_lib.jl
+++ b/src/Routines/BuildSpecLib/build/build_poin_lib.jl
@@ -259,6 +259,9 @@ Removes the following files if they exist:
 - `nothing`
 """
 function cleanUpLibrary(spec_lib_path::String)
+    # Debug toggle: keep build intermediates (raw_fragments/fragments_table/
+    # prec_to_frag) for disk-usage analysis. Off by default.
+    haskey(ENV, "PIONEER_KEEP_BUILD_TEMP") && return nothing
     GC.gc()
     for fname in ["raw_fragments.arrow", "fragments_table.arrow", "prec_to_frag.arrow", "precursors.arrow"]
         fpath = joinpath(spec_lib_path, fname)

--- a/src/Routines/BuildSpecLib/chronologer/chronologer_prep.jl
+++ b/src/Routines/BuildSpecLib/chronologer/chronologer_prep.jl
@@ -134,14 +134,14 @@ function prepare_chronologer_input(
         )
         append!(protein_entries, parsed)
         append!(fasta_entries,
-            digest_fasta(
+            _bdiag!("chron_digest_fasta", @timed digest_fasta(
                 parsed,
                 proteome_name,
                 regex = Regex(_params.fasta_digest_params["cleavage_regex"]),
                 max_length = _params.fasta_digest_params["max_length"],
                 min_length = _params.fasta_digest_params["min_length"],
                 missed_cleavages = _params.fasta_digest_params["missed_cleavages"]
-            )
+            ))
         )
     end
 
@@ -154,25 +154,25 @@ function prepare_chronologer_input(
     use_sequence_decoys = _params.fasta_digest_params["add_decoys"] && decoy_method != "diann_mutation"
 
     # Step 1: Combine shared peptides (I/L equivalence)
-    fasta_entries = combine_shared_peptides(fasta_entries)
-    
+    fasta_entries = _bdiag!("chron_combine_shared", @timed combine_shared_peptides(fasta_entries))
+
     # Step 2: Add modifications (creates peptide variants before entrapment)
-    fasta_entries = add_mods(
-        fasta_entries, 
-        fixed_mods, 
+    fasta_entries = _bdiag!("chron_add_mods", @timed add_mods(
+        fasta_entries,
+        fixed_mods,
         var_mods,
-        _params.fasta_digest_params["max_var_mods"])
+        _params.fasta_digest_params["max_var_mods"]))
 
     # Step 3: Assign base_pep_id for peptide tracking (after modifications)
     pep_entries_processed = assign_base_pep_ids!(fasta_entries)
 
     # Step 4: Add entrapment sequences (grouped by base sequence so all mods share the same entrapments)
     entrapment_method = get(_params.fasta_digest_params, "entrapment_method", "shuffle")
-    fasta_entries = add_entrapment_sequences_grouped(
+    fasta_entries = _bdiag!("chron_add_entrapment", @timed add_entrapment_sequences_grouped(
         fasta_entries,
         UInt8(_params.fasta_digest_params["entrapment_r"]);
         entrapment_method = entrapment_method
-    )
+    ))
 
     # Step 5: Assign base_target_id values for entrapment grouping
     assign_base_target_ids!(fasta_entries)
@@ -182,41 +182,42 @@ function prepare_chronologer_input(
     # by apply_diann_decoy_style!() which shifts target fragment m/z values
     if use_sequence_decoys
         @user_info "Generating grouped decoy sequences (method=$decoy_method)"
-        fasta_entries = add_decoy_sequences_grouped(
+        fasta_entries = _bdiag!("chron_add_decoy", @timed add_decoy_sequences_grouped(
             fasta_entries;
             decoy_method = decoy_method
-        )
+        ))
     end
         
     # Step 7: Add charges (creates precursor variants)
-    fasta_entries = add_charge(
+    fasta_entries = _bdiag!("chron_add_charge", @timed add_charge(
         fasta_entries,
         _params.fasta_digest_params["min_charge"],
         _params.fasta_digest_params["max_charge"]
-    )
+    ))
 
     # Build chronologer input dataframe (one row per peptide × charge state)
-    fasta_df = build_fasta_df(
+    fasta_df = _bdiag!("chron_build_fasta_df", @timed build_fasta_df(
         fasta_entries,
         mod_to_mass_dict = mod_to_mass_dict,
         nce = _params.nce_params["nce"]
-    )
+    ))
     # Calculate precursor m/z values
-    fasta_df[!, :mz] = getMZs(
+    fasta_df[!, :mz] = _bdiag!("chron_getMZs", @timed getMZs(
         fasta_df[!, :sequence],
         fasta_df[!, :mods],
         fasta_df[!, :precursor_charge],
         mod_to_mass_float
-    )
+    ))
 
     # Add length and missed cleavages columns
-    fasta_df[!, :length] = UInt8.(length.(fasta_df[!, :sequence]))
-    fasta_df[!, :missed_cleavages] = zeros(UInt8, size(fasta_df, 1))
-    cleavage_regex = Regex(_params.fasta_digest_params["cleavage_regex"])
-    
-    for i in 1:size(fasta_df, 1)
-        fasta_df[i, :missed_cleavages] = count(cleavage_regex, fasta_df[i, :sequence])
-    end
+    _bdiag!("chron_length_missed_cleavages", @timed begin
+        fasta_df[!, :length] = UInt8.(length.(fasta_df[!, :sequence]))
+        fasta_df[!, :missed_cleavages] = zeros(UInt8, size(fasta_df, 1))
+        cleavage_regex = Regex(_params.fasta_digest_params["cleavage_regex"])
+        for i in 1:size(fasta_df, 1)
+            fasta_df[i, :missed_cleavages] = count(cleavage_regex, fasta_df[i, :sequence])
+        end
+    end)
 
     # Filter by mass rang
     filter!(x -> (x.mz >= prec_mz_min) & (x.mz <= prec_mz_max), fasta_df)

--- a/src/Routines/BuildSpecLib/fragments/fragment_parse.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_parse.jl
@@ -655,3 +655,162 @@ function rebuild_prec_to_frag_index!(prec_to_frag_path::String,
     Arrow.write(prec_to_frag_path, DataFrame(start_idx = starts))
     return nothing
 end
+
+"""
+    build_detailed_frags_from_raw(precursor_table, fragment_table, annotation_type,
+        ion_dictionary, immonium_data_path, out_dir, mods_to_sulfur_diff,
+        iso_mod_to_mass, ::SplineCoefficientModel) -> (detailed_frags, prec_to_frag)
+
+Fused replacement for `parse_altimeter_fragments` + `getDetailedFrags`: decode the
+raw Koina fragment table directly into the final `Vector{SplineCompactFrag}` (plus
+the CSR precursor→fragment index) in a single pass, WITHOUT the intermediate
+`fragments_table.arrow` re-encode/re-read.
+
+It reproduces exactly the per-fragment work of `process_spline_batch!` (sulfur count
+over the fragment's sequence span, capped at the precursor sulfur count; isotope-mod
+m/z adjustment; ion-type flags) and the per-precursor positional rank of
+`getDetailedFrags`. `fragment_table` is assumed grouped by ascending `precursor_idx`
+(predict_fragments emits/filters in that order), so a single sequential pass yields
+contiguous per-precursor ranges; the CSR is built first-occurrence-only +
+right-back-filled, identical to `rebuild_prec_to_frag_index!`. `detailed_frags[fi]`
+is 1:1 with raw row `fi` (no filtering happens here — it already happened in
+`filter_fragments!`), so positions match the two-step path.
+
+Still serializes `frag_name_to_idx.jls` + `ion_annotations.jls` (as the two-step path
+did). Returns `(detailed_frags, prec_to_frag)` to be handed to `buildPionLib` in
+memory; nothing fragment-related is written to disk here.
+"""
+function build_detailed_frags_from_raw(
+    precursor_table::Arrow.Table,
+    fragment_table::Arrow.Table,
+    annotation_type::FragAnnotation,
+    ion_dictionary::Dict{Int32, String},
+    immonium_data_path::String,
+    out_dir::String,
+    mods_to_sulfur_diff::Dict{String, Int8},
+    iso_mod_to_mass::Dict{String, Float32},
+    ::SplineCoefficientModel
+)
+    # Annotation feature dict — identical to parse_altimeter_fragments.
+    immonium_to_sulfur_count = get_immonium_sulfur_dict(immonium_data_path)
+    ion_annotation_to_data_dict = Dict{Int32, PioneerFragAnnotation}()
+    atype = typeof(annotation_type)
+    for (ion_idx, ion_name) in ion_dictionary
+        ion_annotation_to_data_dict[ion_idx] = parse_fragment_annotation(
+            atype(ion_name); immonium_to_sulfur_count = immonium_to_sulfur_count)
+    end
+
+    coef_col = fragment_table[:coefficients]
+    coef_type = eltype(coef_col)
+    N = length(coef_type.parameters)
+    T = eltype(coef_type)
+    n_frags  = length(fragment_table[:mz])
+    n_precursors = length(precursor_table[1])
+    detailed = Vector{SplineCompactFrag{N, T}}(undef, n_frags)
+    prec_to_frag = fill(zero(UInt64), n_precursors + 1)
+
+    # Function barrier: the Arrow.Table columns are abstractly typed at this call
+    # site (Arrow.Table getindex returns Any), so pass them to a kernel that
+    # specializes on their concrete element types (ChainedVector{Int32}, ...) for
+    # a type-stable hot loop — the pattern getDetailedFrags gets from its signature.
+    _fill_detailed_from_raw!(
+        detailed, prec_to_frag,
+        fragment_table[:annotation], fragment_table[:precursor_idx],
+        fragment_table[:mz], coef_col,
+        precursor_table[:sequence], precursor_table[:mods],
+        precursor_table[:isotope_mods], precursor_table[:precursor_charge],
+        ion_annotation_to_data_dict, mods_to_sulfur_diff, iso_mod_to_mass,
+        n_frags, n_precursors)
+
+    serialize_to_jls(joinpath(out_dir, "frag_name_to_idx.jls"), ion_dictionary)
+    serialize_to_jls(joinpath(out_dir, "ion_annotations.jls"), ion_annotation_to_data_dict)
+    return detailed, prec_to_frag
+end
+
+# Type-stable kernel for build_detailed_frags_from_raw. Reproduces
+# process_spline_batch!'s per-fragment decode (sulfur over the fragment's sequence
+# span capped at the precursor sulfur; isotope-mod m/z shift; ion flags) and
+# getDetailedFrags's per-precursor positional rank, emitting SplineCompactFrag at
+# detailed[fi] (1:1 with raw row fi). Builds the CSR prec_to_frag first-occurrence-
+# only + right-back-filled, identical to rebuild_prec_to_frag_index!.
+function _fill_detailed_from_raw!(
+    detailed::Vector{SplineCompactFrag{N, T}},
+    prec_to_frag::Vector{UInt64},
+    frag_ann, frag_pid, frag_mzs, coef_col,
+    seqs, mods_col, iso_mod_col, charge_col,
+    ion_dict::Dict{Int32, PioneerFragAnnotation},
+    mods_to_sulfur_diff::Dict{String, Int8},
+    iso_mod_to_mass::Dict{String, Float32},
+    n_frags::Int, n_precursors::Int) where {N, T}
+
+    seq_idx_to_sulfur  = zeros(UInt8, 255)
+    seq_idx_to_iso_mod = zeros(Float32, 255)
+    last_pid = zero(UInt32)
+    prec_sulfur_count = 0
+    prec_length = zero(UInt8)
+    prec_charge = zero(UInt8)
+    rank = 0
+
+    @inbounds for fi in 1:n_frags
+        pid = frag_pid[fi]
+        if pid != last_pid
+            last_pid = pid
+            rank = 0
+            if prec_to_frag[pid] == 0
+                prec_to_frag[pid] = UInt64(fi)
+            end
+            fill!(seq_idx_to_sulfur, zero(UInt8))
+            fill!(seq_idx_to_iso_mod, zero(Float32))
+            seq = seqs[pid]
+            prec_sulfur_count = Int(count_sulfurs!(
+                seq_idx_to_sulfur, seq, parseMods(mods_col[pid]), mods_to_sulfur_diff))
+            fill_isotope_mods!(seq_idx_to_iso_mod, parseMods(iso_mod_col[pid]), iso_mod_to_mass)
+            prec_length = UInt8(length(seq))
+            prec_charge = UInt8(charge_col[pid])
+        end
+        rank += 1
+
+        frag_data = ion_dict[frag_ann[fi]]
+        start_idx, stop_idx = get_fragment_indices(
+            frag_data.base_type, frag_data.frag_index, prec_length)
+
+        sulfur_count = 0
+        if !frag_data.immonium
+            for i in start_idx:stop_idx
+                sulfur_count += seq_idx_to_sulfur[i]
+            end
+        end
+        sulfur_count += frag_data.sulfur_diff
+
+        frag_mz = frag_mzs[fi] + apply_isotope_mod(
+            frag_data.charge, seq_idx_to_iso_mod, start_idx, stop_idx)
+
+        detailed[fi] = SplineCompactFrag(
+            UInt32(pid),
+            frag_mz,
+            coef_col[fi],
+            frag_data.base_type == 'y',
+            frag_data.base_type == 'b',
+            frag_data.base_type == 'p',
+            frag_data.isotope > 0,
+            frag_data.charge,
+            frag_data.frag_index,
+            prec_charge,
+            UInt8(rank),
+            UInt8(min(sulfur_count, prec_sulfur_count)),
+        )
+    end
+
+    # CSR boundaries: final boundary + right-back-fill so empty precursors inherit
+    # the next non-empty start (identical to rebuild_prec_to_frag_index!).
+    prec_to_frag[end] = UInt64(n_frags + 1)
+    next = prec_to_frag[end]
+    for i in n_precursors:-1:1
+        if prec_to_frag[i] == 0
+            prec_to_frag[i] = next
+        else
+            next = prec_to_frag[i]
+        end
+    end
+    return nothing
+end

--- a/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
@@ -175,7 +175,9 @@ function predict_fragments_batch(
 
     for (i, response) in enumerate(responses)
         batch_result = _bdiag!("parse_koina_batch", @timed parse_koina_batch(model, response))
-        start_idx = (i-1) * batch_size + 1 + first_prec_idx - 1
+        # Keep precursor_idx UInt32 (not Int64) — it is a precursor row index; the
+        # +1-1 cancels. Halves this per-fragment column on disk (8 B -> 4 B).
+        start_idx = first_prec_idx + UInt32((i-1) * batch_size)
 
         batch_df = batch_result.fragments
         n_precursors_in_batch = UInt32(fld(size( batch_df , 1), batch_result.frags_per_precursor))
@@ -303,7 +305,7 @@ function filter_fragments!(df::DataFrame, model::SplineCoefficientModel,
     # ::Vector{T} assertions restore type stability (and act as a schema guard).
     annotations = df[!, :annotation]::Vector{Int32}
     mzs         = df[!, :mz]::Vector{Float32}
-    pids        = df[!, :precursor_idx]::Vector{Int64}
+    pids        = df[!, :precursor_idx]::Vector{UInt32}
 
     keep = trues(n_rows)
 

--- a/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
+++ b/src/Routines/BuildSpecLib/fragments/fragment_predict.jl
@@ -63,6 +63,27 @@ end
 
 Fragment prediction dispatcher for the Altimeter (SplineCoefficientModel) Koina endpoint.
 """
+# ── Env-gated fragment-prediction sub-step diagnostics (PIONEER_DIAG_BUILD=1) ──
+# Accumulates @timed (seconds, bytes) per labelled sub-step; printed at the end of
+# predict_fragments. Zero behavior change; only active when the env var is set.
+const _BUILD_DIAG = Dict{String, Vector{Float64}}()
+@inline _bdiag_on() = get(ENV, "PIONEER_DIAG_BUILD", "0") != "0"
+@inline function _bdiag!(label::String, r)
+    if _bdiag_on()
+        v = get!(_BUILD_DIAG, label, [0.0, 0.0])
+        v[1] += r.time; v[2] += r.bytes
+    end
+    return r.value
+end
+function _bdiag_report()
+    (_bdiag_on() && !isempty(_BUILD_DIAG)) || return
+    @user_info "[BUILD DIAG] fragment-prediction sub-steps (cumulative):"
+    for (k, v) in sort(collect(_BUILD_DIAG), by = x -> -x[2][2])
+        @user_info "  $(rpad(k, 26)) $(round(v[1], digits=2)) s   $(round(v[2]/1e9, digits=2)) GB"
+    end
+    empty!(_BUILD_DIAG)
+end
+
 function predict_fragments(
     peptide_table_path::String,
     frags_out_path::String,
@@ -123,9 +144,10 @@ function predict_fragments(
                 Arrow.write(io, frags_out; file=false, metadata=metadata)
             end
         else
-            Arrow.append(frags_out_path, frags_out)
+            _bdiag!("arrow_append", @timed Arrow.append(frags_out_path, frags_out))
         end
     end
+    _bdiag_report()
 end
 
 """
@@ -140,31 +162,31 @@ function predict_fragments_batch(
     concurrent_koina_requests::Int,
     first_prec_idx::UInt32
 )::Tuple{DataFrame, Vector{Float32}}
-    json_batches = prepare_koina_batch(
+    json_batches = _bdiag!("prepare_koina_batch", @timed prepare_koina_batch(
         model,
         peptides_df,
         batch_size=batch_size
-    )
+    ))
 
-    responses = make_koina_batch_requests(json_batches, KOINA_URLS[model.name]; concurrency=concurrent_koina_requests)
+    responses = _bdiag!("koina_request", @timed make_koina_batch_requests(json_batches, KOINA_URLS[model.name]; concurrency=concurrent_koina_requests))
 
     batch_dfs = []
     knot_vectors = []
 
     for (i, response) in enumerate(responses)
-        batch_result = parse_koina_batch(model, response)
+        batch_result = _bdiag!("parse_koina_batch", @timed parse_koina_batch(model, response))
         start_idx = (i-1) * batch_size + 1 + first_prec_idx - 1
 
         batch_df = batch_result.fragments
         n_precursors_in_batch = UInt32(fld(size( batch_df , 1), batch_result.frags_per_precursor))
         batch_df[!, :precursor_idx] = repeat(start_idx:(start_idx + n_precursors_in_batch - one(UInt32)),
                                                 inner=batch_result.frags_per_precursor)
-        filter_fragments!(batch_df, model, filter_ctx)
+        _bdiag!("filter_fragments", @timed filter_fragments!(batch_df, model, filter_ctx))
         push!(batch_dfs, batch_df)
         push!(knot_vectors, batch_result.extra_data)  # Store knot vectors
     end
 
-    fragments_df = vcat(batch_dfs...)
+    fragments_df = _bdiag!("vcat_batch_dfs", @timed vcat(batch_dfs...))
 
     # Verify knot vectors are consistent
     if !all(k == first(knot_vectors) for k in knot_vectors)
@@ -276,9 +298,12 @@ function filter_fragments!(df::DataFrame, model::SplineCoefficientModel,
     n_rows = nrow(df)
     n_rows == 0 && return df
 
-    annotations = df[!, :annotation]
-    mzs         = df[!, :mz]
-    pids        = df[!, :precursor_idx]
+    # Concrete column types: df[!, :col] is inferred as AbstractVector, so col[i]
+    # in the hot per-fragment loop below returns Any and boxes every read. The
+    # ::Vector{T} assertions restore type stability (and act as a schema guard).
+    annotations = df[!, :annotation]::Vector{Int32}
+    mzs         = df[!, :mz]::Vector{Float32}
+    pids        = df[!, :precursor_idx]::Vector{Int64}
 
     keep = trues(n_rows)
 

--- a/src/Routines/BuildSpecLib/koina/koina_batch_parse.jl
+++ b/src/Routines/BuildSpecLib/koina/koina_batch_parse.jl
@@ -15,6 +15,25 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+# Reshape the flat (n_precs × K × F) coefficient array into one NTuple{K} per
+# fragment. Function barrier specialized on K (Val) so the hot loop is type
+# stable: `flat` is a concrete Vector{Float32} and `ntuple(_, Val(K))` returns a
+# concrete NTuple{K,Float32}, eliminating the per-element boxing that occurs when
+# the loop runs over the `Any`-typed response data directly.
+@inline function _build_coefs(flat::Vector{Float32}, n_precs::Int, n_frags::Int,
+                              ::Val{K}) where {K}
+    coefs = Vector{NTuple{K, Float32}}(undef, n_precs * n_frags)
+    idx = 1
+    @inbounds for i in 1:n_precs
+        base_i = (i - 1) * K * n_frags
+        for j in 1:n_frags
+            coefs[idx] = ntuple(k -> flat[base_i + j + (k - 1) * n_frags], Val(K))
+            idx += 1
+        end
+    end
+    return coefs
+end
+
 """
 Parse results for spline coefficient models.
 """
@@ -33,32 +52,25 @@ function parse_koina_batch(model::SplineCoefficientModel,
     end
     coefficients_output === nothing && throw(ArgumentError(
         "SplineCoefficientModel response is missing a 'coefficients' output"))
-    n_precs, n_coef_per_frag, n_frags = coefficients_output["shape"]
+    # shape comes from a Dict{String,Any}; make the dims concrete Ints so the
+    # loops/typing below are stable.
+    n_precs, n_coef_per_frag, n_frags = Int.(coefficients_output["shape"])
     knot_vector = Float32[]
 
     for col in response["outputs"]
         col_name = Symbol(col["name"])
         if col_name == :coefficients
-            flat_coeffs = Float32.(col["data"])
-            coefs = Vector{NTuple{n_coef_per_frag, Float32}}(undef, n_precs * n_frags)
-
-            idx = 1
-            for i in 1:n_precs
-                for j in 1:n_frags
-                    coefs[idx] = ntuple(k ->
-                        flat_coeffs[(i-1)*n_coef_per_frag*n_frags + j + (k-1)*n_frags],
-                        n_coef_per_frag)
-                    idx += 1
-                end
-            end
-            df[!, :coefficients] = coefs
-
+            # `col["data"]` is Any; assert the converted result is Vector{Float32}
+            # so the reshape loop (in _build_coefs) is allocation-free.
+            flat_coeffs = Float32.(col["data"])::Vector{Float32}
+            df[!, :coefficients] = _build_coefs(flat_coeffs, n_precs, n_frags,
+                                                Val(n_coef_per_frag))
         elseif col_name == :knots
-            knot_vector = Float32.(col["data"])
+            knot_vector = Float32.(col["data"])::Vector{Float32}
         elseif col_name == :mz
-            df[!, col_name] = Float32.(col["data"])
+            df[!, :mz] = Float32.(col["data"])::Vector{Float32}
         elseif col_name == :annotations
-            df[!, :annotation] = Int32.(col["data"])
+            df[!, :annotation] = Int32.(col["data"])::Vector{Int32}
         end
     end
 

--- a/test/Routines/BuildSpecLib/fragments/test_get_frag_bounds.jl
+++ b/test/Routines/BuildSpecLib/fragments/test_get_frag_bounds.jl
@@ -191,7 +191,7 @@
             @test result.prec_mz_max == 1300.0
         end
         
-        rm(temp_dir, recursive=true)
+        safe_rmdir(temp_dir)
     end
     
     @testset "FragBoundModel usage" begin

--- a/test/Routines/BuildSpecLib/params/test_fasta_params.jl
+++ b/test/Routines/BuildSpecLib/params/test_fasta_params.jl
@@ -15,7 +15,7 @@ using CodecZlib
     if isdir(test_data_dir)
         for item in readdir(test_data_dir, join=true)
             if endswith(item, ".json") || isdir(item)
-                rm(item, force=true, recursive=true)
+                safe_rmdir(item)
             end
         end
     else

--- a/test/Routines/BuildSpecLib/test_build_determinism.jl
+++ b/test/Routines/BuildSpecLib/test_build_determinism.jl
@@ -1,0 +1,92 @@
+# Determinism of BuildSpecLib (content-based).
+#
+# Verifies that, under the deterministic SyntheticKoinaClient:
+#   * the same `seed` reproduces a byte-for-content-identical library
+#     (precursors/proteins/fragments + the *content* of the fragment index —
+#     the index .jls serialization layout is not byte-stable, but its content
+#     is), and
+#   * a different `seed` produces different shuffled decoy sequences (so the
+#     library content changes).
+#
+# Run standalone:  julia --project=. -e 'using Pioneer; include("test/Routines/BuildSpecLib/test_build_determinism.jl")'
+
+using Test
+using Pioneer
+
+const _REPO_ROOT = abspath(joinpath(@__DIR__, "..", "..", ".."))
+
+# Content fingerprint of a built .poin. Byte-hashes the byte-deterministic
+# payload files and content-hashes the fragment indexes (whose serialized bytes
+# vary by object-encoding but whose content is deterministic). Uses Julia's
+# content-based `hash` (not randomized across processes).
+function _lib_content_fingerprint(lib::AbstractString)
+    h = UInt(0)
+    for f in ("precursors_table.arrow", "proteins_table.arrow", "detailed_fragments.jls")
+        h = hash(read(joinpath(lib, f)), h)
+    end
+    for f in ("partitioned_fragment_index.jls", "presearch_partitioned_fragment_index.jls")
+        idx = Pioneer.deserialize_from_jls(joinpath(lib, f))
+        for p in idx.partitions
+            s = p.fragment_bins
+            h = hash(s.lows, h); h = hash(s.highs, h)
+            h = hash(s.first_bins, h); h = hash(s.last_bins, h)
+            h = hash(getfield.(p.fragments, 1), h)   # prec local id
+            h = hash(getfield.(p.fragments, 2), h)   # score
+            for fi in 1:4                            # FragIndexBin: lb, ub, first_bin, last_bin
+                h = hash(getfield.(p.rt_bins, fi), h)
+            end
+            h = hash(p.local_to_global, h)
+            h = hash(p.skip_hints, h)
+            h = hash(p.n_local_precs, h)
+        end
+        h = hash(idx.partition_bounds, h)
+        h = hash(idx.n_partitions, h)
+    end
+    return h
+end
+
+# Build keap1 offline with a given seed into <outdir>/<name>.poin; returns the path.
+function _build_keap1(outdir::AbstractString, name::AbstractString, seed::Int)
+    base = read(joinpath(_REPO_ROOT, "test", "integration", "build_keap1.json"), String)
+    fwd(p) = replace(p, "\\" => "/")
+    s = base
+    s = replace(s, r"\"out_dir\"\s*:\s*\"[^\"]*\""      => "\"out_dir\": \"$(fwd(outdir))\"")
+    s = replace(s, r"\"lib_name\"\s*:\s*\"[^\"]*\""     => "\"lib_name\": \"$name\"")
+    s = replace(s, r"\"new_lib_name\"\s*:\s*\"[^\"]*\"" => "\"new_lib_name\": \"$name\"")
+    s = replace(s, r"\"library_path\"\s*:\s*\"[^\"]*\"" => "\"library_path\": \"$(fwd(outdir))/$name\"")
+    # Inject/override the seed (add it before the closing brace if absent).
+    if occursin(r"\"seed\"\s*:", s)
+        s = replace(s, r"\"seed\"\s*:\s*\d+" => "\"seed\": $seed")
+    else
+        s = replace(s, r"\}\s*$" => ",\n  \"seed\": $seed\n}")
+    end
+    cfg = joinpath(outdir, "cfg_$name.json")
+    open(io -> write(io, s), cfg, "w")
+    cd(_REPO_ROOT) do
+        Pioneer.with_koina_client(Pioneer.SyntheticKoinaClient()) do
+            BuildSpecLib(cfg)
+        end
+    end
+    return joinpath(outdir, "$name.poin")
+end
+
+@testset "BuildSpecLib determinism (content-based, seeded)" begin
+    tmp = mktempdir()
+    try
+        libA = _build_keap1(tmp, "det_a", 1844)
+        libB = _build_keap1(tmp, "det_b", 1844)   # same seed
+        libC = _build_keap1(tmp, "det_c", 9999)   # different seed
+
+        fpA = _lib_content_fingerprint(libA)
+        fpB = _lib_content_fingerprint(libB)
+        fpC = _lib_content_fingerprint(libC)
+
+        @test fpA == fpB        # same seed → identical library content
+        @test fpA != fpC        # different seed → different shuffled decoys
+    finally
+        # Best-effort cleanup; on Windows the just-built Arrow files may still be
+        # mmap-locked in-process, so don't fail the test on a cleanup ENOTEMPTY.
+        GC.gc()
+        try; rm(tmp; recursive=true, force=true); catch; end
+    end
+end

--- a/test/UnitTests/BuildPionLibTest.jl
+++ b/test/UnitTests/BuildPionLibTest.jl
@@ -179,7 +179,7 @@
     end
     
     # Clean up test directory
-    rm(test_dir, recursive=true)
+    safe_rmdir(test_dir)
 end
 
 @testset "BuildPionLib" begin
@@ -308,8 +308,8 @@ end
 
 
         # Clean up
-        rm(test_dir, recursive=true)
-        rm(spline_test_dir, recursive=true)
+        safe_rmdir(test_dir)
+        safe_rmdir(spline_test_dir)
     end
     
     #==========================================================================
@@ -347,7 +347,7 @@ end
         @test isfile(joinpath(test_dir, "detailed_fragments.jls"))
         
         # Clean up
-        rm(test_dir, recursive=true)
+        safe_rmdir(test_dir)
     end
     
     #==========================================================================
@@ -954,7 +954,7 @@ end
         @test length(presearch_rt_bins.FragIndexBin) <= length(standard_rt_bins.FragIndexBin)
         
         # Clean up
-        rm(test_dir, recursive=true)
+        safe_rmdir(test_dir)
     end
 
     # The "getDetailedFrags with SplineCoefficientModel" @testset (~190 lines)

--- a/test/UnitTests/FastaDigestTests.jl
+++ b/test/UnitTests/FastaDigestTests.jl
@@ -210,8 +210,8 @@
         @test all(e -> get_proteome(e) == "mouse", entries_gz)
         
         # Clean up
-        rm(temp_fasta)
-        rm(temp_fasta_gz)
+        safe_rmdir(temp_fasta)
+        safe_rmdir(temp_fasta_gz)
         
         # Test invalid file extension
         @test_throws ErrorException parse_fasta(tempname() * ".txt", "human")
@@ -250,7 +250,7 @@
         @test get_gene(entries[2]) == "FAM168B"
         @test get_organism(entries[2]) == "Homo sapiens"
 
-        rm(temp_fasta)
+        safe_rmdir(temp_fasta)
     end
     
     #==========================================================================

--- a/test/UnitTests/test_build_fragment_index_exact.jl
+++ b/test/UnitTests/test_build_fragment_index_exact.jl
@@ -45,6 +45,6 @@ using Pioneer: SimpleFrag, buildFragmentIndex!
             (UInt32(4), 520.0f0, UInt8(40), UInt8(2)),
         ]
     finally
-        rm(test_dir; recursive=true, force=true)
+        safe_rmdir(test_dir)
     end
 end

--- a/test/UnitTests/test_buildpionlib_index_filters.jl
+++ b/test/UnitTests/test_buildpionlib_index_filters.jl
@@ -103,7 +103,7 @@ using Pioneer: FragBoundModel, SplineCoefficientModel, buildPionLib, serialize_t
         @test frag_bins.highs[1:2] == Float32[140.0, 230.0]
         @test UInt8[Pioneer.getScore(f) for f in indexed_fragments] == UInt8[1, 2]
     finally
-        rm(test_dir; recursive=true, force=true)
+        safe_rmdir(test_dir)
     end
 end
 

--- a/test/UnitTests/test_buildspeclib_filter_equivalence.jl
+++ b/test/UnitTests/test_buildspeclib_filter_equivalence.jl
@@ -26,18 +26,27 @@
 
 using Test
 using Pioneer
+import JSON
 
 @testset "BuildSpecLib early-filter equivalence (keap1, synthetic)" begin
     repo_root = abspath(joinpath(@__DIR__, "..", ".."))
-    build_params = joinpath(repo_root, "test", "integration", "build_keap1.json")
-    lib_path     = joinpath(repo_root, "test", "integration", "keap1_lib.poin")
-    ref_dir      = joinpath(repo_root, "test", "integration", "keap1_reference")
+    base_params = joinpath(repo_root, "test", "integration", "build_keap1.json")
+    ref_dir     = joinpath(repo_root, "test", "integration", "keap1_reference")
 
-    @test isfile(build_params)
+    @test isfile(base_params)
     @test isfile(joinpath(ref_dir, "detailed_fragments.jls"))
 
-    # Clean stale build output so the test runs from scratch.
-    isdir(lib_path) && rm(lib_path; recursive=true, force=true)
+    # Build into a private temp dir, NOT the shared ./test/integration/keap1_lib.poin
+    # that the synthetic-build test also targets. Two builds to the same .poin path
+    # in one process leave mmap'd Arrow files locked on Windows, so the second build
+    # fails ("Invalid argument"). A unique out_dir decouples the two tests.
+    out_dir = mktempdir()
+    cfg = JSON.parsefile(base_params)
+    cfg["out_dir"]      = out_dir
+    cfg["library_path"] = joinpath(out_dir, "keap1_lib")
+    build_params = joinpath(out_dir, "build_keap1.json")
+    open(io -> JSON.print(io, cfg), build_params, "w")
+    lib_path = joinpath(out_dir, "keap1_lib.poin")
 
     cd(repo_root) do
         Pioneer.with_koina_client(Pioneer.SyntheticKoinaClient()) do
@@ -57,5 +66,5 @@ using Pioneer
           read(joinpath(lib_path, "detailed_fragments.jls"))
 
     # Cleanup
-    isdir(lib_path) && rm(lib_path; recursive=true, force=true)
+    safe_rmdir(out_dir)
 end

--- a/test/integration/test_buildspeclib_synthetic.jl
+++ b/test/integration/test_buildspeclib_synthetic.jl
@@ -19,7 +19,7 @@ using Pioneer
     @test isfile(build_params)
 
     # Clean any previous output so the test is deterministic.
-    isdir(lib_path) && rm(lib_path; recursive=true, force=true)
+    safe_rmdir(lib_path)
 
     cd(repo_root) do
         Pioneer.with_koina_client(Pioneer.SyntheticKoinaClient()) do
@@ -36,5 +36,5 @@ using Pioneer
     end
 
     # Cleanup
-    isdir(lib_path) && rm(lib_path; recursive=true, force=true)
+    safe_rmdir(lib_path)
 end

--- a/test/runtests_part3_units.jl
+++ b/test/runtests_part3_units.jl
@@ -55,6 +55,7 @@ include("./UnitTests/test_synthetic_koina.jl")
 include("./UnitTests/test_koina_http_retry.jl")
 include("./Routines/BuildSpecLib/fragments/test_get_frag_bounds.jl")
 include("./integration/test_buildspeclib_synthetic.jl")
+include("./Routines/BuildSpecLib/test_build_determinism.jl")
 include("./UnitTests/test_buildspeclib_filter_equivalence.jl")
 
 # Parallel utilities

--- a/test/test_setup.jl
+++ b/test/test_setup.jl
@@ -73,3 +73,28 @@ Pioneer.DEBUG_CONSOLE_LEVEL[] = 0
 
 # Test-specific directory paths.
 const main_dir = joinpath(@__DIR__, "../src")
+
+# Windows-robust recursive removal for test cleanup. BuildSpecLib tests leave
+# memory-mapped Arrow/.jls files (inside .poin dirs) whose OS handles Windows
+# keeps open until GC runs the finalizers, so a plain `rm(...; recursive=true)`
+# throws ENOTEMPTY/EACCES and turns into a spurious test *error* that aborts the
+# whole test part. GC to release the mmaps, retry with backoff, and on final
+# failure warn (never throw) so cleanup can never fail the suite. On POSIX the
+# first rm succeeds immediately.
+function safe_rmdir(path::AbstractString; max_tries::Int=5)
+    (isdir(path) || isfile(path)) || return nothing
+    for i in 1:max_tries
+        try
+            GC.gc(); GC.gc()
+            rm(path; recursive=true, force=true)
+            return nothing
+        catch err
+            if i == max_tries
+                @warn "safe_rmdir: could not remove $path after $max_tries attempts" err
+                return nothing
+            end
+            sleep(0.2 * i)
+        end
+    end
+    return nothing
+end

--- a/test/utils/FileOperations/pipeline/test_pipeline_filtering.jl
+++ b/test/utils/FileOperations/pipeline/test_pipeline_filtering.jl
@@ -117,7 +117,7 @@ This test file covers:
         end
         
         # Clean up
-        rm(temp_dir, recursive=true)
+        safe_rmdir(temp_dir)
     end
     
     @testset "filter_by_multiple_thresholds Tests" begin
@@ -271,7 +271,7 @@ This test file covers:
         end
         
         # Clean up
-        rm(temp_dir, recursive=true)
+        safe_rmdir(temp_dir)
     end
     
     @testset "Helper Functions Tests" begin
@@ -371,7 +371,7 @@ This test file covers:
         @test issorted(result_df.score, rev=true)
         
         # Clean up
-        rm(temp_dir, recursive=true)
+        safe_rmdir(temp_dir)
     end
     
     @testset "Performance with Large Datasets" begin
@@ -414,6 +414,6 @@ This test file covers:
         @test elapsed < 2.0  # Should complete in under 2 seconds for complex filter
         
         # Clean up
-        rm(temp_dir, recursive=true)
+        safe_rmdir(temp_dir)
     end
 end


### PR DESCRIPTION
## Summary

Performance optimization of `BuildSpecLib` (spectral-library build). Output is verified **byte-for-content-identical** at every step — a content fingerprint (byte-hash of `precursors_table.arrow` / `proteins_table.arrow` / `detailed_fragments.jls` + content-hash of the two fragment-index `.jls`) gates each change.

Three independent wins:

1. **Type-stability** in the fragment hot paths — `filter_fragments!` and `parse_koina_batch` read abstractly-typed DataFrame / `Dict{String,Any}` columns, boxing every per-fragment access across tens of millions of fragments.
2. **Disk discipline** — delete consumed intermediates (`raw_fragments.arrow`, `fragments_table.arrow`, `precursors.arrow`) as soon as they're consumed rather than at the end; narrow `precursor_idx` `Int64` -> `UInt32`.
3. **Fusion (#1)** — decode `raw_fragments` directly into the final `Vector{SplineCompactFrag}` + CSR index in a single pass (`build_detailed_frags_from_raw`), eliminating the `fragments_table.arrow` round-trip (Arrow encode + re-read + re-decode). `buildPionLib` keeps the on-disk path as a fallback (used by `predict_fragments=false` resume and the unit tests).

## Results — three-proteome build (human + yeast + E. coli, 10,713,240 precursors / 107M fragments)

A/B vs the pre-optimization baseline (`develop` + only the Windows-EACCES fix, the runnable baseline):

| Metric | Baseline | Branch | Delta |
|---|---|---|---|
| Content fingerprint | `10987503830510232999` | `10987503830510232999` | **identical** |
| Total runtime | 55.8 min | 17.7 min | **-68% (3.1x)** |
| Total allocation | 1417 GB | 439 GB | **-69% (3.2x)** |
| Peak RSS | 14.9 GB | 13.1 GB | **-12%** |

Per-stage: Fragment Prediction 2354 s / 1126 GB -> 449 s / 303 GB (type-stability); Prediction Processing 284 s / 99 GB -> 30 s / 7.6 GB (fusion); Index Building 508 s / 112 GB -> 388 s / 49 GB (fusion). Peak on-disk during build (E. coli, polled): 233 MB -> 96 MB (-59%).

## Correctness

- Content fingerprint **identical** baseline vs branch at 10.7M-precursor scale, and on every per-step E. coli verification.
- `test_buildspeclib_filter_equivalence` byte-compares the built `detailed_fragments.jls` against a committed reference — passes.
- New: configurable RNG `seed` build param (same seed -> identical library; different seed -> different decoys) + a content-determinism unit test.

## Tests

`runtests_part2` and `runtests_part3` pass; the part-1 BuildSpecLib scenario tests (`test_build_spec_lib.jl`, `test_fasta_params.jl`) pass. Also includes a test-robustness fix: Windows-only mmap cleanup flakes (`ENOTEMPTY` / `EACCES` / `EBUSY`) in test teardown were aborting the suite on local Windows runs (Linux CI was unaffected) — fixed with a `safe_rmdir` helper in `test_setup.jl` and by decoupling the two keap1-building tests onto separate output paths. No production behavior change.

## Not included (noted for follow-up)

- `build_fasta_df` string-concat in Chronologer Preparation (~55 GB / 121 s at 3-proteome scale) — the single largest remaining allocation target, untouched here.
- Full `part1_heavy` (SearchDIA integration) was not re-run; it is unrelated to these build-library changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
