### PR TITLE
[codex] Add MBR empirical spectra Hellinger

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/PrecursorScoringSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/PrecursorScoringSearch.jl
@@ -203,6 +203,7 @@ function summarize_results!(
             main_search_psms_folder,
             valid_fold_paths,
             getPrecursors(getSpecLib(search_context)),
+            getFragmentLookupTable(getSpecLib(search_context)),
             max_psms,
             params.q_value_threshold,
             FORCE_OOM;

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/mbr_ftr.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/mbr_ftr.jl
@@ -75,6 +75,7 @@ const FTR_FEATURES_F_TRUE = Symbol[
     # ~5,900 gain at rank #6 in rtv4 alongside trace_prob_infold.
     # Don't drop without first restoring the in-fold score context.
     :MBR_best_rt_diff_true,
+    :MBR_smoothed_frag_hellinger_true,
 ]
 # Dropped 2026-05-16:
 #   :MBR_top_n_median_score_true / :MBR_top_n_irt_diff_true
@@ -100,6 +101,7 @@ const FTR_FEATURES_F_FALSE = Symbol[
     f === :MBR_best_irt_diff_true        ? :MBR_best_irt_diff_false :
     f === :MBR_log_by_diff_true          ? :MBR_log_by_diff_false :
     f === :MBR_best_rt_diff_true         ? :MBR_best_rt_diff_false :
+    f === :MBR_smoothed_frag_hellinger_true ? :MBR_smoothed_frag_hellinger_false :
     f
     for f in FTR_FEATURES_F_TRUE
 ]

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/mbr_streaming.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/mbr_streaming.jl
@@ -38,18 +38,133 @@
 # another file. Holds the bare minimum so the donor dict stays small.
 struct _MBRDonorEntry
     trace_prob::Float32
+    precursor_idx::UInt32
     weight::Float32
     log2_intensity_explained::Float32
     irt_residual::Float32  # irt_pred − irt_obs of the donor row
     irt_obs::Float32       # raw observed iRT of the donor row
     log_by_ratio::Float32  # log(b_int+1) − log(y_int+1) of the donor row
     rt_obs::Float32        # literal scan RT (minutes) of the donor row
+    smoothed_frag_sqrt::NTuple{8, Float32}
     ms_file_idx::UInt32
     is_decoy::Bool
 end
 
 const MBR_SIDECAR_SUFFIX = ".mbr_sidecar.arrow"
 const MBR_MAX_DONOR_FILES_PER_PRECURSOR = 2
+const MBR_SMOOTHED_SPECTRUM_EMPTY_SQRT = ntuple(_ -> 0.0f0, 8)
+
+struct _MBRFragmentAnnotationKeys
+    keys::Vector{UInt16}
+end
+
+@inline function _mbr_smoothed_fragment_intensity(frag_cols, row::Integer, rank::Integer)
+    value = Float32(frag_cols[rank][row])
+    return isfinite(value) ? max(value, 0.0f0) : 0.0f0
+end
+
+@inline function _mbr_smoothed_spectrum_sqrt_tuple(frag_cols, row::Integer)
+    f1 = _mbr_smoothed_fragment_intensity(frag_cols, row, 1)
+    f2 = _mbr_smoothed_fragment_intensity(frag_cols, row, 2)
+    f3 = _mbr_smoothed_fragment_intensity(frag_cols, row, 3)
+    f4 = _mbr_smoothed_fragment_intensity(frag_cols, row, 4)
+    f5 = _mbr_smoothed_fragment_intensity(frag_cols, row, 5)
+    f6 = _mbr_smoothed_fragment_intensity(frag_cols, row, 6)
+    f7 = _mbr_smoothed_fragment_intensity(frag_cols, row, 7)
+    f8 = _mbr_smoothed_fragment_intensity(frag_cols, row, 8)
+    frag_sum = f1 + f2 + f3 + f4 + f5 + f6 + f7 + f8
+    frag_sum > 0.0f0 || return MBR_SMOOTHED_SPECTRUM_EMPTY_SQRT
+
+    inv_sum = 1.0f0 / frag_sum
+    return (
+        sqrt(f1 * inv_sum),
+        sqrt(f2 * inv_sum),
+        sqrt(f3 * inv_sum),
+        sqrt(f4 * inv_sum),
+        sqrt(f5 * inv_sum),
+        sqrt(f6 * inv_sum),
+        sqrt(f7 * inv_sum),
+        sqrt(f8 * inv_sum),
+    )
+end
+
+@inline function _mbr_smoothed_spectrum_sqrt_is_valid(frag_sqrt::NTuple{8, Float32})
+    @inbounds for rank in 1:8
+        frag_sqrt[rank] > 0.0f0 && return true
+    end
+    return false
+end
+
+@inline function _mbr_fragment_annotation_key(frag)
+    ion_type = isY(frag) ? UInt16(1) : isB(frag) ? UInt16(2) : isP(frag) ? UInt16(3) : UInt16(0)
+    ion_type == UInt16(0) && return UInt16(0)
+    return ion_type |
+           (UInt16(getFragCharge(frag)) << 2) |
+           (UInt16(getIonPosition(frag)) << 4)
+end
+
+function build_mbr_fragment_annotation_keys(frag_lookup::LibraryFragmentLookup)
+    n_precursors = length(frag_lookup.prec_frag_ranges) - 1
+    keys = zeros(UInt16, 8 * n_precursors)
+    fragments = getFragments(frag_lookup)
+    @inbounds for pid in 1:n_precursors
+        offset = 8 * (pid - 1)
+        for frag_idx in getPrecFragRange(frag_lookup, pid)
+            frag = fragments[Int(frag_idx)]
+            isIso(frag) && continue
+            rank = Int(getRank(frag))
+            1 <= rank <= 8 || continue
+            keys[offset + rank] = _mbr_fragment_annotation_key(frag)
+        end
+    end
+    return _MBRFragmentAnnotationKeys(keys)
+end
+
+@inline function _mbr_fragment_annotation_key(
+    fragment_keys::_MBRFragmentAnnotationKeys,
+    pid::UInt32,
+    rank::Integer,
+)
+    return fragment_keys.keys[8 * (Int(pid) - 1) + rank]
+end
+
+@inline function _mbr_smoothed_spectrum_hellinger_from_sqrt(
+    recipient_sqrt::NTuple{8, Float32},
+    donor_sqrt::NTuple{8, Float32},
+    fragment_keys::_MBRFragmentAnnotationKeys,
+    recipient_pid::UInt32,
+    donor_pid::UInt32,
+)
+    (_mbr_smoothed_spectrum_sqrt_is_valid(recipient_sqrt) &&
+     _mbr_smoothed_spectrum_sqrt_is_valid(donor_sqrt)) || return 1.0f0
+
+    dist2 = 0.0f0
+    donor_matched = UInt16(0)
+    @inbounds for recipient_rank in 1:8
+        recipient_key = _mbr_fragment_annotation_key(fragment_keys, recipient_pid, recipient_rank)
+        recipient_key == UInt16(0) && continue
+        donor_rank = 0
+        for candidate_rank in 1:8
+            if _mbr_fragment_annotation_key(fragment_keys, donor_pid, candidate_rank) == recipient_key
+                donor_rank = candidate_rank
+                break
+            end
+        end
+        if donor_rank == 0
+            dist2 += recipient_sqrt[recipient_rank] * recipient_sqrt[recipient_rank]
+        else
+            delta = recipient_sqrt[recipient_rank] - donor_sqrt[donor_rank]
+            dist2 += delta * delta
+            donor_matched |= UInt16(1 << (donor_rank - 1))
+        end
+    end
+    @inbounds for donor_rank in 1:8
+        _mbr_fragment_annotation_key(fragment_keys, donor_pid, donor_rank) == UInt16(0) && continue
+        (donor_matched & UInt16(1 << (donor_rank - 1))) != UInt16(0) && continue
+        dist2 += donor_sqrt[donor_rank] * donor_sqrt[donor_rank]
+    end
+    return sqrt(max(0.0f0, 0.5f0 * dist2))
+end
 
 # Columns the donor dict reads from each (main + pass1 sidecar) pair.
 # Listed once so reader and consumer stay in sync. `is_decoy` is hardcoded
@@ -57,7 +172,7 @@ const MBR_MAX_DONOR_FILES_PER_PRECURSOR = 2
 # it from the file.
 const _MBR_DONOR_COLS = (:precursor_idx, :trace_prob_prepass, :weight,
     :log2_intensity_explained, :irt_pred, :irt_obs, :log_by_ratio_m0, :rt,
-    :ms_file_idx)
+    :ms_file_idx, SMOOTHED_FRAGMENT_INTENSITY_COLUMNS...)
 
 # Columns the per-file MBR sidecar emits. precursor_idx + scan_idx are
 # redundant with the main file (same positions) but kept as alignment
