### PR TITLE
Add configurable semi-enzymatic library digestion

### DIFF
--- a/assets/example_config/defaultBuildLibParams.json
+++ b/assets/example_config/defaultBuildLibParams.json
@@ -29,6 +29,7 @@
         "max_charge": 4,
         "cleavage_regex": "[KR][^_|$]",
         "missed_cleavages": 1,
+        "specificity": "full",
         "max_var_mods": 1,
         "add_decoys": true,
         "entrapment_r": 0,

--- a/assets/example_config/defaultBuildLibParamsSimplified.json
+++ b/assets/example_config/defaultBuildLibParamsSimplified.json
@@ -25,6 +25,7 @@
         "max_charge": 3,
         "cleavage_regex": "[KR][^_|$]",
         "missed_cleavages": 1,
+        "specificity": "full",
         "max_var_mods": 1,
         "add_decoys": true,
         "entrapment_r": 0

--- a/docs/src/user_guide/parameters.md
+++ b/docs/src/user_guide/parameters.md
@@ -129,6 +129,7 @@ Header-parsing regex patterns can be configured three ways:
 | `fasta_digest_params.max_charge` | Int | `4` | Maximum charge state. |
 | `fasta_digest_params.cleavage_regex` | String | `[KR][^_\|$]` | Cleavage rule. To exclude cleavage before proline use `[KR][^P\|$]`. |
 | `fasta_digest_params.missed_cleavages` | Int | `1` | Maximum missed cleavages. |
+| `fasta_digest_params.specificity` | String | `"full"` | Digestion specificity: `"full"`, `"semi"` (either terminus), `"semi-n"` (C terminus required), or `"semi-c"` (N terminus required). Protein termini count as enzymatic. |
 | `fasta_digest_params.max_var_mods` | Int | `1` | Maximum variable modifications per peptide. |
 | `fasta_digest_params.add_decoys` | Bool | `true` | Generate decoy sequences. |
 | `fasta_digest_params.entrapment_r` | Float | `0` | Entrapment-sequence ratio. |

--- a/gui/src-tauri/src/paths.rs
+++ b/gui/src-tauri/src/paths.rs
@@ -258,8 +258,9 @@ mod missing_path_tests {
 /// the name does not already say.
 ///
 /// Every field is optional in practice: libraries built before a key existed
-/// simply lack it, so each is reported as empty rather than guessed at. The
-/// oldest libraries have no `prediction_model` at all.
+/// simply lack it, so each is reported as empty rather than guessed at. The one
+/// safe exception is digestion specificity: older libraries were necessarily
+/// fully specific. The oldest libraries have no `prediction_model` at all.
 #[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct LibraryInfo {
     /// False when the path is not a library, or has no readable config.
@@ -269,6 +270,7 @@ pub struct LibraryInfo {
     pub length_range: String,
     pub charge_range: String,
     pub missed_cleavages: String,
+    pub specificity: String,
     pub max_var_mods: String,
     /// "Unimod:35 on M" per entry.
     pub fixed_mods: Vec<String>,
@@ -351,6 +353,12 @@ pub fn library_info(path: &str) -> LibraryInfo {
             out.charge_range = format!("{clo}\u{2013}{chi}");
         }
         out.missed_cleavages = num(d.get("missed_cleavages"));
+        out.specificity = d
+            .get("specificity")
+            .and_then(|x| x.as_str())
+            // Libraries built before this key existed were fully specific.
+            .unwrap_or("full")
+            .to_string();
         out.max_var_mods = num(d.get("max_var_mods"));
         out.has_decoys = d.get("add_decoys").and_then(|x| x.as_bool()).unwrap_or(false);
     }
@@ -415,6 +423,7 @@ mod library_info_tests {
               "fasta_digest_params": {"min_length": 7, "max_length": 30,
                                       "min_charge": 2, "max_charge": 4,
                                       "missed_cleavages": 1, "max_var_mods": 1,
+                                      "specificity": "semi",
                                       "add_decoys": true},
               "nce_params": {"nce": 26.0},
               "variable_mods": {"pattern": ["M"], "name": ["Unimod:35"], "mass": [15.99491]},
@@ -431,6 +440,7 @@ mod library_info_tests {
         assert_eq!(i.length_range, "7\u{2013}30");
         assert_eq!(i.charge_range, "2\u{2013}4");
         assert_eq!(i.missed_cleavages, "1");
+        assert_eq!(i.specificity, "semi");
         assert_eq!(i.variable_mods, vec!["Unimod:35 on M"]);
         assert_eq!(i.fixed_mods, vec!["Unimod:4 on C"]);
         assert_eq!(i.fastas, vec!["ECOLI", "CONTAM"]);

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -366,7 +366,12 @@ export default function App() {
     })
     setCommand(job.cmd)
     if (job.snapshot.cmd === 'searchdia') setSearch(job.snapshot.search)
-    else if (job.snapshot.cmd === 'buildspeclib') setBuild(job.snapshot.build)
+    else if (job.snapshot.cmd === 'buildspeclib') {
+      // Stored runs from before digestion specificity was added do not carry
+      // the field. Merge defaults so recalling one still renders and emits a
+      // full-specific build.
+      setBuild({ ...BUILD_DEFAULTS, ...job.snapshot.build })
+    }
     else setConvert(job.snapshot.convert)
     setRunError('')
   }, [command, search, build, convert])

--- a/gui/src/components/BuildSpecLibForm.tsx
+++ b/gui/src/components/BuildSpecLibForm.tsx
@@ -798,6 +798,39 @@ export function BuildSpecLibForm({
             alignItems: 'start',
           }}
         >
+          <div>
+            <label
+              htmlFor="digest-specificity"
+              style={{ display: 'block', fontSize: 11, color: '#667085', marginBottom: 5 }}
+            >
+              Specificity
+            </label>
+            <select
+              id="digest-specificity"
+              className="pio-input"
+              value={params.digestSpecificity}
+              onChange={(e) => onParam('digestSpecificity', e.target.value)}
+              style={{
+                width: '100%',
+                padding: '8px 34px 8px 10px',
+                border: '1px solid #D7DBE0',
+                borderRadius: 8,
+                font: "12.5px 'IBM Plex Sans'",
+                color: '#1A2230',
+                background: `#FFFFFF ${CHEVRON}`,
+                backgroundSize: '16px 16px',
+                cursor: 'pointer',
+                outline: 'none',
+                appearance: 'none',
+                WebkitAppearance: 'none',
+              }}
+            >
+              <option value="full">Full (both termini)</option>
+              <option value="semi">Semi (either terminus)</option>
+              <option value="semi-n">Semi-N (C terminus required)</option>
+              <option value="semi-c">Semi-C (N terminus required)</option>
+            </select>
+          </div>
           <NumField fieldKey="minLen" value={params.minLen} onChange={onParam} />
           <NumField fieldKey="maxLen" value={params.maxLen} onChange={onParam} />
           <NumField fieldKey="missedCleav" value={params.missedCleav} onChange={onParam} />

