### PR TITLE
perf(bitvec): sample calibration scans at random instead of top-TIC

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/BitVecCalibration/BitVecCalibration.jl
+++ b/src/Routines/SearchDIA/SearchMethods/BitVecCalibration/BitVecCalibration.jl
@@ -5,7 +5,7 @@ index bitmask patterns to discriminate targets from decoys.
 Runs between QuadTuning and MainSearch. Cross-file pooled:
 
 process_file! (per file):
-  1. Sample top-TIC MS2 scans
+  1. Sample MS2 scans at random (representative across the run, not top-TIC)
   2. Run fragment index in accumulator mode (PatternAccumulator)
      — tallies 256-bin target/decoy counts directly in the scoring
        loop with zero tuple allocation
@@ -310,6 +310,11 @@ function process_file!(
 
     scan_priority = get_ms2_scan_priority_order(spectra)
     total_ms2 = length(scan_priority)
+    # Sample scans RANDOMLY (representative across the run) instead of top-TIC. Top-TIC
+    # sampling under-represents low-TIC (e.g. early-gradient) scans, which mis-calibrates
+    # the bitvec filter in those regions and drops early-eluting precursors; a representative
+    # random sample fixes it. Shuffle in place (seeded per file for reproducibility).
+    shuffle!(MersenneTwister(1_800_017 + total_ms2), scan_priority)
     scan_to_prec_idx = Vector{Union{Missing, UnitRange{Int64}}}(undef, length(spectra))
 
     # Adaptive accumulation: collect scans until total counts ≥ 1M or all scans used


### PR DESCRIPTION
## What

`BitVecCalibration.process_file!` accumulates its 256-bin target/decoy bitmask-pattern counts from a sample of MS2 scans, then derives the per-file bitvec pre-filter from those counts. Previously that sample was the **top-TIC** scans. This PR shuffles the scan order (seeded per file for reproducibility) so the adaptive accumulate draws a **representative random sample** across the run instead.

One-line change (plus a doc-comment fix):

    scan_priority = get_ms2_scan_priority_order(spectra)
    total_ms2 = length(scan_priority)
    shuffle!(MersenneTwister(1_800_017 + total_ms2), scan_priority)   # random, not top-TIC

## Why

Top-TIC sampling under-represents **low-TIC regions of the run — most notably the early gradient**. The filter is therefore mis-calibrated in those regions (wrongly strict on the fragment-match patterns that occur there) and drops early-eluting precursors that would otherwise pass at the same 0.03 threshold.

Diagnosis on a 6-file Olsen Exploris set: the precursors recovered by loosening the filter were **not** biased toward the m/z isolation-window edge (so not a transmission artifact) but were **strongly biased to early retention time** (median RT 24 vs 28 min; 2–3× enriched in the first ~12 min). Switching the calibration sample from top-TIC to random recovers ~90% of that gain **at the same 0.03 threshold** — a calibration-sampling fix, not a threshold change.

## Regression results (branch vs develop)

**PASS**, FDR control maintained. Broad small ID gains, neutral where there is no RT/TIC bias, no real losers.

| dataset | precursor IDs |
|---|---|
| Olsen_Exploris_3P | **+3.86%** |
| SCIEX_3P | +1.38% |
| KEAP1KO_Eclipse | +1.05% |
| Olsen_Astral_3P | +0.83% |
| MTAC_3P_Standard | +0.65% |
| APMS_Astral | +0.54% |
| SCP_Astral series | +0.34% to +1.46% |
| YEAST_KO_Astral | +0.26% |
| MTAC_3P_Alternating | +0.05% |
| MTAC_Yeast (all 4 configs) | 0% (neutral) |
| Seer_Astral_single | −0.04% (noise) |
| EWZ_2P_MBR_Exploris | −0.24% (MBR, minor) |

- **Entrapment FDR controlled** — global precursor differences ±0.0001–0.0005 across all datasets; recovered IDs pass entrapment (not FDR-margin inflation).
- **Quant stable** — CV changes tiny (Exploris ±0.002–0.003), fold-change error small/mixed.
- Protein FDR shows larger swings only on SCP_Astral low-abundance (250/500 pg) runs — consistent with inherent low-count noise, not a control failure.

## Runtime & candidate trade-off (controlled local timing)

Dataset-dependent: helps where TIC-sampling under-represented a *productive* region (early gradient), adds unproductive candidate load where the acquisition is already RT-uniform. Warm-start, same machine, hot (2nd-of-2) runs; candidates = LUT-emitted, summed over files.

| dataset | candidates emitted | Main Search | total runtime | 1%-FDR IDs |
|---|---|---|---|---|
| Olsen Exploris 3P (6 files) | 1.78× | +37% | **+14.9%** | **+3.65%** |
| Olsen Astral 200ng (6 files) | +35.6% (448M→608M) | +16% | **+9.5%** | +0.65% |
| MTAC 3P (6 files) | 1.07× | +5% | +4.2% | −0.3% |

- **Exploris:** the extra candidates are the productive early-RT peptides → good trade (+3.65% IDs).
- **Astral:** RT-uniform acquisition, so top-TIC was not mis-calibrated; random sampling mostly pulls in low-TIC **chance-pattern** candidates → +36% candidate load and +9.5% runtime for only +0.65% IDs (poor efficiency, though FDR-controlled).
- **MTAC:** near-neutral both ways.
- Calibration overhead itself is small (BitVec Calibration +1.5–5.7s); the runtime cost is almost entirely Main Search deconvolving the additional admitted candidates.

**Takeaway for reviewers:** clear win on RT-biased acquisitions (Exploris), modest-but-real cost on RT-uniform ones (Astral ~+10% runtime / +36% candidates for marginal ID gain). Worth deciding whether to accept as a blanket default, gate it to acquisitions with a detectable early-RT deficit, or use a TIC+random hybrid.

## Risk

Minimal correctness risk — single, self-contained, deterministic (seeded) change to the calibration scan sampling; no downstream/interface changes; FDR controlled in regression. Main consideration is the runtime/candidate trade-off above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