@@ -70,6 +185,8 @@ const _MBR_SIDECAR_OUT_COLS = (:precursor_idx, :scan_idx,
     :MBR_is_missing_true,           :MBR_is_missing_false,
     :MBR_log_by_diff_true,          :MBR_log_by_diff_false,
     :MBR_best_rt_diff_true,         :MBR_best_rt_diff_false,
+    :MBR_smoothed_frag_hellinger_true,
+    :MBR_smoothed_frag_hellinger_false,
 )
 
 # Suffix conventions for the three sidecar types used by the streaming MBR
@@ -213,6 +330,7 @@ end
     irto_c::AbstractVector{Float32},
     logby_c::Union{Nothing, AbstractVector{Float16}},
     rt_c::Union{Nothing, AbstractVector{Float32}},
+    smoothed_frag_cols,
     fidx_c::AbstractVector{UInt32},
     side_path::String,
 )
@@ -225,11 +343,12 @@ end
             error("Pass-1 sidecar misaligned at row $i of $side_path")
         pid = pid_c[i]
         e = _MBRDonorEntry(
-            score_c[i], w_c[i], Float32(l2ie_c[i]),
+            score_c[i], pid, w_c[i], Float32(l2ie_c[i]),
             irtp_c[i] - irto_c[i],
             irto_c[i],
             has_logby ? Float32(logby_c[i]) : 0f0,
             has_rt    ? rt_c[i]             : 0f0,
+            _mbr_smoothed_spectrum_sqrt_tuple(smoothed_frag_cols, i),
             fidx_c[i], false,
         )
         entries = get!(() -> _MBRDonorEntry[], all_entries, pid)