--- a/gui/src/components/LibrarySummary.tsx
+++ b/gui/src/components/LibrarySummary.tsx
@@ -39,6 +39,7 @@ export function LibrarySummary({ info }: { info: LibraryInfo | null }) {
   }
 
   const digest = [
+    info.specificity && `${info.specificity} specificity`,
     info.length_range && `${info.length_range} residues`,
     info.charge_range && `charge ${info.charge_range}`,
     info.missed_cleavages && `${info.missed_cleavages} missed cleavage${info.missed_cleavages === '1' ? '' : 's'}`,

--- a/gui/src/lib/backend.ts
+++ b/gui/src/lib/backend.ts
@@ -92,6 +92,7 @@ export interface LibraryInfo {
   length_range: string
   charge_range: string
   missed_cleavages: string
+  specificity: string
   max_var_mods: string
   fixed_mods: string[]
   variable_mods: string[]

--- a/gui/src/lib/config.ts
+++ b/gui/src/lib/config.ts
@@ -149,6 +149,7 @@ export const BUILD_OWNED_PATHS = [
   'fasta_digest_params.min_charge',
   'fasta_digest_params.max_charge',
   'fasta_digest_params.missed_cleavages',
+  'fasta_digest_params.specificity',
   'fasta_digest_params.max_var_mods',
   'fasta_digest_params.add_decoys',
   'variable_mods',
@@ -205,6 +206,7 @@ export function buildLibJsonBase(s: BuildParams): Json {
       min_charge: num(s.minCharge, 2),
       max_charge: num(s.maxCharge, 3),
       missed_cleavages: num(s.missedCleav, 1),
+      specificity: s.digestSpecificity,
       max_var_mods: num(s.maxVarMods, 1),
       add_decoys: s.addDecoys,
     },
@@ -275,6 +277,13 @@ export function buildConfigToState(obj: unknown): Partial<BuildParams> | null {
   if (str(d.min_charge) !== undefined) set.minCharge = str(d.min_charge)
   if (str(d.max_charge) !== undefined) set.maxCharge = str(d.max_charge)
   if (str(d.missed_cleavages) !== undefined) set.missedCleav = str(d.missed_cleavages)
+  const specificity = str(d.specificity)
+    ?.trim()
+    .toLowerCase()
+    .replace('_', '-')
+  if (specificity && ['full', 'semi', 'semi-n', 'semi-c'].includes(specificity)) {
+    set.digestSpecificity = specificity as BuildParams['digestSpecificity']
+  }
   if (str(d.max_var_mods) !== undefined) set.maxVarMods = str(d.max_var_mods)
   if ('add_decoys' in d) set.addDecoys = !!d.add_decoys
 

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -125,6 +125,7 @@ export interface BuildParams {
   minCharge: string
   maxCharge: string
   missedCleav: string
+  digestSpecificity: 'full' | 'semi' | 'semi-n' | 'semi-c'
   maxVarMods: string
   addDecoys: boolean
   includeContaminants: boolean
@@ -146,6 +147,7 @@ export const BUILD_DEFAULTS: BuildParams = {
   minCharge: '2',
   maxCharge: '3',
   missedCleav: '1',
+  digestSpecificity: 'full',
   maxVarMods: '1',
   addDecoys: true,
   includeContaminants: true,

--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -365,10 +365,12 @@ function BuildSpecLib(params_path::String)
 
                 # Convert types
                 precursors_table[!, :missed_cleavages] = UInt8.(precursors_table[!, :missed_cleavages])
+                precursors_table[!, :num_enzymatic_termini] = UInt8.(precursors_table[!, :num_enzymatic_termini])
                 precursors_table[!, :prec_charge] = UInt8.(precursors_table[!, :prec_charge])
                 precursors_table[!, :mz] = Float32.(precursors_table[!, :mz])
                 precursors_table[!, :irt] = Float32.(precursors_table[!, :irt])
-                precursors_table[!, :start_idx] = UInt32.(precursors_table[!, :start_idx])
+                precursors_table[!, :start_idx] =
+                    [UInt32.(collect(starts)) for starts in precursors_table[!, :start_idx]]
 
                 # Save processed precursor table
                 @debug_l1 "  Before add_pair_indices!: $(nrow(precursors_table)) precursors"

--- a/src/Routines/BuildSpecLib/chronologer/chronologer_prep.jl
+++ b/src/Routines/BuildSpecLib/chronologer/chronologer_prep.jl
@@ -150,7 +150,8 @@ function prepare_chronologer_input(
                 regex = Regex(_params.fasta_digest_params["cleavage_regex"]),
                 max_length = digest_max_length,
                 min_length = digest_min_length,
-                missed_cleavages = _params.fasta_digest_params["missed_cleavages"]
+                missed_cleavages = _params.fasta_digest_params["missed_cleavages"],
+                specificity = get(_params.fasta_digest_params, "specificity", "full"),
             ))
         )
     end
@@ -333,6 +334,7 @@ function add_mods(
                     var_mod,
                     get_isotopic_mods(fasta_peptide),
                     get_charge(fasta_peptide),
+                    get_num_enzymatic_termini(fasta_peptide),
                     get_base_target_id(fasta_peptide), # preserve base_target_id
                     get_base_pep_id(fasta_peptide),  # Preserve original base_pep_id
                     get_entrapment_pair_id(fasta_peptide),
@@ -386,6 +388,7 @@ function add_charge(
                     get_structural_mods(fasta_peptide),
                     get_isotopic_mods(fasta_peptide),
                     charge,
+                    get_num_enzymatic_termini(fasta_peptide),
                     get_base_target_id(fasta_peptide), # preserve base_target_id
                     get_base_pep_id(fasta_peptide),   # preserve base_pep_id
                     get_entrapment_pair_id(fasta_peptide),
@@ -529,8 +532,9 @@ function build_fasta_df(fasta_peptides::Vector{FastaEntry};
     _sequence = Vector{String}(undef, prec_alloc_size)
     _structural_mods = Vector{Union{String, Missing}}(undef, prec_alloc_size)
     _isotopic_mods = Vector{Union{String, Missing}}(undef, prec_alloc_size)
-    _start_idx = Vector{UInt32}(undef, prec_alloc_size)
+    _start_idx = Vector{Vector{UInt32}}(undef, prec_alloc_size)
     _precursor_charge = Vector{UInt8}(undef, prec_alloc_size)
+    _num_enzymatic_termini = Vector{UInt8}(undef, prec_alloc_size)
     _collision_energy = Vector{Float32}(undef, prec_alloc_size )
     _decoy = Vector{Bool}(undef, prec_alloc_size)  
     _entrapment_group_id = Vector{UInt8}(undef, prec_alloc_size)
@@ -556,6 +560,7 @@ function build_fasta_df(fasta_peptides::Vector{FastaEntry};
         _structural_mods[n] = getModString(get_structural_mods(peptide))
         _isotopic_mods[n] = getModString(get_isotopic_mods(peptide))
         _precursor_charge[n] = get_charge(peptide)
+        _num_enzymatic_termini[n] = get_num_enzymatic_termini(peptide)
         _collision_energy[n] = NCE
         _decoy[n] = decoy
         _entrapment_group_id[n] = entrapment_group_id
@@ -573,6 +578,7 @@ function build_fasta_df(fasta_peptides::Vector{FastaEntry};
          mods = _structural_mods[1:n],
          isotopic_mods = _isotopic_mods[1:n],
          precursor_charge = _precursor_charge[1:n],
+         num_enzymatic_termini = _num_enzymatic_termini[1:n],
          collision_energy = _collision_energy[1:n],
          decoy = _decoy[1:n],
          entrapment_group_id = _entrapment_group_id[1:n],

--- a/src/Routines/BuildSpecLib/fasta/fasta_digest.jl
+++ b/src/Routines/BuildSpecLib/fasta/fasta_digest.jl
@@ -20,60 +20,39 @@
 # Set of valid amino acid characters for fast lookup (O(1) per character)
 const VALID_AAS = Set(['A', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'K', 'L',
                        'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W', 'Y'])
-"""
-    digest_sequence(sequence::AbstractString, regex::Regex, max_length::Int, min_length::Int, missed_cleavages::Int)::Vector{String}
 
-Digest a protein sequence into peptides using the specified enzyme cleavage pattern.
+const VALID_DIGEST_SPECIFICITIES = ("full", "semi", "semi-n", "semi-c")
 
-# Parameters
-- `sequence::AbstractString`: The protein sequence to digest
-- `regex::Regex`: Enzyme cleavage pattern (matches cleavage sites)
-- `max_length::Int`: Maximum peptide length to include
-- `min_length::Int`: Minimum peptide length to include
-- `missed_cleavages::Int`: Maximum number of internal cleavage sites allowed in a peptide
+"""Normalize and validate a FASTA digestion-specificity setting."""
+function normalize_digest_specificity(specificity::AbstractString)::String
+    normalized = replace(lowercase(strip(String(specificity))), '_' => '-')
+    normalized in VALID_DIGEST_SPECIFICITIES || throw(ArgumentError(
+        "specificity must be one of $(join(VALID_DIGEST_SPECIFICITIES, ", ")); got: $specificity"
+    ))
+    return normalized
+end
 
-# Returns
-- `Vector{String}`: Vector of digested peptide sequences as Strings
-
-# Details
-The function simulates enzymatic digestion by:
-1. Finding all cleavage sites matching the regex pattern
-2. Generating peptides between sites, including those with missed cleavages
-3. Filtering peptides by length constraints
-4. Converting all SubStrings to Strings to ensure memory stability
-
-# Examples
-```julia
-# Trypsin-like digestion (cleaves after K or R except when followed by P)
-peptides = digest_sequence("MKVGPKAFRVLTEDEMAKR", r"[KR][^P]", 20, 5, 1)
-# Returns ["MKVGPK", "VGPKAFR", "VLTEDEMAK", "VLTEDEMAKR", "AFRVLTEDEMAK"]
-
-# No missed cleavages
-peptides = digest_sequence("MKVGPKAFRVLTEDEMAKR", r"[KR][^P]", 20, 5, 0)
-# Returns ["VLTEDEMAK"]
-```
-"""
-function digest_sequence(sequence::AbstractString,
-                        regex::Regex,
-                        max_length::Int,
-                        min_length::Int,
-                        missed_cleavages::Int)::Tuple{Vector{String}, Vector{UInt32}}
+function _digest_fully_specific_sequence(sequence::AbstractString,
+                                         regex::Regex,
+                                         max_length::Int,
+                                         min_length::Int,
+                                         missed_cleavages::Int
+                                        )::Tuple{Vector{String}, Vector{UInt32}, Vector{UInt8}}
     
-    function add_peptide!(peptides::Vector{SubString{String}},
-                        starts::Vector{UInt32},
-                        n::Int,
-                        sequence::AbstractString,
-                        site::Int,
-                        previous_sites::Vector{Int},
-                        min_length::Int,
-                        max_length::Int,
-                        missed_cleavages::Int)
+    function add_peptide!(peptides::Vector{String},
+                          starts::Vector{UInt32},
+                          n::Int,
+                          sequence::AbstractString,
+                          site::Int,
+                          previous_sites::Vector{Int},
+                          min_length::Int,
+                          max_length::Int,
+                          missed_cleavages::Int)
         
         for i in 1:min(n, missed_cleavages + 1)
             previous_site = previous_sites[end - i + 1]
             if ((site - previous_site) >= min_length) && 
                 ((site - previous_site) <= max_length)
-                # Convert SubString to String when adding to peptides
                 push!(peptides, String(@view sequence[previous_site+1:site]))
                 push!(starts, UInt32(previous_site + 1))
             end
@@ -86,7 +65,7 @@ function digest_sequence(sequence::AbstractString,
         return n + 1
     end
 
-    peptides = Vector{SubString{String}}()
+    peptides = String[]
     starts = Vector{UInt32}()
     previous_sites = zeros(Int, missed_cleavages + 1)
     previous_sites[1] = 0
@@ -99,15 +78,120 @@ function digest_sequence(sequence::AbstractString,
     end
 
     # Handle C-terminal peptides
-    n = add_peptide!(peptides, starts, n, sequence, length(sequence),
-                    previous_sites, min_length, max_length,
-                    missed_cleavages)
+    add_peptide!(peptides, starts, n, sequence, length(sequence),
+                 previous_sites, min_length, max_length,
+                 missed_cleavages)
 
-    return peptides, starts
+    return peptides, starts, fill(UInt8(2), length(peptides))
 end
 
 """
-    digest_fasta(fasta::Vector{FastaEntry}, proteome_id::String; regex::Regex = r"[KR][^P|\$]", max_length::Int = 40, min_length::Int = 8, missed_cleavages::Int = 1)::Vector{FastaEntry}
+    digest_sequence(sequence, regex, max_length, min_length, missed_cleavages,
+                    specificity) -> (peptides, starts, num_enzymatic_termini)
+
+Digest a protein with configurable enzymatic specificity. `specificity` may be:
+
+- `"full"`: both peptide termini must be enzymatic (the historical behavior),
+- `"semi"`: at least one peptide terminus must be enzymatic,
+- `"semi-n"`: the N terminus may be non-enzymatic; the C terminus must be enzymatic,
+- `"semi-c"`: the C terminus may be non-enzymatic; the N terminus must be enzymatic.
+
+Protein termini count as enzymatic.
+"""
+function digest_sequence(sequence::AbstractString,
+                         regex::Regex,
+                         max_length::Int,
+                         min_length::Int,
+                         missed_cleavages::Int,
+                         specificity::AbstractString
+                        )::Tuple{Vector{String}, Vector{UInt32}, Vector{UInt8}}
+    normalized = normalize_digest_specificity(specificity)
+
+    if normalized == "full"
+        return _digest_fully_specific_sequence(
+            sequence, regex, max_length, min_length, missed_cleavages
+        )
+    end
+
+    isempty(sequence) && return String[], UInt32[], UInt8[]
+
+    sequence_length = length(sequence)
+    cleavage_mask = falses(sequence_length)
+    for site in eachmatch(regex, sequence, overlap = true)
+        1 <= site.offset <= sequence_length || continue
+        cleavage_mask[site.offset] = true
+    end
+
+    # Prefix counts make the missed-cleavage test O(1) for every emitted peptide.
+    cleavage_prefix = zeros(Int, sequence_length)
+    running = 0
+    @inbounds for idx in 1:sequence_length
+        running += cleavage_mask[idx]
+        cleavage_prefix[idx] = running
+    end
+
+    specific_ends = findall(cleavage_mask)
+    if isempty(specific_ends) || specific_ends[end] != sequence_length
+        push!(specific_ends, sequence_length)
+    end
+
+    @inline start_is_enzymatic(start_idx::Int) =
+        start_idx == 1 || cleavage_mask[start_idx - 1]
+    @inline end_is_enzymatic(end_idx::Int) =
+        end_idx == sequence_length || cleavage_mask[end_idx]
+    @inline function internal_cleavages(start_idx::Int, end_idx::Int)
+        end_idx <= start_idx && return 0
+        before_end = cleavage_prefix[end_idx - 1]
+        before_start = start_idx > 1 ? cleavage_prefix[start_idx - 1] : 0
+        return before_end - before_start
+    end
+
+    peptides = String[]
+    starts = UInt32[]
+    enzymatic_termini = UInt8[]
+
+    function emit_candidate!(start_idx::Int, end_idx::Int, start_enzymatic::Bool)
+        internal_cleavages(start_idx, end_idx) <= missed_cleavages || return
+        end_enzymatic = end_is_enzymatic(end_idx)
+        push!(peptides, String(@view sequence[start_idx:end_idx]))
+        push!(starts, UInt32(start_idx))
+        push!(enzymatic_termini,
+              UInt8(start_enzymatic ? 1 : 0) + UInt8(end_enzymatic ? 1 : 0))
+        return
+    end
+
+    for start_idx in 1:sequence_length
+        min_end = start_idx + min_length - 1
+        min_end > sequence_length && continue
+        max_end = min(start_idx + max_length - 1, sequence_length)
+        start_enzymatic = start_is_enzymatic(start_idx)
+
+        # semi-c allows an arbitrary C terminus but requires an enzymatic N
+        # terminus. General semi digestion does the same for enzymatic starts.
+        if normalized == "semi-c" || (normalized == "semi" && start_enzymatic)
+            start_enzymatic || continue
+            for end_idx in min_end:max_end
+                emit_candidate!(start_idx, end_idx, start_enzymatic)
+            end
+            continue
+        end
+
+        # semi-n, and general semi peptides with a non-enzymatic start, require
+        # an enzymatic C terminus. Binary search avoids scanning every cleavage
+        # site for every possible start.
+        first_end = searchsortedfirst(specific_ends, min_end)
+        last_end = searchsortedlast(specific_ends, max_end)
+        first_end > last_end && continue
+        for end_pos in first_end:last_end
+            emit_candidate!(start_idx, specific_ends[end_pos], start_enzymatic)
+        end
+    end
+
+    return peptides, starts, enzymatic_termini
+end
+
+"""
+    digest_fasta(fasta::Vector{FastaEntry}, proteome_id::String; regex::Regex = r"[KR][^P|\$]", max_length::Int = 40, min_length::Int = 8, missed_cleavages::Int = 1, specificity::AbstractString = "full")::Vector{FastaEntry}
 
 Enzymatically digest protein sequences from FASTA entries into peptides.
 
@@ -118,6 +202,7 @@ Enzymatically digest protein sequences from FASTA entries into peptides.
 - `max_length::Int`: Maximum peptide length to include (default: 40)
 - `min_length::Int`: Minimum peptide length to include (default: 8)
 - `missed_cleavages::Int`: Maximum missed cleavages allowed (default: 1)
+- `specificity::AbstractString`: `"full"`, `"semi"`, `"semi-n"`, or `"semi-c"` (default: `"full"`)
 
 # Returns
 - `Vector{FastaEntry}`: Digested peptide entries as FastaEntry objects
@@ -136,6 +221,7 @@ The resulting FastaEntry objects contain:
 - Digested peptide sequence
 - No structural or isotopic modifications (missing)
 - Zero charge state
+- Number of enzymatic termini (one or two for the supported modes)
 - Sequential base_pep_id
 - Zero entrapment_group_id
 - is_decoy set to false
@@ -164,19 +250,22 @@ function digest_fasta(fasta::Vector{FastaEntry},
                      regex::Regex = r"[KR][^P|$]",
                      max_length::Int = 40,
                      min_length::Int = 8,
-                     missed_cleavages::Int = 1)::Vector{FastaEntry}
+                     missed_cleavages::Int = 1,
+                     specificity::AbstractString = "full")::Vector{FastaEntry}
 
     peptides_fasta = Vector{FastaEntry}()
     base_pep_id = one(UInt32)
     for entry in fasta
-        peptides, starts = digest_sequence(
+        peptides, starts, enzymatic_termini = digest_sequence(
             get_sequence(entry),
             regex,
             max_length,
             min_length,
             missed_cleavages,
+            specificity,
         )
-        for (peptide, start_idx) in zip(peptides, starts)
+        for (peptide, start_idx, num_enzymatic_termini) in
+            zip(peptides, starts, enzymatic_termini)
 
             # Skip peptides containing non-standard amino acids
             if !all(aa -> aa ∈ VALID_AAS, peptide)
@@ -195,9 +284,10 @@ function digest_fasta(fasta::Vector{FastaEntry},
                 missing, #structural_mods 
                 missing, #isotopic_mods 
                 zero(UInt8),
+                num_enzymatic_termini,
                 zero(UInt32),  # base_target_id (will be assigned later)
                 base_pep_id,
-                zero(UInt8),   # entrapment_pair_id
+                zero(UInt32),  # entrapment_pair_id
                 false          # is_decoy
             ))
             base_pep_id += one(UInt32)

--- a/src/Routines/BuildSpecLib/fasta/fasta_utils.jl
+++ b/src/Routines/BuildSpecLib/fasta/fasta_utils.jl
@@ -220,6 +220,7 @@ function add_entrapment_sequences(
                         adjusted_structural_mods, #structural_mods - now properly adjusted
                         adjusted_isotopic_mods,   #isotopic_mods - now properly adjusted
                         get_charge(target_entry),
+                        get_num_enzymatic_termini(target_entry),
                         get_base_target_id(target_entry), # inherit base_target_id for tracking
                         get_base_pep_id(target_entry),
                         entrapment_group_id,
@@ -397,6 +398,7 @@ function add_entrapment_sequences_grouped(
                     adjusted_structural_mods,
                     adjusted_isotopic_mods,
                     get_charge(target_entry),
+                    get_num_enzymatic_termini(target_entry),
                     get_base_target_id(target_entry),
                     get_base_pep_id(target_entry),
                     UInt8(i),
@@ -801,6 +803,7 @@ function add_decoy_sequences(
                 adjusted_structural_mods,
                 adjusted_isotopic_mods,
                 get_charge(target_entry),
+                get_num_enzymatic_termini(target_entry),
                 get_base_target_id(target_entry), # inherit base_target_id for tracking
                 get_base_pep_id(target_entry),  # inherit base_pep_id for pairing
                 get_entrapment_pair_id(target_entry),
@@ -959,6 +962,7 @@ function add_decoy_sequences_grouped(
                 adjusted_structural_mods,
                 adjusted_isotopic_mods,
                 get_charge(target_entry),
+                get_num_enzymatic_termini(target_entry),
                 get_base_target_id(target_entry),
                 get_base_pep_id(target_entry),
                 get_entrapment_pair_id(target_entry),
@@ -1000,8 +1004,9 @@ This function:
 1. Identifies peptides with identical sequences (considering I/L as equivalent)
 2. For shared peptides, combines their protein accessions with semicolon separators
 3. Also combines proteome identifiers and descriptions if multiple exist
-4. Preserves other metadata from the first encountered instance of each sequence
-5. Returns a vector containing only unique peptide sequences
+4. Preserves all aligned accession/start-position mappings
+5. Preserves other metadata from the first encountered instance of each sequence
+6. Returns a vector containing only unique peptide sequences
 
 # Examples
 ```julia
@@ -1036,6 +1041,7 @@ function combine_shared_peptides(peptides::Vector{FastaEntry})
             a += 1
             fasta_entry = seq_to_fasta_entry[sequence_il_equiv]
             accession = get_id(peptide)*";"*get_id(fasta_entry)
+            start_idxs = vcat(get_start_idx(peptide), get_start_idx(fasta_entry))
             proteome = get_proteome(peptide)*";"*get_proteome(fasta_entry)
             description = get_description(peptide)*";"*get_description(fasta_entry)
             gene = get_gene(peptide)*";"*get_gene(fasta_entry)
@@ -1049,10 +1055,14 @@ function combine_shared_peptides(peptides::Vector{FastaEntry})
                                                         organism,
                                                         proteome,
                                                         get_sequence(fasta_entry),
-                                                        get_start_idx(fasta_entry),
+                                                        start_idxs,
                                                         get_structural_mods(fasta_entry),
                                                         get_isotopic_mods(fasta_entry),
                                                         get_charge(fasta_entry),
+                                                        max(
+                                                            get_num_enzymatic_termini(peptide),
+                                                            get_num_enzymatic_termini(fasta_entry),
+                                                        ),
                                                         get_base_target_id(fasta_entry), # preserve base_target_id
                                                         base_pep_id,
                                                         get_entrapment_pair_id(fasta_entry), 
@@ -1100,6 +1110,7 @@ function assign_base_pep_ids!(fasta_entries::Vector{FastaEntry})
             get_structural_mods(entry),
             get_isotopic_mods(entry),
             get_charge(entry),
+            get_num_enzymatic_termini(entry),
             get_base_target_id(entry), # preserve base_target_id
             UInt32(i),               # base_pep_id - sequential assignment
             get_entrapment_pair_id(entry),
@@ -1127,6 +1138,7 @@ function assign_base_target_ids!(fasta_entries::Vector{FastaEntry})
             get_structural_mods(entry),
             get_isotopic_mods(entry),
             get_charge(entry),
+            get_num_enzymatic_termini(entry),
             UInt32(i),   # assign grouped base_target_id
             get_base_pep_id(entry),    # preserve existing base_pep_id
             get_entrapment_pair_id(entry),

--- a/src/Routines/BuildSpecLib/utils/check_params.jl
+++ b/src/Routines/BuildSpecLib/utils/check_params.jl
@@ -72,6 +72,10 @@ function check_params_bsp(json_string::String)
     check_param(fasta_digest_params, "max_var_mods", Integer)
     check_param(fasta_digest_params, "add_decoys", Bool)
     check_param(fasta_digest_params, "entrapment_r", Real)
+
+    check_param(fasta_digest_params, "specificity", String)
+    specificity = normalize_digest_specificity(fasta_digest_params["specificity"])
+    fasta_digest_params["specificity"] = specificity
     
     # Check decoy_method with default value
     if !haskey(fasta_digest_params, "decoy_method")

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
@@ -2085,6 +2085,7 @@ function process_final_psms!(
     isotopic_mods = Vector{Union{Missing, String}}(undef, n)
     charge = Vector{UInt8}(undef, n)
     sequence = Vector{String}(undef, n)
+    peptide_start_positions = Vector{String}(undef, n)
     file_name = Vector{String}(undef, n)
     psms_precursor_idx = psms[!,:precursor_idx]::Vector{UInt32}
 
@@ -2107,6 +2108,7 @@ function process_final_psms!(
     isotopic_mods_col = getIsotopicMods(precursors)
     charge_col = getCharge(precursors)
     sequence_col = getSequence(precursors)
+    start_idx_col = getStartIdx(precursors)
     for i in range(1, n)
         pid = psms_precursor_idx[i]
         ms_file_idxs[i] = UInt32(ms_file_idx)
@@ -2117,6 +2119,7 @@ function process_final_psms!(
         isotopic_mods[i] = isotopic_mods_col[pid]
         charge[i] = charge_col[pid]
         sequence[i] = sequence_col[pid]
+        peptide_start_positions[i] = _format_start_idx(start_idx_col[pid])
         file_name[i] = parsed_fname
     end
 
@@ -2128,6 +2131,7 @@ function process_final_psms!(
     psms[!,:isotopic_mods] = isotopic_mods
     psms[!,:charge] = charge 
     psms[!,:sequence] = sequence
+    psms[!,:peptide_start_positions] = peptide_start_positions
     psms[!,:file_name] = file_name
     
     return nothing

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
@@ -19,7 +19,7 @@ needed by the per-file LightGBM. Reads the deconv-emit columns
 - `:decoy`, `:target`, `:cv_fold`, `:charge`, `:charge2`
 - `:rt`, `:err_norm`
 - `:irt_obs`, `:irt_pred`, `:irt_error`
-- `:missed_cleavage`, `:Mox`, `:sequence_length`, `:prec_mz`
+- `:missed_cleavage`, `:num_enzymatic_termini`, `:Mox`, `:sequence_length`, `:prec_mz`
 - `:spectrum_peak_count`
 
 Mox is computed lazily once per precursor via a length-`n_library` cache;
@@ -50,6 +50,7 @@ function _add_psm_features!(psms::DataFrame,
     prec_length      = getLength(precursors_lib)
     structural_mods  = getStructuralMods(precursors_lib)
     prec_missed_clv  = getMissedCleavages(precursors_lib)
+    prec_enzymatic_termini = getNumEnzymaticTermini(precursors_lib)
     scan_rts         = getRetentionTimes(spectra)
     masses           = getMzArrays(spectra)
 
@@ -72,6 +73,7 @@ function _add_psm_features!(psms::DataFrame,
     irt_pred            = zeros(Float32, N)
     irt_error           = zeros(Float32, N)
     missed_cleavage     = zeros(UInt8,   N)
+    num_enzymatic_termini = zeros(UInt8, N)
     Mox                 = zeros(UInt8,   N)
     spectrum_peak_count = zeros(Float16, N)
     sequence_length     = zeros(UInt8,   N)
@@ -104,6 +106,7 @@ function _add_psm_features!(psms::DataFrame,
             irt_pred[i]      = irt_pred_i
             irt_error[i]     = abs(irt_obs_i - irt_pred_i)
             missed_cleavage[i]     = prec_missed_clv[prec_idx]
+            num_enzymatic_termini[i] = prec_enzymatic_termini[prec_idx]
             sequence_length[i]     = prec_length[prec_idx]
             prec_mzs[i]            = prec_mz[prec_idx]
             spectrum_peak_count[i] = length(masses[scan_idx])
@@ -128,6 +131,7 @@ function _add_psm_features!(psms::DataFrame,
     psms[!, :irt_pred]            = irt_pred
     psms[!, :irt_error]           = irt_error
     psms[!, :missed_cleavage]     = missed_cleavage
+    psms[!, :num_enzymatic_termini] = num_enzymatic_termini
     psms[!, :Mox]                 = Mox
     psms[!, :spectrum_peak_count] = spectrum_peak_count
     psms[!, :sequence_length]     = sequence_length
@@ -154,7 +158,8 @@ const PRESCORE_FEATURES = [
 
     # Core PSM / sequence metrics
     :fitted_manhattan_distance, :irt_error, :poisson, :err_norm,
-    :total_ions, :missed_cleavage, :y_count, :weight, :gof,
+    :total_ions, :missed_cleavage, :num_enzymatic_termini,
+    :y_count, :weight, :gof,
     :Mox, :spectrum_peak_count, :sequence_length,
     :fitted_hellinger,
 

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/scoring.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/scoring.jl
@@ -154,6 +154,20 @@ function _train_psm_classifier_with_fallback(
     n_total = nrow(psms)
 
     available_features = filter(f -> hasproperty(psms, f), features)
+    if :num_enzymatic_termini in available_features
+        enzymatic_termini = psms[!, :num_enzymatic_termini]
+        first_value = isempty(enzymatic_termini) ? nothing : first(enzymatic_termini)
+        if isempty(enzymatic_termini) ||
+           all(value -> isequal(value, first_value), enzymatic_termini)
+            # Full-specific libraries (and some small semi-specific files) have
+            # no information in this column. Keep their model matrix identical
+            # to the pre-specificity path and avoid a collinear probit input.
+            deleteat!(
+                available_features,
+                findfirst(==(:num_enzymatic_termini), available_features),
+            )
+        end
+    end
     n_features = length(available_features)
 
     # Build feature matrix

--- a/src/Routines/SearchDIA/SearchMethods/MaxLFQSearch/MaxLFQSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MaxLFQSearch/MaxLFQSearch.jl
@@ -200,17 +200,20 @@ function summarize_results!(
         )
     end
 
-    # Ensure all PSM files are sorted correctly for MaxLFQ
+    # Keep inferred protein groups contiguous for MaxLFQ. Ascending group order
+    # places `missing` (non-inferred peptides) after all inferred groups; the
+    # remaining tie-breakers retain their historical descending order.
     sort_keys = (:inferred_protein_group, :target, :entrapment_group_id, :precursor_idx)
     sort_file_by_keys!(psm_refs, :inferred_protein_group, :target, :entrapment_group_id, :precursor_idx;
-                       reverse=[true, true, true, true], parallel=true )
+                       reverse=[false, true, true, true], parallel=true )
 
     # Chunked merge: split into protein-group-aligned chunks bounded by max_chunk_size_mb
     chunk_dir = joinpath(temp_folder, "merge_chunks")
     max_chunk_bytes = round(Int, params.max_chunk_size_mb * 1_000_000)
     chunk_refs = stream_sorted_merge_chunked(
         psm_refs, chunk_dir, :inferred_protein_group, sort_keys...;
-        batch_size=1_000_000, reverse=true, max_chunk_bytes=max_chunk_bytes
+        batch_size=1_000_000, reverse=[false, true, true, true],
+        max_chunk_bytes=max_chunk_bytes
     )
 
     # Validate first chunk has required columns for MaxLFQ

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/model_config.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/model_config.jl
@@ -76,7 +76,8 @@ const ADVANCED_FEATURE_SET = [
     # Kept close to PRESCORE_FEATURES (MainSearch/features.jl), with
     # cross-run-only substitutions where the selected best PSM is known.
     :fitted_manhattan_distance, :irt_error, :poisson, :err_norm,
-    :total_ions, :missed_cleavage, :y_count, :weight, :gof,
+    :total_ions, :missed_cleavage, :num_enzymatic_termini,
+    :y_count, :weight, :gof,
     :Mox, :spectrum_peak_count, :sequence_length,
     :fitted_hellinger,
     :weight_ratio_at_scan, :weight_rank_at_scan,

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/pass1_oom.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/pass1_oom.jl
@@ -4,7 +4,8 @@
 # streaming passes over the per-file Arrow tables:
 #
 #   Pass 1 (metadata): Count rows per cv_fold; pick the feature list. Reads
-#                      only Arrow metadata, no column data.
+#                      Arrow metadata plus the optional UInt8 digestion column
+#                      to remove it when it is constant.
 #   Pass 2 (sample):   Reservoir-sample up to K rows per fold into a fixed-
 #                      size feature matrix. Train one LightGBM booster per
 #                      fold on its sampled matrix.
@@ -70,14 +71,44 @@ end
 
 # Determine which features in `requested` are actually present in the per-file
 # Arrow tables. We trust the first non-empty file's schema (all per-file
-# arrows produced by MainSearch share the same columns).
+# arrows produced by MainSearch share the same columns). The optional digestion
+# feature gets one lightweight UInt8 scan so full-specific libraries retain the
+# same model matrix they used before the feature existed.
 function _resolve_available_features(file_paths::Vector{String}, requested::Vector{Symbol})
+    available = Symbol[]
     for fpath in file_paths
         tbl = Arrow.Table(fpath)
         length(tbl.precursor_idx) == 0 && continue
-        return filter(f -> hasproperty(tbl, f), requested)
+        available = filter(f -> hasproperty(tbl, f), requested)
+        break
     end
-    return Symbol[]
+
+    if :num_enzymatic_termini in available
+        first_value = nothing
+        found_value = false
+        varies = false
+        for fpath in file_paths
+            tbl = Arrow.Table(fpath)
+            hasproperty(tbl, :num_enzymatic_termini) || continue
+            for value in tbl.num_enzymatic_termini
+                if !found_value
+                    first_value = value
+                    found_value = true
+                elseif !isequal(value, first_value)
+                    varies = true
+                    break
+                end
+            end
+            varies && break
+        end
+        if !varies
+            deleteat!(
+                available,
+                findfirst(==(:num_enzymatic_termini), available),
+            )
+        end
+    end
+    return available
 end
 
 # Pass 2: single-pass reservoir-sample both folds simultaneously.

--- a/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/protein_groups.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/protein_groups.jl
@@ -32,17 +32,19 @@ Calculate statistical features for a protein group.
 - `ProteinFeatures`: Statistical features for the protein group
 """
 function calculate_protein_features(builder::ProteinGroupBuilder, catalog::Dictionary{ProteinKey, Set{String}})::ProteinFeatures
-    n_peptides = UInt16(length(builder.peptides))
+    n_peptides = UInt32(length(builder.peptides))
     
     # Get possible peptides for this protein
     possible_peptides = get(catalog, builder.key, Set{String}())
-    n_possible_peptides = UInt16(length(possible_peptides))
+    # Semi-specific libraries can contain more than typemax(UInt16) possible
+    # peptides for a single long protein.
+    n_possible_peptides = UInt32(length(possible_peptides))
     
     # Calculate coverage
     peptide_coverage = n_possible_peptides > 0 ? Float32(n_peptides) / Float32(n_possible_peptides) : 0.0f0
     
     # Calculate total peptide length
-    total_peptide_length = UInt16(sum(length(peptide) for peptide in builder.peptides))
+    total_peptide_length = UInt32(sum(length(peptide) for peptide in builder.peptides))
     
     # Calculate log features for regression
     log_n_possible_peptides = n_possible_peptides > 0 ? log(Float32(n_possible_peptides)) : 0.0f0
@@ -93,11 +95,11 @@ function write_protein_groups_arrow(protein_groups::Dictionary{ProteinKey, Prote
     targets = Vector{Bool}(undef, n_groups)
     entrap_ids = Vector{UInt8}(undef, n_groups)
     pg_scores = Vector{Float32}(undef, n_groups)
-    n_peptides = Vector{UInt16}(undef, n_groups)
-    n_possible_peptides = Vector{UInt16}(undef, n_groups)
+    n_peptides = Vector{UInt32}(undef, n_groups)
+    n_possible_peptides = Vector{UInt32}(undef, n_groups)
     peptide_coverages = Vector{Float32}(undef, n_groups)
     peptide_coverage_logits = Vector{Float32}(undef, n_groups)
-    total_peptide_lengths = Vector{UInt16}(undef, n_groups)
+    total_peptide_lengths = Vector{UInt32}(undef, n_groups)
     log_n_possible_peptides = Vector{Float32}(undef, n_groups)
     log_binom_coeffs = Vector{Float32}(undef, n_groups)
     

--- a/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/protein_inference_pipeline.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/protein_inference_pipeline.jl
@@ -1508,9 +1508,13 @@ function group_psms_by_protein(
             precursor_consensus_prefix_shape = prefix_features.prefix_shape
         end
 
+        fully_enzymatic = hasproperty(gdf, :num_enzymatic_termini) ?
+            (gdf.num_enzymatic_termini .== 2) :
+            trues(nrow(gdf))
         has_common = any(
             quant_mask .&
             (gdf.missed_cleavage .== 0) .&
+            fully_enzymatic .&
             (gdf.Mox .== 0)
         )
 

--- a/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
+++ b/src/Routines/SearchDIA/WriteOutputs/writeCSVTables.jl
@@ -503,6 +503,9 @@ function writePrecursorCSV_chunked(
         "structural_mods",
         "isotopic_mods",
         "prec_mz",
+        "peptide_start_positions",
+        "missed_cleavage",
+        "num_enzymatic_termini",
         "global_score",
         "global_qval",
         "use_for_protein_quant",
@@ -524,7 +527,9 @@ function writePrecursorCSV_chunked(
         :structural_mods,
         :isotopic_mods,
         :prec_mz,
+        :peptide_start_positions,
         :missed_cleavage,
+        :num_enzymatic_termini,
         :global_score,
         :score,
         :global_qval,
@@ -569,6 +574,15 @@ function writePrecursorCSV_chunked(
                     precursors_long = DataFrame()
                     for col in _precursor_csv_read_columns(chunk_tbl, requested_cols)
                         precursors_long[!, col] = chunk_tbl[col]
+                    end
+                    if :num_enzymatic_termini in requested_cols &&
+                       !hasproperty(precursors_long, :num_enzymatic_termini)
+                        # Resume/output compatibility for chunks written before
+                        # semi-specific digestion existed. Those searches used
+                        # fully specific libraries by construction.
+                        precursors_long[!, :num_enzymatic_termini] = fill(
+                            UInt8(2), length(chunk_tbl.precursor_idx)
+                        )
                     end
                     n_rows = size(precursors_long, 1)
                     n_rows == 0 && continue

--- a/src/structs/KoinaStructs/FastaTypes.jl
+++ b/src/structs/KoinaStructs/FastaTypes.jl
@@ -26,10 +26,12 @@ struct FastaEntry
     organism::String
     proteome::String
     sequence::String
-    start_idx::UInt32
+    # Protein starts aligned with the semicolon-delimited accession mappings.
+    start_idx::Vector{UInt32}
     structural_mods::Union{Missing,Vector{PeptideMod}}
     isotopic_mods::Union{Missing,Vector{PeptideMod}}
     charge::UInt8
+    num_enzymatic_termini::UInt8
     base_target_id::UInt32
     base_pep_id::UInt32
     entrapment_pair_id::UInt32
@@ -52,6 +54,34 @@ is_decoy(entry::FastaEntry) = entry.is_decoy
 get_isotopic_mods(entry::FastaEntry) = entry.isotopic_mods
 get_structural_mods(entry::FastaEntry) = entry.structural_mods
 get_charge(entry::FastaEntry) = entry.charge
+get_num_enzymatic_termini(entry::FastaEntry) = entry.num_enzymatic_termini
+
+"""Construct a FASTA entry with one protein-position mapping."""
+function FastaEntry(
+    accession::String,
+    description::String,
+    gene::String,
+    protein::String,
+    organism::String,
+    proteome::String,
+    sequence::String,
+    start_idx::Integer,
+    struct_mods::Union{Missing,Vector{PeptideMod}},
+    iso_mods::Union{Missing,Vector{PeptideMod}},
+    charge::UInt8,
+    num_enzymatic_termini::UInt8,
+    base_target_id::UInt32,
+    base_pep_id::UInt32,
+    entrapment_pair_id::UInt32,
+    is_decoy::Bool,
+)
+    return FastaEntry(
+        accession, description, gene, protein, organism, proteome, sequence,
+        UInt32[UInt32(start_idx)], struct_mods, iso_mods, charge,
+        num_enzymatic_termini, base_target_id, base_pep_id,
+        entrapment_pair_id, is_decoy,
+    )
+end
 
 # ---------------------------------------------------------------------------
 # Backward-compatible outer constructors
@@ -85,8 +115,8 @@ function FastaEntry(
 )
     return FastaEntry(
         String(accession), String(description), String(gene), String(protein), String(organism), String(proteome), String(sequence),
-        start_idx, struct_mods, iso_mods, charge,
-        base_target_id, base_pep_id, UInt32(entrapment_pair_id), is_decoy,
+        UInt32[start_idx], struct_mods, iso_mods, charge,
+        UInt8(2), base_target_id, base_pep_id, UInt32(entrapment_pair_id), is_decoy,
     )
 end
 
@@ -119,7 +149,7 @@ function FastaEntry(
 )
     return FastaEntry(
         String(accession), String(description), String(gene), String(protein), String(organism), String(proteome), String(sequence),
-        start_idx, struct_mods, iso_mods, charge,
-        base_target_id, base_pep_id, UInt32(entrapment_pair_id), is_decoy,
+        UInt32[start_idx], struct_mods, iso_mods, charge,
+        UInt8(2), base_target_id, base_pep_id, UInt32(entrapment_pair_id), is_decoy,
     )
 end

--- a/src/structs/SpectralLibrary/precursors.jl
+++ b/src/structs/SpectralLibrary/precursors.jl
@@ -77,6 +77,19 @@ getEntrapmentGroupId(lp::LibraryPrecursors)::Arrow.Primitive{UInt8, Vector{UInt8
 getMz(lp::LibraryPrecursors)::Arrow.Primitive{Float32, Vector{Float32}} = lp.data[:mz]
 getLength(lp::LibraryPrecursors)::Arrow.Primitive{UInt8, Vector{UInt8}} = lp.data[:length]
 getMissedCleavages(lp::LibraryPrecursors)::Arrow.Primitive{UInt8, Vector{UInt8}} = lp.data[:missed_cleavages]
+getStartIdx(lp::LibraryPrecursors) = lp.data[:start_idx]
+
+@inline _format_start_idx(start::Integer) = string(start)
+@inline _format_start_idx(starts) = join(starts, ';')
+
+function getNumEnzymaticTermini(lp::LibraryPrecursors)
+    hasproperty(lp.data, :num_enzymatic_termini) &&
+        return lp.data[:num_enzymatic_termini]
+
+    # Libraries built before enzymatic specificity was recorded were fully
+    # specific, so both termini are enzymatic by construction.
+    return fill(UInt8(2), length(lp))
+end
 getIrt(lp::LibraryPrecursors)::Arrow.Primitive{Float32, Vector{Float32}} = lp.data[:irt]
 getSulfurCount(lp::LibraryPrecursors)::Arrow.Primitive{UInt8, Vector{UInt8}} = lp.data[:sulfur_count]
 getIsotopicMods(lp::LibraryPrecursors)::Arrow.List{Union{Missing, String}, Int32, Vector{UInt8}} = lp.data[:isotopic_mods]

--- a/src/structs/protein_inference_types.jl
+++ b/src/structs/protein_inference_types.jl
@@ -72,18 +72,18 @@ Base.hash(k::PeptideKey, h::UInt) = hash((k.sequence, k.is_target, k.entrap_id),
 Statistical features of a protein group used for scoring and FDR control.
 
 # Fields
-- `n_peptides::UInt16`: Number of unique peptides observed
-- `n_possible_peptides::UInt16`: Total possible peptides from in silico digestion
+- `n_peptides::UInt32`: Number of unique peptides observed
+- `n_possible_peptides::UInt32`: Total possible peptides from in silico digestion
 - `peptide_coverage::Float32`: Fraction of possible peptides observed
-- `total_peptide_length::UInt16`: Sum of lengths of all observed peptides
+- `total_peptide_length::UInt32`: Sum of lengths of all observed peptides
 - `log_n_possible_peptides::Float32`: Log of n_possible_peptides for regression
 - `log_binom_coeff::Float32`: Log binomial coefficient for peptide sampling
 """
 struct ProteinFeatures
-    n_peptides::UInt16
-    n_possible_peptides::UInt16
+    n_peptides::UInt32
+    n_possible_peptides::UInt32
     peptide_coverage::Float32
-    total_peptide_length::UInt16
+    total_peptide_length::UInt32
     log_n_possible_peptides::Float32
     log_binom_coeff::Float32
 end

--- a/src/utils/FileOperations/streaming/MergeOperations.jl
+++ b/src/utils/FileOperations/streaming/MergeOperations.jl
@@ -284,23 +284,13 @@ function _mixed_reverse_compare(a, b, reverse_vec::Vector{Bool})
     # Compare each sort key according to its reverse setting
     for i in 1:(length(a)-1)  # -1 to skip table_idx (last element)
         val_a, val_b = a[i], b[i]
-        if reverse_vec[i]
-            # Reverse order: larger values come first
-            if val_a > val_b
-                return true
-            elseif val_a < val_b
-                return false
-            end
-            # Equal values continue to next key
-        else
-            # Normal order: smaller values come first
-            if val_a < val_b
-                return true
-            elseif val_a > val_b
-                return false
-            end
-            # Equal values continue to next key
-        end
+        isequal(val_a, val_b) && continue
+
+        # `isless` provides a total order for `missing`, unlike `<`/`>`, which
+        # return `missing`. This keeps mixed-direction merges consistent with
+        # Julia/DataFrames sorting: missing values are last for ascending keys
+        # and first for descending keys.
+        return reverse_vec[i] ? isless(val_b, val_a) : isless(val_a, val_b)
     end
     # All sort keys are equal, use table_idx as tiebreaker (always ascending)
     return a[end] < b[end]

--- a/src/utils/maxLFQ.jl
+++ b/src/utils/maxLFQ.jl
@@ -707,7 +707,7 @@ function LFQ(prot_ref,  # PSMFileReference - using Any to avoid dependency issue
     # Main processing logic (inlined from original LFQ function)
     nfiles = length(unique(prot[!, :ms_file_idx]))
     batch_start_idx, batch_end_idx = 1, min(batch_size, size(prot, 1))
-    @assert issorted(prot[!, :inferred_protein_group], rev=true) "LFQ input must be sorted by :inferred_protein_group (descending)"
+    @assert issorted(prot[!, :inferred_protein_group]) "LFQ input must be sorted by :inferred_protein_group (ascending)"
 
     while batch_start_idx <= size(prot, 1)
         last_prot_idx = prot[batch_end_idx, :inferred_protein_group]

--- a/test/UnitTests/FastaDigestTests.jl
+++ b/test/UnitTests/FastaDigestTests.jl
@@ -22,51 +22,90 @@
     @testset "digest_sequence" begin
         # Test basic tryptic digest with no missed cleavages
         sequence = "MKVGPKAFRVLTEDEMAKR"
-        peptides, starts = digest_sequence(sequence, r"[KR][^P]", 20, 5, 1)
+        peptides, starts, termini = digest_sequence(
+            sequence, r"[KR][^P]", 20, 5, 1, "full"
+        )
         @test Set(peptides) == Set(["MKVGPK", "VGPKAFR", "VLTEDEMAK", "VLTEDEMAKR", "AFRVLTEDEMAK"])
         @test Set(starts) == Set([1, 3, 7, 10])
+        @test all(==(UInt8(2)), termini)
         
-        peptides, starts = digest_sequence(sequence, r"[KR][^P]", 20, 5, 0)
+        peptides, starts, _ = digest_sequence(
+            sequence, r"[KR][^P]", 20, 5, 0, "full"
+        )
         @test Set(peptides) == Set(["VLTEDEMAK"])
         @test Set(starts) == Set([10])
 
         sequence = "MAKRTGKR"
-        peptides, starts = digest_sequence(sequence, r"[KR]", 10, 1, 0)
+        peptides, starts, _ = digest_sequence(sequence, r"[KR]", 10, 1, 0, "full")
         @test Set(peptides) == Set(["MAK", "R", "TGK", "R"])
         @test Set(starts) == Set([1, 4, 5, 8])
         
         # Test with missed cleavages
-        peptides, starts = digest_sequence(sequence, r"[KR]", 10, 1, 1)
+        peptides, starts, _ = digest_sequence(sequence, r"[KR]", 10, 1, 1, "full")
         @test Set(peptides) == Set(["MAK", "MAKR", "R", "RTGK", "TGK", "TGKR", "R"])
         @test Set(starts) == Set([1, 4, 5, 8])
         
         # Test with length constraints
-        peptides, starts = digest_sequence(sequence, r"[KR]", 5, 3, 0)
+        peptides, starts, _ = digest_sequence(sequence, r"[KR]", 5, 3, 0, "full")
         @test Set(peptides) == Set(["MAK", "TGK"])
         @test Set(starts) == Set([1, 5])
         
         # Test with regex that has overlap=true
         sequence = "MAKRRMAK"
-        peptides, starts = digest_sequence(sequence, r"R", 10, 1, 0)
+        peptides, starts, _ = digest_sequence(sequence, r"R", 10, 1, 0, "full")
         @test Set(peptides) == Set(["MAKR","R","MAK"])
         @test Set(starts) == Set([1, 5, 6])
         
         # Test with no matches
         sequence = "ACDEFGHIJ"
-        peptides, starts = digest_sequence(sequence, r"[KR]", 10, 1, 0)
+        peptides, starts, _ = digest_sequence(sequence, r"[KR]", 10, 1, 0, "full")
         @test Set(peptides) == Set(["ACDEFGHIJ"])
         @test Set(starts) == Set([1])
         
         # Test with empty sequence
         sequence = ""
-        peptides, starts = digest_sequence(sequence, r"[KR]", 10, 1, 0)
+        peptides, starts, termini = digest_sequence(sequence, r"[KR]", 10, 1, 0, "full")
         @test isempty(peptides)
         @test isempty(starts)
+        @test isempty(termini)
         
         # Test returned type is Vector{String}, not Vector{SubString}
         sequence = "MAKRTGKR"
-        peptides, starts = digest_sequence(sequence, r"[KR]", 10, 1, 0)
+        peptides, _, _ = digest_sequence(sequence, r"[KR]", 10, 1, 0, "full")
         @test eltype(peptides) === String
+    end
+
+    @testset "digest_sequence specificity" begin
+        sequence = "MAKRTGKR"
+        full, full_starts, full_ntt = digest_sequence(
+            sequence, r"[KR]", 4, 2, 0, "full"
+        )
+        semi_n, _, semi_n_ntt = digest_sequence(
+            sequence, r"[KR]", 4, 2, 0, "semi-n"
+        )
+        semi_c, _, semi_c_ntt = digest_sequence(
+            sequence, r"[KR]", 4, 2, 0, "semi-c"
+        )
+        semi, semi_starts, semi_ntt = digest_sequence(
+            sequence, r"[KR]", 4, 2, 0, "semi"
+        )
+
+        @test all(==(UInt8(2)), full_ntt)
+
+        @test !("AK" in full)
+        @test "AK" in semi_n
+        @test "MA" in semi_c
+        @test "AK" in semi
+        @test "MA" in semi
+        @test all(>=(UInt8(1)), semi_n_ntt)
+        @test all(>=(UInt8(1)), semi_c_ntt)
+        @test any(==(UInt8(1)), semi_ntt)
+        @test length(semi) == length(semi_starts) == length(semi_ntt)
+
+        @test normalize_digest_specificity(" Semi_N ") == "semi-n"
+        @test_throws ArgumentError digest_sequence(
+            sequence, r"[KR]", 4, 2, 0, "none"
+        )
     end
     
     
@@ -129,6 +168,8 @@
         @test get_charge(first_peptide) == 0
         @test get_base_pep_id(first_peptide) == 1
         @test get_entrapment_pair_id(first_peptide) == 0
+        @test get_num_enzymatic_termini(first_peptide) == 2
+        @test get_start_idx(first_peptide) == UInt32[1]
         @test is_decoy(first_peptide) == false
         
         # Test base_pep_id increments
@@ -143,6 +184,65 @@
         # Check some combined peptides exist
         peptide_seqs = [get_sequence(p) for p in peptides]
         @test Set(["MAK", "MAKR", "TGK", "RTGK", "TGKR", "PEPT", "RPEPT"]) == Set(peptide_seqs)
+
+        semi_peptides = digest_fasta(
+            fasta_entries,
+            "human";
+            regex=r"[KR]",
+            max_length=4,
+            min_length=2,
+            missed_cleavages=0,
+            specificity="semi",
+        )
+        @test "AK" in get_sequence.(semi_peptides)
+        @test any(==(UInt8(1)), get_num_enzymatic_termini.(semi_peptides))
+    end
+
+    @testset "enzymatic termini survive precursor expansion" begin
+        entry = FastaEntry(
+            "P1", "", "", "", "human", "test", "PEPTIDEK",
+            UInt32(1), missing, missing, UInt8(0), UInt8(1),
+            UInt32(1), UInt32(1), UInt32(0), false,
+        )
+        charged = add_charge([entry], 2, 3)
+        @test length(charged) == 2
+        @test all(==(UInt8(1)), get_num_enzymatic_termini.(charged))
+        @test all(e -> get_start_idx(e) === get_start_idx(entry), charged)
+
+        decoys = add_decoy_sequences([entry])
+        @test all(==(UInt8(1)), get_num_enzymatic_termini.(decoys))
+        @test get_start_idx(only(filter(is_decoy, decoys))) === get_start_idx(entry)
+
+        entrapments = add_entrapment_sequences([entry], UInt8(1))
+        @test all(==(UInt8(1)), get_num_enzymatic_termini.(entrapments))
+        entrapment = only(filter(e -> get_entrapment_pair_id(e) > 0, entrapments))
+        @test get_start_idx(entrapment) === get_start_idx(entry)
+
+        fully_specific = FastaEntry(
+            "P2", "", "", "", "human", "test", "PEPTIDEK",
+            UInt32(1), missing, missing, UInt8(0), UInt8(2),
+            UInt32(2), UInt32(2), UInt32(0), false,
+        )
+        shared = combine_shared_peptides([entry, fully_specific])
+        @test length(shared) == 1
+        @test get_num_enzymatic_termini(only(shared)) == 2
+        @test get_start_idx(only(shared)) == UInt32[1, 1]
+    end
+
+    @testset "digestion specificity parameter validation" begin
+        template_path = joinpath(
+            @__DIR__, "..", "..", "assets", "example_config",
+            "defaultBuildLibParams.json",
+        )
+        params = JSON.parsefile(template_path, dicttype=Dict{String,Any})
+        digest_params = params["fasta_digest_params"]
+        digest_params["specificity"] = " Semi_N "
+
+        validated = Pioneer.check_params_bsp(JSON.json(params))
+        @test validated["fasta_digest_params"]["specificity"] == "semi-n"
+
+        digest_params["specificity"] = "none"
+        @test_throws ArgumentError Pioneer.check_params_bsp(JSON.json(params))
     end
 
     #==========================================================================
@@ -376,10 +476,10 @@
     @testset "combine_shared_peptides" begin
         # Create test entries with shared sequences
         entries = [
-            FastaEntry("P1", "desc1", "", "", "human", "human", "PEPTIDE", UInt32(1), missing, missing, UInt8(0), UInt32(1), UInt32(1), UInt8(0), false),
-            FastaEntry("P2", "desc2", "", "", "human", "human", "PEPTIDE", UInt32(1), missing, missing, UInt8(0), UInt32(2), UInt32(2), UInt8(0), false),
+            FastaEntry("P1", "desc1", "", "", "human", "human", "PEPTIDE", UInt32(11), missing, missing, UInt8(0), UInt32(1), UInt32(1), UInt8(0), false),
+            FastaEntry("P2", "desc2", "", "", "human", "human", "PEPTIDE", UInt32(22), missing, missing, UInt8(0), UInt32(2), UInt32(2), UInt8(0), false),
             FastaEntry("P3", "desc3", "", "", "mouse", "mouse", "UNIQUE", UInt32(1), missing, missing, UInt8(0), UInt32(3), UInt32(3), UInt8(0), false),
-            FastaEntry("P4", "desc4", "", "", "human", "human", "PEPTLDE", UInt32(1), missing, missing, UInt8(0), UInt32(4), UInt32(4), UInt8(0), false)
+            FastaEntry("P4", "desc4", "", "", "human", "human", "PEPTLDE", UInt32(44), missing, missing, UInt8(0), UInt32(4), UInt32(4), UInt8(0), false)
         ]
         
         # Test combination
@@ -395,6 +495,8 @@
         # Check combined properties
         combined_entry = result[combined]
         @test Set(split(get_id(combined_entry), ';')) == Set(["P1", "P2", "P4"])
+        @test split(get_id(combined_entry), ';') == ["P4", "P2", "P1"]
+        @test get_start_idx(combined_entry) == UInt32[44, 22, 11]
         @test any(desc -> occursin(desc, get_description(combined_entry)), ["desc1", "desc2", "desc4"])
         
         # Find unique entry
@@ -402,6 +504,13 @@
         @test get_id(unique_entry) == "P3"
         @test get_description(unique_entry) == "desc3"
         @test get_proteome(unique_entry) == "mouse"
+
+        repeated = combine_shared_peptides([
+            FastaEntry("P5", "", "", "", "human", "human", "SAMEPEP", UInt32(3), missing, missing, UInt8(0), UInt32(1), UInt32(1), UInt8(0), false),
+            FastaEntry("P5", "", "", "", "human", "human", "SAMEPEP", UInt32(19), missing, missing, UInt8(0), UInt32(2), UInt32(2), UInt8(0), false),
+        ])
+        @test get_id(only(repeated)) == "P5;P5"
+        @test get_start_idx(only(repeated)) == UInt32[19, 3]
     end
     
 end

--- a/test/UnitTests/FastaEntryConstructorsTests.jl
+++ b/test/UnitTests/FastaEntryConstructorsTests.jl
@@ -33,6 +33,8 @@ using Test
     @test get_entrapment_pair_id(e1) == 0
     @test get_base_pep_id(e1) == 0
     @test get_charge(e1) == 0
+    @test get_num_enzymatic_termini(e1) == 2
+    @test get_start_idx(e1) == UInt32[1]
 
     # 16-arg compatibility constructor (base_prec_id ignored)
     e2 = FastaEntry(acc, desc, gene, prot, org, protm, seq,
@@ -40,5 +42,40 @@ using Test
                     UInt32(1), UInt32(2), UInt32(999), 1, false)
     @test get_base_pep_id(e2) == 2
     @test get_entrapment_pair_id(e2) == 1
+    @test get_num_enzymatic_termini(e2) == 2
+
+    # Explicit enzymatic-termini metadata uses the canonical field order.
+    e3 = FastaEntry(String(acc), String(desc), String(gene), String(prot),
+                    String(org), String(protm), String(seq), UInt32(1),
+                    missing, missing, UInt8(0), UInt8(1), UInt32(1),
+                    UInt32(2), UInt32(0), false)
+    @test get_num_enzymatic_termini(e3) == 1
+    @test get_start_idx(e3) == UInt32[1]
 end
 
+@testset "spectral-library precursor metadata" begin
+    mktempdir() do temp_dir
+        legacy_path = joinpath(temp_dir, "legacy.arrow")
+        Arrow.write(legacy_path, (
+            sequence = ["PEPTIDEK"],
+            accession_numbers = ["P1"],
+            start_idx = UInt32[17],
+        ))
+        legacy = Pioneer.SetPrecursors(Arrow.Table(legacy_path))
+        @test Pioneer.getNumEnzymaticTermini(legacy) == UInt8[2]
+        @test Pioneer.getStartIdx(legacy)[1] == UInt32(17)
+        @test Pioneer._format_start_idx(Pioneer.getStartIdx(legacy)[1]) == "17"
+
+        current_path = joinpath(temp_dir, "current.arrow")
+        Arrow.write(current_path, (
+            sequence = ["PEPTIDEK"],
+            accession_numbers = ["P1"],
+            start_idx = [UInt32[17, 42]],
+            num_enzymatic_termini = UInt8[1],
+        ))
+        current = Pioneer.SetPrecursors(Arrow.Table(current_path))
+        @test collect(Pioneer.getNumEnzymaticTermini(current)) == UInt8[1]
+        @test collect(Pioneer.getStartIdx(current)[1]) == UInt32[17, 42]
+        @test Pioneer._format_start_idx(Pioneer.getStartIdx(current)[1]) == "17;42"
+    end
+end

--- a/test/UnitTests/PrecursorPositionOutputTests.jl
+++ b/test/UnitTests/PrecursorPositionOutputTests.jl
@@ -1,0 +1,76 @@
+@testset "precursor protein-position output" begin
+    mktempdir() do temp_dir
+        chunk_path = joinpath(temp_dir, "precursors.arrow")
+        Arrow.write(chunk_path, DataFrame(
+            file_name = ["run1", "run1"],
+            species = ["human", "human"],
+            inferred_protein_group = ["P1", "P2"],
+            accession_numbers = ["P1;P3", "P2"],
+            peptide_start_positions = ["17;42", "9"],
+            sequence = ["PEPTIDEK", "ANOTHERK"],
+            charge = UInt8[2, 2],
+            structural_mods = Union{Missing,String}[missing, missing],
+            isotopic_mods = Union{Missing,String}[missing, missing],
+            prec_mz = Float32[500, 600],
+            missed_cleavage = UInt8[0, 1],
+            num_enzymatic_termini = UInt8[1, 2],
+            global_prob = Float32[0.99, 0.98],
+            global_qval = Float32[0.001, 0.002],
+            use_for_protein_quant = [true, true],
+            precursor_idx = UInt32[1, 2],
+            target = [true, true],
+            entrapment_group_id = UInt8[0, 0],
+            peak_area = Float32[1000, 2000],
+        ))
+
+        proteins_path = joinpath(temp_dir, "proteins.arrow")
+        Arrow.write(proteins_path, (
+            accession = ["P1", "P2", "P3"],
+            gene_name = ["G1", "G2", "G3"],
+            protein_name = ["Protein 1", "Protein 2", "Protein 3"],
+        ))
+        proteins = Pioneer.SetProteins(Arrow.Table(proteins_path))
+        refs = [Pioneer.PSMFileReference(chunk_path)]
+
+        Pioneer.writePrecursorCSV_chunked(
+            refs,
+            temp_dir,
+            ["run1"],
+            false,
+            proteins;
+            write_csv = true,
+        )
+
+        long = CSV.read(
+            joinpath(temp_dir, "precursors_long.tsv"),
+            DataFrame;
+            delim = '\t',
+            types = Dict(:peptide_start_positions => String),
+        )
+        wide = CSV.read(
+            joinpath(temp_dir, "precursors_wide.tsv"),
+            DataFrame;
+            delim = '\t',
+            types = Dict(:peptide_start_positions => String),
+        )
+        wide_arrow = Arrow.Table(joinpath(temp_dir, "precursors_wide.arrow"))
+
+        expected_order = [
+            :prec_mz,
+            :peptide_start_positions,
+            :missed_cleavage,
+            :num_enzymatic_termini,
+        ]
+        long_names = Symbol.(names(long))
+        wide_names = Symbol.(names(wide))
+        @test long.peptide_start_positions == ["17;42", "9"]
+        @test wide.peptide_start_positions == ["17;42", "9"]
+        @test collect(wide_arrow.peptide_start_positions) == ["17;42", "9"]
+        @test filter(in(expected_order), long_names) == expected_order
+        @test filter(in(expected_order), wide_names) == expected_order
+        @test Symbol.(propertynames(wide_arrow))[
+            findall(in(expected_order), Symbol.(propertynames(wide_arrow)))
+        ] == expected_order
+        @test wide.missed_cleavage == UInt8[0, 1]
+    end
+end

--- a/test/UnitTests/test_mainsearch_irt_refinement.jl
+++ b/test/UnitTests/test_mainsearch_irt_refinement.jl
@@ -32,6 +32,7 @@ end
                 0.85, 0.15, 0.25, 0.75,
                 0.88, 0.12, 0.22, 0.78,
             ],
+            num_enzymatic_termini = fill(UInt8(2), 12),
         )
 
         tiny_lgbm_hp = (
@@ -51,7 +52,7 @@ end
 
         scores, infold_scores, _last_classifier, info = train_psm_classifier_with_fallback(
             psms;
-            features = [:discriminant],
+            features = [:discriminant, :num_enzymatic_termini],
             lgbm_hp = tiny_lgbm_hp,
         )
 
@@ -60,6 +61,45 @@ end
         @test info.low_data
         @test haskey(info.candidate_oof, "probit")
         @test all(isfinite, scores)
+        @test :num_enzymatic_termini ∉ info.available_features
+
+        psms.num_enzymatic_termini .= repeat(UInt8[1, 2], 6)
+        _, _, _, varying_info = train_psm_classifier_with_fallback(
+            psms;
+            features = [:discriminant, :num_enzymatic_termini],
+            lgbm_hp = tiny_lgbm_hp,
+        )
+        @test :num_enzymatic_termini in varying_info.available_features
+    end
+
+    @testset "OOM feature selection drops only constant enzymatic termini" begin
+        mktempdir() do temp_dir
+            first_path = joinpath(temp_dir, "first.arrow")
+            second_path = joinpath(temp_dir, "second.arrow")
+            Arrow.write(first_path, (
+                precursor_idx = UInt32[1, 2],
+                discriminant = Float32[0.1, 0.2],
+                num_enzymatic_termini = UInt8[2, 2],
+            ))
+            Arrow.write(second_path, (
+                precursor_idx = UInt32[3, 4],
+                discriminant = Float32[0.3, 0.4],
+                num_enzymatic_termini = UInt8[2, 2],
+            ))
+            requested = [:discriminant, :num_enzymatic_termini]
+            @test Pioneer._resolve_available_features(
+                [first_path, second_path], requested
+            ) == [:discriminant]
+
+            Arrow.write(second_path, (
+                precursor_idx = UInt32[3, 4],
+                discriminant = Float32[0.3, 0.4],
+                num_enzymatic_termini = UInt8[1, 2],
+            ))
+            @test Pioneer._resolve_available_features(
+                [first_path, second_path], requested
+            ) == requested
+        end
     end
 end
 

--- a/test/integration/test_buildspeclib_synthetic.jl
+++ b/test/integration/test_buildspeclib_synthetic.jl
@@ -35,6 +35,13 @@ using Pioneer
         @test isfile(joinpath(lib_path, f))
     end
 
+    precursors = Arrow.Table(joinpath(lib_path, "precursors_table.arrow"))
+    @test hasproperty(precursors, :num_enzymatic_termini)
+    @test all(==(UInt8(2)), precursors.num_enzymatic_termini)
+    @test hasproperty(precursors, :start_idx)
+    @test all(starts -> !isempty(starts), precursors.start_idx)
+    @test all(starts -> eltype(starts) == UInt32, precursors.start_idx)
+
     # Cleanup
     safe_rmdir(lib_path)
 end

--- a/test/runtests_part2_units.jl
+++ b/test/runtests_part2_units.jl
@@ -37,6 +37,7 @@ include("./UnitTests/test_global_protein_inference.jl")
 include("./UnitTests/ChronologerPrepTests.jl")
 include("./UnitTests/FastaDigestTests.jl")
 include("./UnitTests/FastaEntryConstructorsTests.jl")
+include("./UnitTests/PrecursorPositionOutputTests.jl")
 include("./UnitTests/BuildPionLibTest.jl")
 include("./UnitTests/RazoQuadModel.jl")
 

--- a/test/test_setup.jl
+++ b/test/test_setup.jl
@@ -22,7 +22,8 @@ using Pioneer: getHigh, Counter, IndexFragment
 using Pioneer: UniformSpline
 using Pioneer: ProteinKey, PeptideKey, InferenceResult
 using Pioneer: PeptideMod, matchVarMods, add_pair_indices!
-using Pioneer: digest_sequence, getFixedMods!, countVarModCombinations
+using Pioneer: digest_sequence, normalize_digest_specificity
+using Pioneer: getFixedMods!, countVarModCombinations
 using Pioneer: FastaEntry, parse_fasta, PeptideSequenceSet
 using Pioneer: buildFragmentIndex!, FragBoundModel, cleanUpLibrary, get_fragment_bounds
 using Pioneer: RazoQuadParams, simmulateQuad, fitRazoQuadModel, MergeBins
@@ -30,11 +31,13 @@ using Pioneer: buildPionLib
 using Pioneer: digest_fasta, combine_shared_peptides
 using Pioneer: add_decoy_sequences, add_entrapment_sequences
 using Pioneer: fillVarModStrings!, fragFilter
-using Pioneer: get_base_pep_id, get_charge
+using Pioneer: get_base_pep_id, get_charge, get_num_enzymatic_termini
+using Pioneer: add_charge
 using Pioneer: make_koina_request, prepare_koina_batch, parse_koina_batch
 using Pioneer: KoinaBatchResult
 using Pioneer: get_proteome, get_sequence, get_structural_mods
 using Pioneer: get_isotopic_mods, get_description, get_id
+using Pioneer: get_start_idx
 using Pioneer: get_entrapment_pair_id
 using Pioneer: get_gene, get_protein, get_organism
 using Pioneer: filter_by_threshold, filter_by_multiple_thresholds

--- a/test/utils/FileOperations/streaming/test_stream_sorted_merge_basic.jl
+++ b/test/utils/FileOperations/streaming/test_stream_sorted_merge_basic.jl
@@ -29,6 +29,44 @@ using Pioneer: PSMFileReference, stream_sorted_merge, stream_sorted_merge_chunke
     @test length(dfm.score) == 6
 end
 
+@testset "mixed-direction merge keeps missing groups last" begin
+    tmp = mktempdir()
+    refs = PSMFileReference[]
+
+    for (i, df) in enumerate((
+        DataFrame(
+            group = Union{Missing,String}[missing, "B"],
+            target = Bool[false, true],
+            id = Int64[4, 2],
+        ),
+        DataFrame(
+            group = Union{Missing,String}["A", missing],
+            target = Bool[true, true],
+            id = Int64[1, 3],
+        ),
+    ))
+        path = joinpath(tmp, "mixed_$i.arrow")
+        Arrow.write(path, df)
+        ref = PSMFileReference(path)
+        sort_file_by_keys!(ref, :group, :target; reverse=[false, true])
+        push!(refs, ref)
+    end
+
+    chunks = stream_sorted_merge_chunked(
+        refs,
+        joinpath(tmp, "mixed_chunks"),
+        :group,
+        :group,
+        :target;
+        reverse=[false, true],
+    )
+    combined = vcat(load_dataframe.(chunks)...)
+
+    @test collect(skipmissing(combined.group)) == ["A", "B"]
+    @test all(ismissing, combined.group[end-1:end])
+    @test combined.target[end-1:end] == [true, false]
+end
+
 @testset "hierarchical merge with many files" begin
     tmp = mktempdir()
     n_files = 20  # triggers multiple stages with max_fanin=4


### PR DESCRIPTION
## Summary

- add explicit digestion specificity modes for spectral-library building: full, semi-N, semi-C, and semi
- expose specificity through validation, example configs, documentation, the GUI form, saved configuration, and library summaries
- carry missed cleavages and enzymatic-termini counts into precursor scoring at both run and global levels
- preserve all peptide start positions through target, decoy, and entrapment generation and export them as `peptide_start_positions`
- include missed cleavages and enzymatic termini in wide precursor output and place protein-inferred precursor rows first

## Why

Semi-enzymatic libraries need digestion and search behavior that is explicit and consistent across library generation, model features, resumable processing, GUI configuration, and exported results. Peptides can also occur more than once within a protein or protein group, so the output must retain every applicable start position rather than only the first match.

## Impact

Library builders can select a precise enzymatic specificity without enabling a non-specific mode. Searches use the generated precursor metadata directly, and output tables report protein positions and enzymatic metadata with clearer names and ordering.

## Validation

- focused Julia regression suite: 228 tests passed, including FASTA digestion, precursor metadata/output, MainSearch scoring and iRT refinement, streaming merge ordering, and an offline synthetic spectral-library build
- `npm run build`: passed
- `git diff --check`: passed
- `cargo test --lib`: not run to completion because the local Cargo 1.83 toolchain cannot parse a transitive dependency requiring stabilized Rust 2024 support