### PR TITLE
fix: declare Altimeter's 40-residue peptide ceiling

### DIFF
--- a/src/Pioneer.jl
+++ b/src/Pioneer.jl
@@ -746,12 +746,24 @@ const MODEL_CONFIGS = Dict{String, @NamedTuple{
     fragmentation_type::Union{Nothing, String},
     peptide_length::ModelPeptideLength,
 }}(
+    # peptide_length probed directly against Koina's
+    # Altimeter_2024_splines_index: a 40-mer is accepted and a 41-mer is
+    # rejected with `ValueError: Peptide too long`; a 1-mer is accepted, so
+    # there is no lower bound to declare.
+    #
+    # Declaring it matters because the failure is otherwise late and
+    # misdiagnosed rather than loud. One over-long peptide fails its whole
+    # 1000-peptide Koina batch; make_koina_http_request treats any "error" in
+    # the response as retryable and burns all 100 attempts on a deterministic
+    # failure; the build then dies blaming the network. With the bound
+    # declared, clamp_digest_length_to_model narrows the digest and warns
+    # before any peptide is predicted.
     "altimeter" => (
         annotation_type = UniSpecFragAnnotation("y1^1"),
         model_type = SplineCoefficientModel("altimeter"),
         instruments = Set([]),
         fragmentation_type = nothing,
-        peptide_length = nothing,
+        peptide_length = (min = 1, max = 40),
     ),
     # Prosit models. All three are instrument-agnostic scalar-intensity models:
     # fixed fragment intensities at one collision energy, no NCE spline.

--- a/test/UnitTests/test_model_limits.jl
+++ b/test/UnitTests/test_model_limits.jl
@@ -1,6 +1,18 @@
 @testset "Model peptide-length limits" begin
-    # A model whose entry declares no range must not alter the user's request.
+    # Altimeter's ceiling is 40, probed against Koina: a 40-mer is accepted and
+    # a 41-mer is rejected outright. The catalog builds at exactly 7-40, so this
+    # request must pass through untouched.
     @test Pioneer.clamp_digest_length_to_model("altimeter", 7, 40) == (7, 40)
+
+    # ...and one residue past it must be narrowed here rather than surviving to
+    # Koina, where a single over-long peptide fails its entire batch and the
+    # retry loop then misreports it as a network fault.
+    @test Pioneer.clamp_digest_length_to_model("altimeter", 7, 41) == (7, 40)
+    @test Pioneer.clamp_digest_length_to_model("altimeter", 7, 50) == (7, 40)
+
+    # No lower bound: a 1-mer is accepted by the model, so a short digest is the
+    # user's business.
+    @test Pioneer.clamp_digest_length_to_model("altimeter", 5, 30) == (5, 30)
 
     # An unrecognised name is a pass-through, not an error: prediction_model is
     # validated where it is read, and this function must not become a second


### PR DESCRIPTION
`clamp_digest_length_to_model` exists to narrow a digest to what the prediction model accepts, and warn, before any peptide reaches Koina. It could not fire for Altimeter, whose `MODEL_CONFIGS` entry declared `peptide_length = nothing` — "unconstrained" — when the model in fact caps at 40.

Probed directly against Koina's `Altimeter_2024_splines_index`:

| length | result |
|---|---|
| 1 | accepted — no lower bound to declare |
| 40 | accepted |
| 41 | **rejected**, `ValueError: Peptide too long` |

Undeclared, the failure was late and misdiagnosed rather than loud:

1. Fragment prediction batches up to 1000 peptides per request, so one over-long peptide fails the **whole batch**.
2. `make_koina_http_request` treats any `"error"` key as retryable, so it spends all **100 attempts at 1 s intervals** on a failure that is deterministic.
3. Nothing catches `KoinaRequestError`, so the build dies reporting *"This may indicate network issues, API rate limiting, or service unavailability. Check your internet connection."* The real cause appears only at `@debug_l2`.

All of that lands *after* digestion, decoy generation, Chronologer RT prediction, and every fragment batch that already succeeded — hours into a human-scale build, pointing at the network.

With the bound declared, a `max_length` of 41+ is narrowed with a `@user_warn` naming the model and both values, before any peptide is predicted.

No existing build config in the repo exceeds 40, so no current behaviour changes. Chronologer accepts ≥52 and is never the binding constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)