### PR TITLE
[codex] add MBR protein scoring features

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/feature_selection.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/feature_selection.jl
@@ -82,7 +82,9 @@ function protein_probit_feature_names()
         :peptide_coverage_logit,
         :any_common_peps,
         :coverage_log_ratio,
-        :precursor_consensus_prefix_shape
+        :precursor_consensus_prefix_shape,
+        :mbr_recovered_peptides,
+        :mbr_only_protein
     ]
 end
 

--- a/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/protein_inference_pipeline.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/protein_inference_pipeline.jl
@@ -402,6 +402,31 @@ end
     return Float32(max(-log_none_sum, 0.0))
 end
 
+function _protein_mbr_summary(gdf::AbstractDataFrame, quant_mask::AbstractVector{Bool})
+    if !hasproperty(gdf, :mbr_recovered)
+        return (recovered_peptides = Int64(0), only_protein = false)
+    end
+
+    recovered_precursors = 0
+    retained_precursors = 0
+    recovered_peptides = Set{String}()
+
+    @inbounds for i in eachindex(quant_mask)
+        quant_mask[i] || continue
+        retained_precursors += 1
+
+        if Bool(gdf.mbr_recovered[i])
+            recovered_precursors += 1
+            push!(recovered_peptides, String(gdf.sequence[i]))
+        end
+    end
+
+    return (
+        recovered_peptides = Int64(length(recovered_peptides)),
+        only_protein = retained_precursors > 0 && recovered_precursors == retained_precursors
+    )
+end
+
 """
 Reusable scratch for `_build_protein_rollup`. One dedup `Dict` per roll-up level
 (precursor_idx / mod-key / sequence -> row index) plus parallel arrays for the
@@ -1171,7 +1196,9 @@ function group_psms_by_protein(
             pg_score = Float32[],
             any_common_peps = Bool[],
             top_pep_peak_area = Float32[],
-            precursor_consensus_prefix_shape = Float32[]
+            precursor_consensus_prefix_shape = Float32[],
+            mbr_recovered_peptides = Int64[],
+            mbr_only_protein = Bool[]
         )
     end
 
@@ -1187,7 +1214,9 @@ function group_psms_by_protein(
             pg_score = Float32[],
             any_common_peps = Bool[],
             top_pep_peak_area = Float32[],
-            precursor_consensus_prefix_shape = Float32[]
+            precursor_consensus_prefix_shape = Float32[],
+            mbr_recovered_peptides = Int64[],
+            mbr_only_protein = Bool[]
         )
     end
 
@@ -1204,6 +1233,7 @@ function group_psms_by_protein(
     protein_groups = combine(grouped) do gdf
         quant_mask = _protein_rollup_quant_mask(gdf; q_value_threshold = q_value_threshold)
         rollup = _build_protein_rollup(gdf, quant_mask, prob_col, rollup_scratches[Threads.threadid()])
+        mbr_summary = _protein_mbr_summary(gdf, quant_mask)
         n_peptides = rollup.n_peptides
         pg_score = rollup.pg_score
         top_pep_peak_area = rollup.top_pep_peak_area
@@ -1242,7 +1272,9 @@ function group_psms_by_protein(
             pg_score = pg_score,
             any_common_peps = has_common,
             top_pep_peak_area = top_pep_peak_area,
-            precursor_consensus_prefix_shape = precursor_consensus_prefix_shape
+            precursor_consensus_prefix_shape = precursor_consensus_prefix_shape,
+            mbr_recovered_peptides = mbr_summary.recovered_peptides,
+            mbr_only_protein = mbr_summary.only_protein
         )
     end
 

--- a/test/UnitTests/test_protein_mbr_features.jl
+++ b/test/UnitTests/test_protein_mbr_features.jl
@@ -1,0 +1,88 @@
+using DataFrames
+using Test
+
+using Pioneer: group_psms_by_protein, protein_probit_feature_names
+
+function _empty_precursor_consensus_for_mbr_feature_tests()
+    return (
+        selected_run_votes = Dict{Tuple{String, Bool, UInt8}, Vector{Any}}(),
+        consensus_target_run_count = Dict{Tuple{String, Bool, UInt8}, Int32}(),
+        cached_consensus_weight_sums = Dict{Tuple{String, Bool, UInt8}, Dict{UInt32, Float64}}(),
+        cached_protein_total_vote = Dict{Tuple{String, Bool, UInt8}, Float64}(),
+        shape_confidence_scale = 1.0f0
+    )
+end
+
+@testset "ProteinScoring MBR feature rollup" begin
+    @testset "MBR recovered support becomes protein probit features" begin
+        psms = DataFrame(
+            inferred_protein_group = ["P_MBR", "P_MBR"],
+            species = ["YEAST", "YEAST"],
+            target = Bool[true, true],
+            entrap_id = UInt8[0, 0],
+            use_for_protein_quant = Bool[true, true],
+            qval = Float32[0.0, 0.0],
+            global_qval = Float32[0.001, 0.001],
+            precursor_idx = UInt32[10, 11],
+            prec_prob = Float32[0.12, 0.15],
+            peak_area = Float32[1000.0, 800.0],
+            base_pep_id = UInt32[101, 102],
+            sequence = ["PEPTIDEA", "PEPTIDEB"],
+            missed_cleavage = Int64[0, 0],
+            Mox = Int64[0, 0],
+            mbr_recovered = Bool[true, true],
+        )
+
+        protein_groups = group_psms_by_protein(
+            psms;
+            precursor_consensus = _empty_precursor_consensus_for_mbr_feature_tests(),
+            q_value_threshold = 0.01f0
+        )
+
+        @test nrow(protein_groups) == 1
+        @test protein_groups.mbr_recovered_peptides[1] == 2
+        @test protein_groups.mbr_only_protein[1]
+    end
+
+    @testset "Mixed support tracks retained MBR evidence without changing pg_score input" begin
+        psms = DataFrame(
+            inferred_protein_group = ["P_MIXED", "P_MIXED"],
+            species = ["YEAST", "YEAST"],
+            target = Bool[true, true],
+            entrap_id = UInt8[0, 0],
+            use_for_protein_quant = Bool[true, true],
+            qval = Float32[0.0, 0.001],
+            global_qval = Float32[0.001, 0.001],
+            precursor_idx = UInt32[20, 21],
+            prec_prob = Float32[0.20, 0.80],
+            peak_area = Float32[500.0, 1500.0],
+            base_pep_id = UInt32[201, 202],
+            sequence = ["PEPTIDEC", "PEPTIDED"],
+            missed_cleavage = Int64[0, 0],
+            Mox = Int64[0, 0],
+            mbr_recovered = Bool[true, false],
+        )
+
+        protein_groups = group_psms_by_protein(
+            psms;
+            precursor_consensus = _empty_precursor_consensus_for_mbr_feature_tests(),
+            q_value_threshold = 0.01f0
+        )
+
+        @test nrow(protein_groups) == 1
+        @test protein_groups.mbr_recovered_peptides[1] == 1
+        @test !protein_groups.mbr_only_protein[1]
+        @test protein_groups.pg_score[1] > 0.0f0
+    end
+
+    @testset "Protein probit feature list includes only the lightweight MBR summaries" begin
+        features = protein_probit_feature_names()
+        @test :mbr_recovered_peptides in features
+        @test :mbr_only_protein in features
+        @test !in(:mbr_recovered_precursors, features)
+        @test !in(:mbr_recovered_precursor_fraction, features)
+        @test !in(:mbr_best_transfer_confidence, features)
+        @test !in(:mbr_sum_transfer_evidence, features)
+        @test !in(:mbr_best_pair_prob, features)
+    end
+end

--- a/test/runtests_part2_units.jl
+++ b/test/runtests_part2_units.jl
@@ -53,6 +53,7 @@ include("./UnitTests/test_solve_poisson_mm.jl")
 include("./UnitTests/test_scoring_workspace_coverage.jl")
 include("./UnitTests/test_rt_alignment_utils.jl")
 include("./UnitTests/test_protein_model_fit.jl")
+include("./UnitTests/test_protein_mbr_features.jl")
 
 # Coverage data is normally flushed to .cov files by an atexit hook
 # that `_exit` skips. Flush it explicitly before terminating, otherwise


### PR DESCRIPTION
## Summary
- Add protein-level MBR recovery summaries to the probit feature set: `mbr_recovered_peptides` and `mbr_only_protein`.
- Compute the summaries during protein-group rollup using the existing quant-retained precursor mask.
- Add focused unit coverage for the MBR protein feature aggregation and feature list.

## Validation
- `julia --project=. test/UnitTests/test_protein_mbr_features.jl`
- `julia --project=. test/runtests_part2_units.jl`
- `git diff --check`