### PR TITLE
fix(snoop): do not delete a fixture the previous target has mapped

### DIFF
--- a/src/build/snoop.jl
+++ b/src/build/snoop.jl
@@ -133,7 +133,29 @@ end
 # holding both layouts. Generated at snoop time rather than checked in, so it cannot drift from the
 # fixtures it is derived from.
 function prepare_mixed_batch_ms_data(raw_dir::String, out_dir::String)
-    rm(out_dir; force = true, recursive = true)
+    # Two snoop targets share this directory: SearchDIA builds it, then
+    # SearchDIA_prosit asks for it again. By then the first target's searches
+    # have memory-mapped the Arrow files inside it, and Windows refuses to
+    # delete a mapped file -- the rm fails with ENOTEMPTY and takes the whole
+    # app build down with it. POSIX unlinks an open file happily, which is why
+    # this only ever failed on Windows.
+    #
+    # The contents are deterministic, so if they are already there, they are
+    # already correct: reuse them rather than deleting and rewriting.
+    expected = sort(filter(f -> endswith(f, ".arrow"), readdir(raw_dir)))
+    if isdir(out_dir)
+        have = Set(readdir(out_dir))
+        if all(in(have), expected) && ("ecoli_multibatch.arrow" in have)
+            return out_dir
+        end
+        # Present but incomplete: a previous build died partway. Rebuilding is
+        # worth attempting, but a mapped leftover must not fail the build.
+        try
+            rm(out_dir; force = true, recursive = true)
+        catch err
+            @warn "could not clear $out_dir; reusing what is there" exception = err
+        end
+    end
     mkpath(out_dir)
     arrows = sort(filter(f -> endswith(f, ".arrow"), readdir(raw_dir)))
     for f in arrows


### PR DESCRIPTION
Blocks the Windows app build on develop. `create_app` fails during the snoop run:

```
SearchDIA_prosit: IOError: rm(".../data/precompile/ecoli_raw_mixed"):
                  directory not empty (ENOTEMPTY)
```

Two snoop targets share that fixture. `SearchDIA` builds it and runs three searches over it, memory-mapping the Arrow files. `SearchDIA_prosit` then calls the same helper, whose first act is to delete and rebuild the directory — and Windows refuses to delete a mapped file. POSIX unlinks an open file happily, which is why this never reproduced locally.

Mine: `SearchDIA_prosit` was added pointing at the existing fixture.

The contents are deterministic, so if the expected files are present they are already correct — reuse them instead of rebuilding. A present-but-incomplete directory (a build that died partway) is still cleared, but a failure to clear now warns rather than taking the build down.

## Verification

Dispatched Build Windows on this branch: **[run 31722723335](https://github.com/nwamsley1/Pioneer.jl/actions/runs/31722723335) — success**, including every step that had never run before:

- Swap in MSVC LightGBM DLL — log confirms it actually replaced a DLL, not silently no-opped
- Download VC++ redistributable
- Build installer bundle (`candle`/`light` + WixBalExtension)
- Upload MSI and installer bundle

Artifacts: `Pioneer-windows-x64-setup` (697 MB) and `Pioneer-windows-x64-msi` (673 MB).

The same build was then verified on a clean machine in Windows Sandbox: all four VC++ runtime DLLs absent before install, present after, and a full search completing — 76,461 precursor rows, 4,626 protein groups. That is the path CI cannot exercise, since the runner already has the runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)