### PR TITLE
perf: drop redundant per-file ParameterTuning PDFs (−42% Parameter Tuning, ID-neutral)

### DIFF
--- a/src/Pioneer.jl
+++ b/src/Pioneer.jl
@@ -728,6 +728,13 @@ const KOINA_URLS = Dict(
 function __init__()
     # Don't initialize gr() immediately - let it be initialized when first used
     ENV["PLOTS_DEFAULT_BACKEND"] = "GR"
+    # Force GR's off-screen workstation so plot creation never opens a gksqt
+    # window. Plots are rendered to in-memory bits and then combined into the
+    # multi-page PDFs by save_multipage_pdf — opening Qt windows here both
+    # slows down PDF writes substantially and disrupts the user's desktop
+    # during long searches. Set both legacy and modern env var names.
+    get!(ENV, "GKSwstype", "100")
+    get!(ENV, "GKS_WSTYPE", "100")
 end
 
 export SearchDIA, BuildSpecLib, GetSearchParams, GetBuildLibParams, convertMzML,

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ParameterTuningSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ParameterTuningSearch.jl
@@ -542,7 +542,7 @@ function generate_wide_scout_plot(wide_frags, scout_model, parsed_fname)
         alpha=0.1, markersize=1.5, color=:steelblue, label=nothing,
         xlabel="Fragment m/z", ylabel="Raw error (mDa)",
         title="$(parsed_fname)\nWide scout m/z bias (n=$(length(wide_frags)), tol=±$(round(tol_mda, digits=1)) mDa)",
-        size=(900, 900), topmargin=10Plots.mm)
+        size=(600, 600), topmargin=10Plots.mm)
     Plots.plot!(p, mz_range, bias_mda, lw=2.5, color=:red, label="m/z bias (robust linear)")
     Plots.plot!(p, mz_range, bias_mda .+ tol_mda, lw=1.5, ls=:dash, color=:red,
         label="collection tol: ±$(round(tol_mda, digits=1)) mDa")
