### PR TITLE
Fix quant normalization crash when no file supports a spline

### DIFF
--- a/src/utils/normalizeQuant.jl
+++ b/src/utils/normalizeQuant.jl
@@ -137,11 +137,17 @@ end
 Compute per-file RT-dependent correction offsets. Evaluates each file's spline
 on a grid, computes the cross-file median at each RT point, and returns a
 dictionary of interpolated offset functions (file_spline - global_median).
+
+Returns an empty dictionary when no file got a spline: there is no cross-file
+median to correct toward, and `rt_range` is still the empty-range sentinel
+`(Inf, -Inf)`. `applyNormalization!` reads that as "no correction for this file"
+and copies the abundances through unchanged (correction factor 1.0).
 """
 function getQuantCorrections(
     quant_splines::Dictionary{String, UniformSpline},
     rt_range::Tuple{AbstractFloat, AbstractFloat};
     N = 100)
+    isempty(quant_splines) && return Dictionary{String, Any}()
     median_quant = zeros(Float32, (length(quant_splines), N))
     rt_grid = collect(LinRange(first(rt_range), last(rt_range), N))
     for (i, rt) in enumerate(rt_grid)

--- a/test/UnitTests/test_chromatogram_integration_bounds.jl
+++ b/test/UnitTests/test_chromatogram_integration_bounds.jl
@@ -1,8 +1,11 @@
-@testset "single-scan peak integrates at least three points" begin
-    rt = Float32.(1:5)
-    scan_idx = UInt32.(1:5)
+@testset "single-scan peak integrates at least five points" begin
+    # getIntegrationBounds! starts the boundary search at apex +/-2, so even a
+    # one-scan spike integrates over five scans (3bcbe5a0e). Seven points here
+    # so the window is set by that rule, not by clamping to the array ends.
+    rt = Float32.(1:7)
+    scan_idx = UInt32.(1:7)
     fraction = fill(1.0f0, length(rt))
-    intensity = Float32[0, 0, 10, 0, 0]
+    intensity = Float32[0, 0, 0, 10, 0, 0, 0]
     ws = Pioneer.WHWorkspace(length(rt))
     state = Pioneer.Chromatogram(zeros(Float32, length(rt)), zeros(Float32, length(rt)), 0)
     debug_plot_data = Ref{Any}(nothing)
@@ -12,7 +15,7 @@
         scan_idx,
         intensity,
         fraction,
-        3,
+        4,
         ws,
         state,
         1.0f0,
@@ -21,10 +24,10 @@
         debug_plot_data = debug_plot_data,
     )
 
-    @test best_scan == UInt32(3)
+    @test best_scan == UInt32(4)
     @test start_scan == UInt32(2)
-    @test stop_scan == UInt32(4)
-    @test debug_plot_data[].scan_range == 2:4
+    @test stop_scan == UInt32(6)
+    @test debug_plot_data[].scan_range == 2:6
 end
 
 @testset "baseline subtraction uses selected boundary endpoints" begin

--- a/test/UnitTests/test_normalizeQuant.jl
+++ b/test/UnitTests/test_normalizeQuant.jl
@@ -16,7 +16,10 @@ if !@isdefined(Pioneer)
     using Dictionaries
 end
 
-# Helper: create a synthetic PSM Arrow file with RT-dependent abundance
+# Helper: create a synthetic PSM Arrow file with RT-dependent abundance.
+# Files meant to get a spline need enough PSMs to fill
+# `_min_bins_for_spline(spline_n_knots)` bins of `QUANT_MIN_BIN_OCCUPANCY` each:
+# at spline_n_knots=5 that is 8 bins × 100 = 800 PSMs, hence n=1000 below.
 function _write_quant_arrow(path::String, n::Int, offset::Float64;
                             rt_range::Tuple{Float64,Float64}=(0.0, 100.0))
     rts = Float32.(collect(LinRange(first(rt_range), last(rt_range), n)))
@@ -42,8 +45,8 @@ end
         # Two files with different intensity levels
         path1 = joinpath(dir, "file1.arrow")
         path2 = joinpath(dir, "file2.arrow")
-        _write_quant_arrow(path1, 200, 0.0)
-        _write_quant_arrow(path2, 200, 2.0)  # 4× higher
+        _write_quant_arrow(path1, 1000, 0.0)
+        _write_quant_arrow(path2, 1000, 2.0)  # 4× higher
 
         splines, rt_range = Pioneer.getQuantSplines(
             [path1, path2], :abundance; N=50, spline_n_knots=5)
@@ -76,8 +79,8 @@ end
     mktempdir() do dir
         path1 = joinpath(dir, "file1.arrow")
         path2 = joinpath(dir, "file2.arrow")
-        _write_quant_arrow(path1, 200, 0.0)
-        _write_quant_arrow(path2, 200, 2.0)
+        _write_quant_arrow(path1, 1000, 0.0)
+        _write_quant_arrow(path2, 1000, 2.0)
 
         splines, rt_range = Pioneer.getQuantSplines(
             [path1, path2], :abundance; N=50, spline_n_knots=5)
@@ -113,7 +116,7 @@ end
         offsets = [0.0, 1.5, -1.0]
         for (i, offset) in enumerate(offsets)
             path = joinpath(dir, "file$i.arrow")
-            _write_quant_arrow(path, 200, offset)
+            _write_quant_arrow(path, 1000, offset)
             push!(paths, path)
         end
 
@@ -152,7 +155,7 @@ end
 @testset "single file" begin
     mktempdir() do dir
         path = joinpath(dir, "only.arrow")
-        _write_quant_arrow(path, 200, 0.0)
+        _write_quant_arrow(path, 1000, 0.0)
 
         Pioneer.normalizeQuant(dir, :abundance; N=50, spline_n_knots=5)
 
@@ -161,6 +164,40 @@ end
         # With one file, correction should be ~zero → normalized ≈ raw
         ratio = median(df.abundance_normalized ./ df.abundance)
         @test ratio ≈ 1.0 atol=0.1
+    end
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Edge case: too few PSMs to fit any spline — fall back to identity
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@testset "no file supports a spline" begin
+    mktempdir() do dir
+        # 200 PSMs fills only 2 bins at >= 100 each, short of the 8 a
+        # 7-coefficient spline needs, so every file is skipped.
+        paths = String[]
+        for (i, offset) in enumerate([0.0, 2.0])
+            path = joinpath(dir, "file$i.arrow")
+            _write_quant_arrow(path, 200, offset)
+            push!(paths, path)
+        end
+
+        splines, rt_range = Pioneer.getQuantSplines(
+            paths, :abundance; N=50, spline_n_knots=5)
+        @test isempty(splines)
+
+        # No cross-file median exists; corrections must be empty, not an error.
+        corrections = Pioneer.getQuantCorrections(splines, rt_range; N=50)
+        @test isempty(corrections)
+
+        Pioneer.normalizeQuant(dir, :abundance; N=50, spline_n_knots=5)
+
+        for path in paths
+            df = DataFrame(Arrow.Table(path))
+            @test hasproperty(df, :abundance_normalized)
+            # Correction factor 1.0: abundances pass through untouched.
+            @test all(df.abundance_normalized .≈ Float64.(df.abundance))
+        end
     end
 end
 


### PR DESCRIPTION
`develop` is red on [run 31643106390](https://github.com/nwamsley1/Pioneer.jl/actions/runs/31643106390) (`test_normalizeQuant.jl`, 5 failed / 4 errored).

The occupancy guard added in #453 skips files with too few PSMs to fit a spline. When *every* file is skipped, `getQuantCorrections` took a `median` over a 0xN matrix and threw `ArgumentError: median of an empty array`. It now returns an empty dictionary; `applyNormalization!` already treats a missing key as "no correction" and copies abundances through unchanged, i.e. a correction factor of 1.0.

Two tests were left stale by recent behavior changes and are refreshed here:

- `test_normalizeQuant.jl` used 200-PSM files, which fill 2 RT bins against the guard's 8-bin floor, so every assertion failed. Bumped to 1000 PSMs, plus a new testset that keeps 200 deliberately and asserts the identity fallback.
- `test_chromatogram_integration_bounds.jl` expected a 3-scan window; 3bcbe5a0e widened the minimum to 5 (apex +/-2). Now uses 7 scans expecting 2:6, so it asserts the rule rather than clamping to the array ends. This failure was masked in CI because `normalizeQuant` aborted the process first.

Full suite passes locally (all three parts, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)