@@ -274,6 +393,7 @@ function build_mbr_donor_dict_streaming_with_pass1(file_paths::Vector{String})
             main.irt_pred, main.irt_obs,
             hasproperty(main, :log_by_ratio_m0) ? main.log_by_ratio_m0 : nothing,
             hasproperty(main, :rt) ? main.rt : nothing,
+            ntuple(rank -> getproperty(main, SMOOTHED_FRAGMENT_INTENSITY_COLUMNS[rank]), 8),
             main.ms_file_idx,
             side_path,
         )
@@ -384,6 +504,8 @@ end
     out_miss_t::BitVector,      out_miss_f::BitVector,
     out_log_by_t::Vector{Float32}, out_log_by_f::Vector{Float32},
     out_rt_t::Vector{Float32},   out_rt_f::Vector{Float32},
+    out_smoothed_hellinger_t::Vector{Float32},
+    out_smoothed_hellinger_f::Vector{Float32},
     pid_v::AbstractVector{UInt32},
     file_v::AbstractVector{UInt32},
     weight_v::AbstractVector{Float32},
@@ -392,6 +514,8 @@ end
     irto_v::AbstractVector{Float32},
     logby_v::Union{Nothing, AbstractVector{Float16}},
     rt_v::Union{Nothing, AbstractVector{Float32}},
+    smoothed_frag_cols,
+    fragment_keys::_MBRFragmentAnnotationKeys,
     donor_dict::Dict{UInt32, Vector{_MBRDonorEntry}},
     partner_pools::_CounterfactualPartnerPools,
     false_donor_cache::Dict{UInt32, Union{Nothing, _MBRDonorEntry}},