@@ -868,7 +868,7 @@ function process_search_results!(
                 ylabel="Indexed Retention Time iRT (min)",
                 title=parsed_fname * "\n⚠️ Insufficient PSMs for RT model " *
                       "($(iteration_state.best_psm_count) PSMs, need 750)",
-                size=(900, 900))
+                size=(600, 600))
             push!(file_rt_plots, p)
         else
             fallback_plot = generate_fallback_rt_plot_in_memory(results, parsed_fname, search_context, ms_file_idx)

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ParameterTuningSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ParameterTuningSearch.jl
@@ -921,11 +921,12 @@ function process_search_results!(
             end
         end
 
-        # Save per-file PDF and accumulate Plot objects for combined PDF
+        # Accumulate Plot objects for the combined mass-error PDF written by
+        # summarize_results!. The per-file mass-error PDF was dropped 2026-06-26:
+        # writing it took ~2.4 s per file (Plots.jl PDF backend; ~15 s of the
+        # ~44 s warm Param Tuning stage on 6-file Olsen). The combined PDF
+        # already paginates per file, so no diagnostic info is lost.
         if !isempty(file_mass_plots)
-            per_file_dir = joinpath(getMassErrPlotFolder(search_context), "per_file")
-            mkpath(per_file_dir)
-            save_multipage_pdf(file_mass_plots, joinpath(per_file_dir, "$(parsed_fname).pdf"))
             append!(results.mass_plot_objects, file_mass_plots)
         end
 

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ParameterTuningSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/ParameterTuningSearch.jl
@@ -692,15 +692,13 @@ function process_file!(
                         @debug_l1 "  MS1 diag failed: $(sprint(showerror, ms1_err))"
                     end
 
-                    # NCE sweep: reuse collected PSMs (skip fragment index)
+                    # NCE sweep: reuse collected PSMs (skip fragment index).
+                    # Plots are accumulated for the combined NCE PDF written
+                    # by summarize_results!; the redundant per-file PDF was
+                    # dropped 2026-06-26 (same rationale as the mass-error PDF).
                     nce_result = fit_nce_from_psms!(search_context, params, ms_file_idx, spectra, scored_psms)
                     if nce_result !== nothing
-                        nce_file_plots = nce_result[2]
-                        nce_dir = joinpath(getDataOutDir(search_context), "qc_plots", "collision_energy_alignment", "per_file")
-                        mkpath(nce_dir)
-                        parsed_fname_nce = getParsedFileName(search_context, ms_file_idx)
-                        save_multipage_pdf(nce_file_plots, joinpath(nce_dir, "$(parsed_fname_nce).pdf"))
-                        append!(results.nce_plot_objects, nce_file_plots)
+                        append!(results.nce_plot_objects, nce_result[2])
                     end
 
                     iteration_state.best_psms = rt_psms
@@ -930,11 +928,11 @@ function process_search_results!(
             append!(results.mass_plot_objects, file_mass_plots)
         end
 
-        # RT per-file PDF
+        # Accumulate RT plots for the combined RT-alignment PDF written by
+        # summarize_results!. The per-file RT PDF was dropped 2026-06-26 (same
+        # rationale as the mass-error PDF: the combined PDF already paginates
+        # per file, so no diagnostic info is lost).
         if !isempty(file_rt_plots)
-            per_file_rt_dir = joinpath(getRtAlignPlotFolder(search_context), "per_file")
-            mkpath(per_file_rt_dir)
-            save_multipage_pdf(file_rt_plots, joinpath(per_file_rt_dir, "$(parsed_fname).pdf"))
             append!(results.rt_plot_objects, file_rt_plots)
         end
 

--- a/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ParameterTuningSearch/utils.jl
@@ -793,7 +793,7 @@ function generate_intensity_model_plots(
         push!(bin_med_raw, median(mda_errs[idx]))
     end
 
-    p_mz_bias = plot(size=(900, 900), bottommargin=10Plots.mm, leftmargin=10Plots.mm)
+    p_mz_bias = plot(size=(600, 600), bottommargin=10Plots.mm, leftmargin=10Plots.mm)
     scatter!(p_mz_bias, mz_f64, mda_errs,
              alpha=0.08, markersize=1, color=:gray, label=nothing)
     scatter!(p_mz_bias, bin_mz_c, bin_med_raw,
@@ -822,7 +822,7 @@ function generate_intensity_model_plots(
     end
 
     log2I_range = range(minimum(log2I), maximum(log2I), length=200)
-    p_int_bias = plot(size=(900, 900), bottommargin=10Plots.mm, leftmargin=10Plots.mm)
+    p_int_bias = plot(size=(600, 600), bottommargin=10Plots.mm, leftmargin=10Plots.mm)
     scatter!(p_int_bias, log2I, mz_resid_mda,
              alpha=0.08, markersize=1, color=:gray, label=nothing)
     scatter!(p_int_bias, bin_log2I_c, bin_med_resid,
@@ -853,7 +853,7 @@ function generate_intensity_model_plots(
     rt_range = range(minimum(rt_raw), maximum(rt_raw), length=200)
     rt_fit = [Float64(_rt_bias_da(model, Float32(x))) * 1e3
               for x in rt_range]
-    p_rt_bias = plot(size=(900, 900), bottommargin=10Plots.mm, leftmargin=10Plots.mm)
+    p_rt_bias = plot(size=(600, 600), bottommargin=10Plots.mm, leftmargin=10Plots.mm)
     scatter!(p_rt_bias, rt_raw, mz_int_resid_mda,
              alpha=0.08, markersize=1, color=:gray, label=nothing)
     scatter!(p_rt_bias, bin_rt_c, bin_med_rt_resid,
@@ -880,7 +880,7 @@ function generate_intensity_model_plots(
     log2I_range_local = range(minimum(log2I), maximum(log2I), length=200)
     spread_fit_mda = [Float64(_laplace_scale_mda(model, Float32(x))) for x in log2I_range_local]
 
-    p_spread = plot(size=(900, 900),
+    p_spread = plot(size=(600, 600),
         plot_title=_split_title(fname, "Spread (mDa) vs log2(I)"))
     scatter!(p_spread, I_centers_mda, I_b_mda,
         xlabel="log2(intensity)", ylabel="MAD-based spread (mDa)",
@@ -906,7 +906,7 @@ function generate_intensity_model_plots(
     frac_within_env = round(100.0 * n_within_env / n, digits=1)
 
     n_scatter = length(scatter_idx)
-    p_envelope = plot(size=(900, 900),
+    p_envelope = plot(size=(600, 600),
         plot_title=_split_title(fname, "Spread envelope") * "\n(n=$n, $(frac_within_env)% within k×σ boundary)")
 
     scatter!(p_envelope, log2I[scatter_idx], corrected_mda[scatter_idx],
@@ -953,7 +953,7 @@ function generate_intensity_model_plots(
     model_corr = [Float64(_mz_spread_correction(model, Float32(mz))) for mz in mz_fit_range]
     model_label = "model: correction spline ($(length(model.mz_spread_spline.coeffs)) coeffs)"
 
-    p_corr = plot(size=(900, 900),
+    p_corr = plot(size=(600, 600),
         plot_title=_split_title(fname, "m/z-dependent spread correction"),
         bottommargin=10Plots.mm, leftmargin=10Plots.mm)
     scatter!(p_corr, bin_mz_centers, bin_correction;
@@ -976,7 +976,7 @@ function generate_intensity_model_plots(
         ylabel="log2(intensity)",
         title=_split_title(fname, "Fitted tolerance heatmap") *
               "\ncolor = k*sigma tolerance half-width (mDa)",
-        size=(900, 900),
+        size=(600, 600),
         color=:viridis,
         rightmargin=12Plots.mm,
         bottommargin=10Plots.mm,

--- a/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/QuadTuningSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/QuadTuningSearch/QuadTuningSearch.jl
@@ -306,10 +306,12 @@ function process_file!(
                                                            initial_model=razo_initial_model))
         end
 
-        per_file_dir = joinpath(results.quad_plot_dir, "per_file")
-        mkpath(per_file_dir)
+        # Accumulate plot objects for the combined quad-transmission PDF
+        # written by summarize_results!. The per-file PDF was dropped
+        # 2026-06-26 (same rationale as the ParameterTuningSearch mass-error
+        # PDF: the combined PDF paginates per file, so no diagnostic info is
+        # lost, and writing it doubled the QuadTuning plot I/O cost).
         parsed_fname = getParsedFileName(search_context, ms_file_idx)
-        save_multipage_pdf(file_plots, joinpath(per_file_dir, "$(parsed_fname).pdf"))
         append!(results.quad_plot_objects, file_plots)
         push!(results.per_file_models, (parsed_fname, active_model, Float64(window_width)))
 


### PR DESCRIPTION
## Summary

Profiling showed the **Parameter Tuning** stage regressed sharply (Exploris: +136% vs the pre-ASMS May-25 develop), and an allocation/sample profile pinned the cause to **per-file diagnostic PDF rendering** through the Plots.jl PDF backend — **86k of ~130k profile samples (66%)** were in plotting; the iterative spline solver / Theil-Sen path I initially suspected was negligible (<130 samples). The May→June mass-error calibration rewrite added new per-file bias/spread diagnostic plots on top of the existing per-file mass-error / RT-alignment / NCE / Quad PDFs, and writing those PDFs is the cost (~2.4 s per file per plot type, heaviest on dense-scatter Exploris data).

## Changes (plot-only, no algorithm changes)

- Drop the **redundant per-file** mass-error / RT-alignment / NCE / Quad PDFs — the **combined paginated PDFs** (`mass_error_plots.pdf`, `rt_alignment_plots.pdf`, `nce_alignment_plots.pdf`, `quad_transmission_plots.pdf`, `QC_PLOTS.pdf`) already contain every per-file page.
- `GKSwstype=100` in `__init__` so GR renders off-screen (no gksqt windows; also prevents GR window-state accumulation across repeated runs).
- Shrink diagnostic plots 900×900 → 600×600.

## Validation (controlled, full Exploris 23-file, warm)

Identical code except these 4 commits:

| Phase | develop | +this PR | Δ |
|---|---:|---:|---:|
| **Parameter Tuning** | 103.1 s | **59.7 s** | **−42%** |
| Quadrupole Tuning | 29.3 s | 23.7 s | −19% |
| **TOTAL** | 445.1 s | 399.3 s | **−10%** |

**ID-neutral:** precursors (1,353,983) and protein groups (159,484) **identical** develop-vs-branch. Main Search / Precursor Scoring timings unchanged. The only output difference is the absence of the `qc_plots/*/per_file/` PDFs (combined PDFs retained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)