### PR TITLE
build(deps): consolidate the four open GitHub Actions bumps

### DIFF
--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -97,7 +97,7 @@ jobs:
           version: '1.12.6'  # must satisfy Project.toml's julia = "1.12.5" compat
 
       - name: Cache Julia packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.julia/registries

--- a/.github/workflows/build_app_linux.yml
+++ b/.github/workflows/build_app_linux.yml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           ref: ${{ inputs.checkout_ref || github.sha }}

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -112,7 +112,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Cache Julia packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.julia/registries

--- a/.github/workflows/build_app_macos.yml
+++ b/.github/workflows/build_app_macos.yml
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           ref: ${{ inputs.checkout_ref || github.sha }}

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -98,7 +98,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Cache Julia packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             C:\Users\runneradmin\.julia\registries

--- a/.github/workflows/build_app_windows.yml
+++ b/.github/workflows/build_app_windows.yml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           ref: ${{ inputs.checkout_ref || github.sha }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
           version: '1.12.6'  # match Project.toml's `julia = "1.12.5"` compat lower bound
 
       - name: Cache docs packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.julia/registries

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           ref: ${{ inputs.source_branch }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -978,7 +978,7 @@ jobs:
 
       - name: Comment regression report on pull request
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           CLUSTER_RUN_DIR: ${{ env.CLUSTER_RUN_DIR }}
           CLUSTER_RUN_DIR_MOUNT: ${{ env.CLUSTER_RUN_DIR_MOUNT }}
@@ -1021,7 +1021,7 @@ jobs:
 
       - name: Update release notes with regression report
         if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/'))) && env.REPORT_PAGES_SUBDIR != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           REPORT_PAGES_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
           REPORT_PAGES_SUBDIR: ${{ env.REPORT_PAGES_SUBDIR }}

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -84,7 +84,7 @@ jobs:
       GITHUB_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || (startsWith(github.ref, 'refs/tags/') && github.ref_name || github.sha) }}
       GITHUB_REF_NAME: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || github.ref_name }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
       - name: Verify tag matches Project.toml version
@@ -74,7 +74,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout just the publish-release action
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           sparse-checkout: |
@@ -99,7 +99,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
         arch:    [x64]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
         uses: julia-actions/julia-processcoverage@v1
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
           arch:    ${{ matrix.arch }}
 
       - name: Cache Julia packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.julia/registries

--- a/.github/workflows/validate_installers.yml
+++ b/.github/workflows/validate_installers.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Cache RAW fixture
         id: raw_fixture_cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ runner.temp }}/ci-raw-fixture
           key: raw-fixture-${{ runner.os }}-${{ env.RAW_FIXTURE_RELEASE }}
@@ -235,7 +235,7 @@ jobs:
 
       - name: Cache RAW fixture
         id: raw_fixture_cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ runner.temp }}\ci-raw-fixture
           key: raw-fixture-${{ runner.os }}-${{ env.RAW_FIXTURE_RELEASE }}
@@ -357,7 +357,7 @@ jobs:
 
       - name: Cache RAW fixture
         id: raw_fixture_cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ runner.temp }}/ci-raw-fixture
           key: raw-fixture-${{ runner.os }}-${{ env.RAW_FIXTURE_RELEASE }}
@@ -463,7 +463,7 @@ jobs:
 
       - name: Cache RAW fixture
         id: raw_fixture_cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ runner.temp }}/ci-raw-fixture
           key: raw-fixture-${{ runner.os }}-${{ env.RAW_FIXTURE_RELEASE }}

--- a/.github/workflows/validate_installers.yml
+++ b/.github/workflows/validate_installers.yml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           ref: ${{ inputs.checkout_ref || github.sha }}
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           ref: ${{ inputs.checkout_ref || github.sha }}
@@ -196,7 +196,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           ref: ${{ inputs.checkout_ref || github.sha }}
@@ -338,7 +338,7 @@ jobs:
     runs-on: macos-15-intel
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           ref: ${{ inputs.checkout_ref || github.sha }}
@@ -444,7 +444,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           ref: ${{ inputs.checkout_ref || github.sha }}


### PR DESCRIPTION
Replaces #436, #406, #390 and #421 with one PR and one CI run, kept as **one commit per bump** so a single offender can be dropped without losing the rest. None of these are security fixes — the only open Dependabot alert is a medium `rust/glib` unsoundness in `gui/src-tauri/Cargo.lock`, untouched by any of them; the five npm alerts were closed by #463.

| Commit | Bump | Usages |
|---|---|---|
| `124cefd4` | `actions/cache` 5 → 6 | 9 |
| `344eb577` | `codecov/codecov-action` 6 → 7 | 1 |
| `c4b16052` | `actions/github-script` 7 → 9 | 2 |
| `f449885b` | `actions/checkout` 6 → 7 | 15 |

## `regression.yml` is deliberately left on `checkout@v5`

While checking whether the version drift in that file was intentional, I found the LSF regression workflow has not completed a run since March:

```
v0.7.2  failure  720h0m2s   <- exactly GitHub's 30-day maximum job timeout
v0.7.3  failure  720h0m2s
v0.7.4  failure  720h0m2s
v0.8.0  waiting  12h49m     <- currently heading the same way
```

Each run sits waiting for a `[self-hosted, Linux, pioneer-regression]` runner that never picks it up, then times out marked failed. It triggers only on `v*.*.*` tags, so it never runs on a PR — meaning any bump to it would get **zero CI signal here** and would only be exercised at the next release tag. `regression_slurm.yml` is the workflow actually doing this job today: it completes in minutes and already runs on pushes and pull requests.

`github-script` is bumped there anyway (both usages are in that file) purely to match `regression_slurm.yml`, but `checkout` is not — there is no point churning a dormant file's widest-blast-radius action.

**Worth deciding separately:** whether the LSF workflow should be deleted, or its runner label fixed. As it stands it puts a red X on every release tag and has done since v0.7.2.

## Sequencing

Both `main` and `develop` are currently red on the var-mods fixture break (#464). Merging dependency bumps onto a red baseline makes a failure hard to attribute, so I would land #464 first, confirm green, then take this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)