@@ -402,6 +526,8 @@ end
     @inbounds for i in 1:n
         my_file = file_v[i]
         my_pid  = pid_v[i]
+        recipient_sqrt = MBR_SMOOTHED_SPECTRUM_EMPTY_SQRT
+        has_recipient_spectrum = false
 
         donor_t = _donor_for_pid(donor_dict, my_pid, my_file)
         if donor_t !== nothing
@@ -418,6 +544,15 @@ end
             if has_rt
                 out_rt_t[i] = abs(rt_v[i] - donor_t.rt_obs)
             end
+            recipient_sqrt = _mbr_smoothed_spectrum_sqrt_tuple(smoothed_frag_cols, i)
+            has_recipient_spectrum = true
+            out_smoothed_hellinger_t[i] = _mbr_smoothed_spectrum_hellinger_from_sqrt(
+                recipient_sqrt,
+                donor_t.smoothed_frag_sqrt,
+                fragment_keys,
+                my_pid,
+                donor_t.precursor_idx,
+            )
             out_miss_t[i] = false
         end
         donor_f = _false_donor_for_pid(false_donor_cache, donor_dict, partner_pools, my_pid, my_file)
@@ -435,6 +570,16 @@ end
             if has_rt
                 out_rt_f[i] = abs(rt_v[i] - donor_f.rt_obs)
             end
+            if !has_recipient_spectrum
+                recipient_sqrt = _mbr_smoothed_spectrum_sqrt_tuple(smoothed_frag_cols, i)
+            end
+            out_smoothed_hellinger_f[i] = _mbr_smoothed_spectrum_hellinger_from_sqrt(
+                recipient_sqrt,
+                donor_f.smoothed_frag_sqrt,
+                fragment_keys,
+                my_pid,
+                donor_f.precursor_idx,
+            )
             out_miss_f[i] = false
         end
     end
@@ -447,7 +592,8 @@ end
 function compute_mbr_features_per_file_to_sidecar_with_pass1!(
         main_path::AbstractString,
         donor_dict::Dict{UInt32, Vector{_MBRDonorEntry}},
-        partner_pools::_CounterfactualPartnerPools)
+        partner_pools::_CounterfactualPartnerPools,
+        fragment_keys::_MBRFragmentAnnotationKeys)
     pass1_path = main_path * PASS1_SIDECAR_SUFFIX
     isfile(pass1_path) || error("Missing Pass-1 sidecar at $pass1_path")
     main = Arrow.Table(main_path)
@@ -465,6 +611,7 @@ function compute_mbr_features_per_file_to_sidecar_with_pass1!(
     irto_v  = main.irt_obs
     logby_v = hasproperty(main, :log_by_ratio_m0) ? main.log_by_ratio_m0 : nothing
     rt_v    = hasproperty(main, :rt) ? main.rt : nothing
+    smoothed_frag_cols = ntuple(rank -> getproperty(main, SMOOTHED_FRAGMENT_INTENSITY_COLUMNS[rank]), 8)
 
     @inbounds for i in 1:n
         (pid_v[i] == pass1.precursor_idx[i] && scan_v[i] == pass1.scan_idx[i]) ||
@@ -478,6 +625,7 @@ function compute_mbr_features_per_file_to_sidecar_with_pass1!(
     out_miss_t = trues(n);     out_miss_f = trues(n)
     out_log_by_t = fill(-1f0, n); out_log_by_f = fill(-1f0, n)
     out_rt_t = fill(-1f0, n); out_rt_f = fill(-1f0, n)
+    out_smoothed_h_t = fill(-1f0, n); out_smoothed_h_f = fill(-1f0, n)
     false_donor_cache = Dict{UInt32, Union{Nothing, _MBRDonorEntry}}()
 
     _compute_mbr_inner!(
@@ -485,8 +633,9 @@ function compute_mbr_features_per_file_to_sidecar_with_pass1!(
         out_le_t, out_le_f, out_ir_t, out_ir_f,
         out_miss_t, out_miss_f,
         out_log_by_t, out_log_by_f, out_rt_t, out_rt_f,
+        out_smoothed_h_t, out_smoothed_h_f,
         pid_v, file_v, weight_v, l2ie_v, irtp_v, irto_v,
-        logby_v, rt_v,
+        logby_v, rt_v, smoothed_frag_cols, fragment_keys,
         donor_dict, partner_pools, false_donor_cache,
     )
 
@@ -508,6 +657,8 @@ function compute_mbr_features_per_file_to_sidecar_with_pass1!(
         MBR_log_by_diff_false          = out_log_by_f,
         MBR_best_rt_diff_true          = out_rt_t,
         MBR_best_rt_diff_false         = out_rt_f,
+        MBR_smoothed_frag_hellinger_true  = out_smoothed_h_t,
+        MBR_smoothed_frag_hellinger_false = out_smoothed_h_f,
     )
     writeArrow(side_path, side_df)
     return side_path

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/score_psms.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/score_psms.jl
@@ -24,8 +24,9 @@ and the low-data probit fallback.
 
 """
     score_precursor_isotope_traces(second_pass_folder, file_paths, precursors,
-                                    max_psms_in_memory, q_value_threshold,
-                                    force_oom; match_between_runs=true)
+                                    fragment_lookup, max_psms_in_memory,
+                                    q_value_threshold, force_oom;
+                                    match_between_runs=true)
 
 Score PSMs experiment-wide with the same LightGBM classifier the per-file
 MainSearch uses (`SHARED_LGBM_HP` in `MainSearch/scoring.jl`). Loads PSMs
@@ -38,6 +39,8 @@ to the per-file Arrow files.
 - `file_paths`: Vector of per-file (or fold-split per-file) Arrow paths to
   write the scored output back to.
 - `precursors`: Library precursor metadata (used to add `:accession_numbers`).
+- `fragment_lookup`: Library fragment metadata used by MBR empirical-spectrum
+  features.
 - `max_psms_in_memory`: Memory budget; surfaced for backward compatibility,
   currently unused (in-memory always; per-fold sub-sampling inside the
   shared helper handles large datasets).
@@ -51,6 +54,7 @@ function score_precursor_isotope_traces(
     second_pass_folder::String,
     file_paths::Vector{String},
     precursors::LibraryPrecursors,
+    fragment_lookup::LibraryFragmentLookup,
     ::Int64,                       # max_psms_in_memory (unused)
     ::Float32 = 0.01f0,            # q_value_threshold (unused)
     ::Bool = false;                # force_oom (unused)
@@ -60,7 +64,7 @@ function score_precursor_isotope_traces(
     # MBR features, FTR recovery) — best_psms is never materialised as the
     # full concatenated DataFrame. MBR-off keeps the legacy in-memory path.
     if match_between_runs
-        return _score_precursor_isotope_traces_mbr(file_paths, precursors)
+        return _score_precursor_isotope_traces_mbr(file_paths, precursors, fragment_lookup)
     else
         return _score_precursor_isotope_traces_no_mbr(
             second_pass_folder, file_paths, precursors,
@@ -260,10 +264,13 @@ end
 # the only DataFrame ever materialised is the slim FTR table (10 cols)
 # reconstructed from sidecars right before the FTR controller runs.
 function _score_precursor_isotope_traces_mbr(
-    file_paths::Vector{String}, precursors::LibraryPrecursors,
+    file_paths::Vector{String},
+    precursors::LibraryPrecursors,
+    fragment_lookup::LibraryFragmentLookup,
 )
     # 1. Counterfactual iRT pools for deterministic file-aware partner resolution.
     cf_partner_pools = build_counterfactual_partner_pools(file_paths, precursors)
+    fragment_keys = build_mbr_fragment_annotation_keys(fragment_lookup)
 
     # 2. Feature list. _qbin variants in ADVANCED_FEATURE_SET are commented
     # out, so no quantile-binned features need pre-computing.
@@ -310,12 +317,14 @@ function _score_precursor_isotope_traces_mbr(
                 file_paths[f_idx],
                 donor_dict,
                 cf_partner_pools,
+                fragment_keys,
             )
         end
     end
 
     donor_dict = Dict{UInt32, Vector{_MBRDonorEntry}}()
     cf_partner_pools = nothing
+    fragment_keys = nothing
     GC.gc()
 
     # 6. Slim FTR DataFrame (~10 cols) reconstituted from main + sidecars,

--- a/test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_empirical_spectra_hellinger.jl
+++ b/test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_empirical_spectra_hellinger.jl
@@ -1,0 +1,136 @@
+import Pioneer
+using Arrow
+using DataFrames
+using Test
+
+struct MBREmpiricalMockPrecursors <: Pioneer.LibraryPrecursors
+    mz::Vector{Float32}
+    irt::Vector{Float32}
+end
+
+Pioneer.getMz(p::MBREmpiricalMockPrecursors) = p.mz
+Pioneer.getIrt(p::MBREmpiricalMockPrecursors) = p.irt
+
+function _mbr_empirical_fragment_lookup()
+    frags = Pioneer.CompactFrag{Float32}[
+        Pioneer.CompactFrag(
+            UInt32(1), 500.0f0, Float16(1),
+            true, false, false, false,
+            UInt8(1), UInt8(3), UInt8(2), UInt8(1), UInt8(0),
+        ),
+        Pioneer.CompactFrag(
+            UInt32(1), 600.0f0, Float16(1),
+            false, true, false, false,
+            UInt8(1), UInt8(4), UInt8(2), UInt8(2), UInt8(0),
+        ),
+        Pioneer.CompactFrag(
+            UInt32(2), 600.0f0, Float16(1),
+            false, true, false, false,
+            UInt8(1), UInt8(4), UInt8(2), UInt8(1), UInt8(0),
+        ),
+        Pioneer.CompactFrag(
+            UInt32(2), 500.0f0, Float16(1),
+            true, false, false, false,
+            UInt8(1), UInt8(3), UInt8(2), UInt8(2), UInt8(0),
+        ),
+    ]
+    return Pioneer.StandardFragmentLookup{Float32}(frags, UInt64[1, 3, 5])
+end
+
+function _mbr_empirical_main_table(;
+    precursor_idx,
+    scan_idx,
+    ms_file_idx,
+    target,
+    frag1,
+    frag2,
+)
+    n = length(precursor_idx)
+    return DataFrame(
+        precursor_idx = UInt32.(precursor_idx),
+        scan_idx = UInt32.(scan_idx),
+        weight = ones(Float32, n),
+        log2_intensity_explained = fill(Float16(1), n),
+        irt_pred = zeros(Float32, n),
+        irt_obs = zeros(Float32, n),
+        log_by_ratio_m0 = zeros(Float16, n),
+        rt = zeros(Float32, n),
+        ms_file_idx = fill(UInt32(ms_file_idx), n),
+        target = Bool.(target),
+        cv_fold = zeros(UInt8, n),
+        frag1_smoothed_intensity = Float32.(frag1),
+        frag2_smoothed_intensity = Float32.(frag2),
+        frag3_smoothed_intensity = zeros(Float32, n),
+        frag4_smoothed_intensity = zeros(Float32, n),
+        frag5_smoothed_intensity = zeros(Float32, n),
+        frag6_smoothed_intensity = zeros(Float32, n),
+        frag7_smoothed_intensity = zeros(Float32, n),
+        frag8_smoothed_intensity = zeros(Float32, n),
+    )
+end
+
+function _mbr_empirical_pass1_table(; precursor_idx, scan_idx, score)
+    return DataFrame(
+        precursor_idx = UInt32.(precursor_idx),
+        scan_idx = UInt32.(scan_idx),
+        trace_prob_prepass = Float32.(score),
+        trace_prob_infold = Float32.(score),
+    )
+end
+
+@testset "MBR empirical smoothed Hellinger aligns spectra by library annotation" begin
+    mktempdir() do dir
+        f1 = joinpath(dir, "run1_fold0.arrow")
+        f2 = joinpath(dir, "run2_fold0.arrow")
+
+        Arrow.write(f1, _mbr_empirical_main_table(
+            precursor_idx = [1],
+            scan_idx = [1001],
+            ms_file_idx = 1,
+            target = [true],
+            frag1 = [100],
+            frag2 = [0],
+        ))
+        Arrow.write(f1 * Pioneer.PASS1_SIDECAR_SUFFIX, _mbr_empirical_pass1_table(
+            precursor_idx = [1],
+            scan_idx = [1001],
+            score = [0.40],
+        ))
+
+        Arrow.write(f2, _mbr_empirical_main_table(
+            precursor_idx = [2],
+            scan_idx = [2001],
+            ms_file_idx = 2,
+            target = [false],
+            frag1 = [0],
+            frag2 = [100],
+        ))
+        Arrow.write(f2 * Pioneer.PASS1_SIDECAR_SUFFIX, _mbr_empirical_pass1_table(
+            precursor_idx = [2],
+            scan_idx = [2001],
+            score = [0.91],
+        ))
+
+        precursors = MBREmpiricalMockPrecursors(
+            Float32[500, 501],
+            Float32[10, 10.01],
+        )
+        fragment_keys = Pioneer.build_mbr_fragment_annotation_keys(_mbr_empirical_fragment_lookup())
+        partner_pools = Pioneer.build_counterfactual_partner_pools([f1, f2], precursors)
+        donor_dict = Pioneer.build_mbr_donor_dict_streaming_with_pass1([f1, f2])
+
+        Pioneer.compute_mbr_features_per_file_to_sidecar_with_pass1!(
+            f1,
+            donor_dict,
+            partner_pools,
+            fragment_keys,
+        )
+        mbr = DataFrame(Arrow.Table(f1 * Pioneer.MBR_SIDECAR_SUFFIX))
+
+        @test isapprox(mbr.MBR_smoothed_frag_hellinger_false[1], 0.0f0; atol = 1.0f-6)
+        @test mbr.MBR_is_missing_false[1] == false
+        @test mbr.MBR_max_pair_prob_false[1] == 0.91f0
+        @test :MBR_smoothed_frag_hellinger_true in Pioneer.FTR_FEATURES_F_TRUE
+        @test :MBR_smoothed_frag_hellinger_false in Pioneer.FTR_FEATURES_F_FALSE
+    end
+end

--- a/test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_file_aware_decoys.jl
+++ b/test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_file_aware_decoys.jl
@@ -4,12 +4,14 @@ using Pioneer
 function _test_mbr_donor(prob::Float32, file_idx::UInt32)
     return Pioneer._MBRDonorEntry(
         prob,
+        UInt32(1),
         1.0f0,
         0.25f0,
         0.5f0,
         12.0f0,
         0.1f0,
         24.0f0,
+        Pioneer.MBR_SMOOTHED_SPECTRUM_EMPTY_SQRT,
         file_idx,
         false,
     )
@@ -56,6 +58,7 @@ end
         Float32[11, 11, 11, 11, 11],
         nothing,
         nothing,
+        ntuple(_ -> zeros(Float32, 5), 8),
         UInt32[10, 10, 20, 30, 40],
         "unit-test",
     )

--- a/test/runtests_part3_units.jl
+++ b/test/runtests_part3_units.jl
@@ -83,6 +83,7 @@ include("./UnitTests/test_summarize_precursor.jl")
 include("./Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_scoring_interface.jl")
 include("./Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_wide_window_features.jl")
 include("./Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_file_aware_decoys.jl")
+include("./Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_empirical_spectra_hellinger.jl")
 include("./UnitTests/test_mainsearch_irt_refinement.jl")
 include("./UnitTests/test_scoring_semisupervised.jl")
 


### PR DESCRIPTION
## Summary
- Add MBR-only empirical smoothed-spectrum Hellinger features for true and false donor comparisons.
- Derive rank annotation keys once from the spectral library instead of storing annotation columns in Arrow.
- Feed `MBR_smoothed_frag_hellinger_true/false` into the paired MBR FTR feature set.
- Add focused unit coverage for annotation-aligned donor/receiver spectra.

## Validation
- `julia --project=. test/runtests_part3_units.jl`
- `git diff --check`