### PR TITLE
Improve semi-tryptic protein scoring coverage features

### DIFF
--- a/src/Routines/BuildSpecLib.jl
+++ b/src/Routines/BuildSpecLib.jl
@@ -371,6 +371,9 @@ function BuildSpecLib(params_path::String)
                 precursors_table[!, :irt] = Float32.(precursors_table[!, :irt])
                 precursors_table[!, :start_idx] =
                     [UInt32.(collect(starts)) for starts in precursors_table[!, :start_idx]]
+                precursors_table[!, :num_variable_modifications] = UInt8.(
+                    precursors_table.num_variable_modifications
+                )
 
                 # Save processed precursor table
                 @debug_l1 "  Before add_pair_indices!: $(nrow(precursors_table)) precursors"

--- a/src/Routines/BuildSpecLib/chronologer/chronologer_prep.jl
+++ b/src/Routines/BuildSpecLib/chronologer/chronologer_prep.jl
@@ -333,6 +333,7 @@ function add_mods(
                     get_start_idx(fasta_peptide),
                     var_mod,
                     get_isotopic_mods(fasta_peptide),
+                    UInt8(length(var_mod) - length(fixed_mods_vector)),
                     get_charge(fasta_peptide),
                     get_num_enzymatic_termini(fasta_peptide),
                     get_base_target_id(fasta_peptide), # preserve base_target_id
@@ -387,6 +388,7 @@ function add_charge(
                     get_start_idx(fasta_peptide),
                     get_structural_mods(fasta_peptide),
                     get_isotopic_mods(fasta_peptide),
+                    get_num_variable_modifications(fasta_peptide),
                     charge,
                     get_num_enzymatic_termini(fasta_peptide),
                     get_base_target_id(fasta_peptide), # preserve base_target_id
@@ -532,6 +534,7 @@ function build_fasta_df(fasta_peptides::Vector{FastaEntry};
     _sequence = Vector{String}(undef, prec_alloc_size)
     _structural_mods = Vector{Union{String, Missing}}(undef, prec_alloc_size)
     _isotopic_mods = Vector{Union{String, Missing}}(undef, prec_alloc_size)
+    _num_variable_modifications = Vector{UInt8}(undef, prec_alloc_size)
     _start_idx = Vector{Vector{UInt32}}(undef, prec_alloc_size)
     _precursor_charge = Vector{UInt8}(undef, prec_alloc_size)
     _num_enzymatic_termini = Vector{UInt8}(undef, prec_alloc_size)
@@ -559,6 +562,8 @@ function build_fasta_df(fasta_peptides::Vector{FastaEntry};
         _start_idx[n] = get_start_idx(peptide)
         _structural_mods[n] = getModString(get_structural_mods(peptide))
         _isotopic_mods[n] = getModString(get_isotopic_mods(peptide))
+        _num_variable_modifications[n] =
+            get_num_variable_modifications(peptide)
         _precursor_charge[n] = get_charge(peptide)
         _num_enzymatic_termini[n] = get_num_enzymatic_termini(peptide)
         _collision_energy[n] = NCE
@@ -577,6 +582,8 @@ function build_fasta_df(fasta_peptides::Vector{FastaEntry};
          start_idx = _start_idx[1:n],
          mods = _structural_mods[1:n],
          isotopic_mods = _isotopic_mods[1:n],
+         num_variable_modifications =
+            _num_variable_modifications[1:n],
          precursor_charge = _precursor_charge[1:n],
          num_enzymatic_termini = _num_enzymatic_termini[1:n],
          collision_energy = _collision_energy[1:n],

--- a/src/Routines/BuildSpecLib/fasta/fasta_utils.jl
+++ b/src/Routines/BuildSpecLib/fasta/fasta_utils.jl
@@ -219,6 +219,7 @@ function add_entrapment_sequences(
                         get_start_idx(target_entry),
                         adjusted_structural_mods, #structural_mods - now properly adjusted
                         adjusted_isotopic_mods,   #isotopic_mods - now properly adjusted
+                        get_num_variable_modifications(target_entry),
                         get_charge(target_entry),
                         get_num_enzymatic_termini(target_entry),
                         get_base_target_id(target_entry), # inherit base_target_id for tracking
@@ -397,6 +398,7 @@ function add_entrapment_sequences_grouped(
                     get_start_idx(target_entry),
                     adjusted_structural_mods,
                     adjusted_isotopic_mods,
+                    get_num_variable_modifications(target_entry),
                     get_charge(target_entry),
                     get_num_enzymatic_termini(target_entry),
                     get_base_target_id(target_entry),
@@ -802,6 +804,7 @@ function add_decoy_sequences(
                 get_start_idx(target_entry),
                 adjusted_structural_mods,
                 adjusted_isotopic_mods,
+                get_num_variable_modifications(target_entry),
                 get_charge(target_entry),
                 get_num_enzymatic_termini(target_entry),
                 get_base_target_id(target_entry), # inherit base_target_id for tracking
@@ -961,6 +964,7 @@ function add_decoy_sequences_grouped(
                 get_start_idx(target_entry),
                 adjusted_structural_mods,
                 adjusted_isotopic_mods,
+                get_num_variable_modifications(target_entry),
                 get_charge(target_entry),
                 get_num_enzymatic_termini(target_entry),
                 get_base_target_id(target_entry),
@@ -1058,6 +1062,7 @@ function combine_shared_peptides(peptides::Vector{FastaEntry})
                                                         start_idxs,
                                                         get_structural_mods(fasta_entry),
                                                         get_isotopic_mods(fasta_entry),
+                                                        get_num_variable_modifications(fasta_entry),
                                                         get_charge(fasta_entry),
                                                         max(
                                                             get_num_enzymatic_termini(peptide),
@@ -1109,6 +1114,7 @@ function assign_base_pep_ids!(fasta_entries::Vector{FastaEntry})
             get_start_idx(entry),
             get_structural_mods(entry),
             get_isotopic_mods(entry),
+            get_num_variable_modifications(entry),
             get_charge(entry),
             get_num_enzymatic_termini(entry),
             get_base_target_id(entry), # preserve base_target_id
@@ -1137,6 +1143,7 @@ function assign_base_target_ids!(fasta_entries::Vector{FastaEntry})
             get_start_idx(entry),
             get_structural_mods(entry),
             get_isotopic_mods(entry),
+            get_num_variable_modifications(entry),
             get_charge(entry),
             get_num_enzymatic_termini(entry),
             UInt32(i),   # assign grouped base_target_id

--- a/src/Routines/SearchDIA/ParseInputs/loadSpectralLibrary.jl
+++ b/src/Routines/SearchDIA/ParseInputs/loadSpectralLibrary.jl
@@ -137,24 +137,26 @@ function loadSpectralLibrary(SPEC_LIB_DIR::String,
     partitioned_index = deserialize_from_jls(joinpath(SPEC_LIB_DIR, "partitioned_fragment_index.jls"))
     presearch_partitioned_index = deserialize_from_jls(joinpath(SPEC_LIB_DIR, "presearch_partitioned_fragment_index.jls"))
 
-    # Load the BuildSpecLib config (if present) to derive the output-column
-    # exclusion policy; falls back to an empty policy when absent.
+    # Load the BuildSpecLib config (if present) for output policy and for
+    # reconstructing variable-modification counts in older precursor tables.
     build_config_path = joinpath(SPEC_LIB_DIR, "config.json")
-    output_schema_policy = if isfile(build_config_path)
+    build_config = if isfile(build_config_path)
         try
-            OutputSchemaPolicy(JSON.parsefile(build_config_path, dicttype=Dict{String,Any}))
+            JSON.parsefile(build_config_path, dicttype=Dict{String,Any})
         catch
-            OutputSchemaPolicy()
+            nothing
         end
     else
-        OutputSchemaPolicy()
+        nothing
     end
+    output_schema_policy = OutputSchemaPolicy(build_config)
+    variable_mod_names = _configured_variable_mod_names(build_config)
 
     if typeof(library_fragment_lookup_table) == Pioneer.StandardFragmentLookup{Float32}
         return FragmentIndexLibrary(
             presearch_partitioned_index,
             partitioned_index,
-            SetPrecursors(precursors),
+            SetPrecursors(precursors; variable_mod_names = variable_mod_names),
             SetProteins(proteins),
             spec_lib["f_det"],
             output_schema_policy
@@ -163,7 +165,7 @@ function loadSpectralLibrary(SPEC_LIB_DIR::String,
         return SplineFragmentIndexLibrary(
             presearch_partitioned_index,
             partitioned_index,
-            SetPrecursors(precursors),
+            SetPrecursors(precursors; variable_mod_names = variable_mod_names),
             SetProteins(proteins),
             spec_lib["f_det"],
             output_schema_policy

--- a/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MainSearch/features.jl
@@ -6,9 +6,6 @@
 # work, but one parallel_foreach! task spawn / join instead of two and one
 # cache-warm read of `precursor_idx` / `scan_idx` per row instead of two.
 
-@inline _count_mox(seq::AbstractString) = UInt8(count("Unimod:35", seq))
-@inline _count_mox(::Missing)            = zero(UInt8)
-
 """
     add_psm_features!(psms, search_context, spectra, ms_file_idx)
 
@@ -19,7 +16,8 @@ needed by the per-file LightGBM. Reads the deconv-emit columns
 - `:decoy`, `:target`, `:cv_fold`, `:charge`, `:charge2`
 - `:rt`, `:err_norm`
 - `:irt_obs`, `:irt_pred`, `:irt_error`
-- `:missed_cleavage`, `:num_enzymatic_termini`, `:Mox`, `:sequence_length`, `:prec_mz`
+- `:missed_cleavage`, `:num_enzymatic_termini`, `:num_variable_modifications`
+- `:Mox`, `:sequence_length`, `:prec_mz`
 - `:spectrum_peak_count`
 
 Mox is computed lazily once per precursor via a length-`n_library` cache;
@@ -51,6 +49,7 @@ function _add_psm_features!(psms::DataFrame,
     structural_mods  = getStructuralMods(precursors_lib)
     prec_missed_clv  = getMissedCleavages(precursors_lib)
     prec_enzymatic_termini = getNumEnzymaticTermini(precursors_lib)
+    prec_num_var_mods = getNumVariableModifications(precursors_lib)
     scan_rts         = getRetentionTimes(spectra)
     masses           = getMzArrays(spectra)
 
@@ -74,6 +73,7 @@ function _add_psm_features!(psms::DataFrame,
     irt_error           = zeros(Float32, N)
     missed_cleavage     = zeros(UInt8,   N)
     num_enzymatic_termini = zeros(UInt8, N)
+    num_variable_modifications = zeros(UInt8, N)
     Mox                 = zeros(UInt8,   N)
     spectrum_peak_count = zeros(Float16, N)
     sequence_length     = zeros(UInt8,   N)
@@ -117,6 +117,11 @@ function _add_psm_features!(psms::DataFrame,
                 _mox_computed[prec_idx] = true
             end
             Mox[i] = _mox_vals[prec_idx]
+            num_variable_modifications[i] = _num_variable_modifications_at(
+                prec_num_var_mods,
+                structural_mods,
+                prec_idx
+            )
         end
     end
 
@@ -132,6 +137,7 @@ function _add_psm_features!(psms::DataFrame,
     psms[!, :irt_error]           = irt_error
     psms[!, :missed_cleavage]     = missed_cleavage
     psms[!, :num_enzymatic_termini] = num_enzymatic_termini
+    psms[!, :num_variable_modifications] = num_variable_modifications
     psms[!, :Mox]                 = Mox
     psms[!, :spectrum_peak_count] = spectrum_peak_count
     psms[!, :sequence_length]     = sequence_length

--- a/src/Routines/SearchDIA/SearchMethods/ProteinInferenceSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ProteinInferenceSearch/utils.jl
@@ -74,7 +74,8 @@ function count_protein_peptide_opportunities(
     sequences::AbstractVector{<:AbstractString},
     is_decoys::AbstractVector{Bool},
     entrap_ids::AbstractVector{UInt8},
-    final_groups::Set{ProteinKey}
+    final_groups::Set{ProteinKey};
+    common_precursor_mask::Union{Nothing, AbstractVector{Bool}} = nothing
 )
     n_rows = length(accession_numbers)
     length(sequences) == n_rows ||
@@ -83,6 +84,11 @@ function count_protein_peptide_opportunities(
         throw(ArgumentError("is_decoys must match accession_numbers length"))
     length(entrap_ids) == n_rows ||
         throw(ArgumentError("entrap_ids must match accession_numbers length"))
+    common_precursor_mask === nothing ||
+        length(common_precursor_mask) == n_rows ||
+        throw(ArgumentError(
+            "common_precursor_mask must match accession_numbers length"
+        ))
 
     accession_to_groups =
         Dict{Tuple{String, Bool, UInt8}, Vector{ProteinKey}}()
@@ -99,6 +105,8 @@ function count_protein_peptide_opportunities(
     group_cache =
         Dict{Tuple{String, Bool, UInt8}, Vector{ProteinKey}}()
     peptide_to_groups =
+        Dict{Tuple{String, Bool, UInt8}, Vector{ProteinKey}}()
+    common_peptide_to_groups =
         Dict{Tuple{String, Bool, UInt8}, Vector{ProteinKey}}()
 
     @inbounds for i in eachindex(accession_numbers, sequences, is_decoys, entrap_ids)
@@ -128,21 +136,42 @@ function count_protein_peptide_opportunities(
             peptide_to_groups[peptide_key] =
                 sort!(unique!(vcat(peptide_to_groups[peptide_key], groups)))
         end
+        is_common = common_precursor_mask === nothing || common_precursor_mask[i]
+        if is_common
+            if !haskey(common_peptide_to_groups, peptide_key)
+                common_peptide_to_groups[peptide_key] = groups
+            elseif common_peptide_to_groups[peptide_key] != groups
+                common_peptide_to_groups[peptide_key] = sort!(unique!(vcat(
+                    common_peptide_to_groups[peptide_key],
+                    groups
+                )))
+            end
+        end
     end
 
     unique_counts = Dict(group => 0 for group in final_groups)
     shared_counts = Dict(group => 0 for group in final_groups)
-    for groups in values(peptide_to_groups)
+    common_unique_counts = Dict(group => 0 for group in final_groups)
+    for (peptide_key, groups) in pairs(peptide_to_groups)
         counts = length(groups) == 1 ? unique_counts : shared_counts
         for group in groups
             counts[group] += 1
+        end
+        if length(groups) == 1
+            common_groups = get(
+                common_peptide_to_groups,
+                peptide_key,
+                ProteinKey[]
+            )
+            groups[1] in common_groups && (common_unique_counts[groups[1]] += 1)
         end
     end
 
     opportunities = Dict(
         group => ProteinPeptideOpportunityCounts(
             unique_counts[group],
-            shared_counts[group]
+            shared_counts[group],
+            common_unique_counts[group]
         )
         for group in final_groups
     )
@@ -153,12 +182,29 @@ function count_protein_peptide_opportunities(
     precursors::LibraryPrecursors,
     final_groups::Set{ProteinKey}
 )
+    missed_cleavages = getMissedCleavages(precursors)
+    num_enzymatic_termini = getNumEnzymaticTermini(precursors)
+    num_variable_modifications = getNumVariableModifications(precursors)
+    structural_mods = getStructuralMods(precursors)
+    common_precursor_mask = BitVector(undef, length(precursors))
+    @inbounds for precursor_idx in eachindex(common_precursor_mask)
+        common_precursor_mask[precursor_idx] = _is_common_peptide(
+            missed_cleavages[precursor_idx],
+            num_enzymatic_termini[precursor_idx],
+            _num_variable_modifications_at(
+                num_variable_modifications,
+                structural_mods,
+                precursor_idx
+            )
+        )
+    end
     return count_protein_peptide_opportunities(
         getAccessionNumbers(precursors),
         getSequence(precursors),
         getIsDecoy(precursors),
         getEntrapmentGroupId(precursors),
-        final_groups
+        final_groups;
+        common_precursor_mask = common_precursor_mask
     )
 end
 
@@ -179,6 +225,7 @@ function add_peptide_metadata(precursors::LibraryPrecursors)
         all_base_pep_ids = getBasePepId(precursors)::AbstractVector{UInt32}
         all_structural_mods = getStructuralMods(precursors)::AbstractVector{Union{Missing, String}}
         all_isotopic_mods = getIsotopicMods(precursors)::AbstractVector{Union{Missing, String}}
+        all_num_variable_modifications = getNumVariableModifications(precursors)
 
         precursor_idx = df.precursor_idx::AbstractVector{UInt32}
         n_rows = length(precursor_idx)
@@ -230,6 +277,16 @@ function add_peptide_metadata(precursors::LibraryPrecursors)
             isotopic_mods[i] = coalesce(all_isotopic_mods[precursor_idx[i]], "")
         end
         df.isotopic_mods = isotopic_mods
+
+        num_variable_modifications = Vector{UInt8}(undef, n_rows)
+        for i in 1:n_rows
+            num_variable_modifications[i] = _num_variable_modifications_at(
+                all_num_variable_modifications,
+                all_structural_mods,
+                precursor_idx[i]
+            )
+        end
+        df.num_variable_modifications = num_variable_modifications
 
         return df
     end

--- a/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/feature_selection.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/feature_selection.jl
@@ -83,6 +83,7 @@ function run_level_protein_feature_names()
         :shared_peptide_coverage_logit,
         :shared_coverage_log_ratio,
         :peptide_coverage_logit,
+        :all_peptide_coverage_logit,
         :any_common_peps,
         :coverage_log_ratio,
         :precursor_consensus_prefix_shape,

--- a/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/global_protein_scoring.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/global_protein_scoring.jl
@@ -32,6 +32,8 @@ const GLOBAL_PROTEIN_SCORE_FEATURES = Symbol[
     :max_n_peptides_observed,
     :global_peptide_coverage,
     :max_peptide_coverage,
+    :global_all_peptide_coverage,
+    :max_all_peptide_coverage,
     :n_passing_runs,
     :n_score_gt_0_5,
     :n_score_gt_0_9,
@@ -55,6 +57,8 @@ const GLOBAL_PROTEIN_MONOTONE_INCREASING_FEATURES = (
     :max_n_peptides_observed,
     :global_peptide_coverage,
     :max_peptide_coverage,
+    :global_all_peptide_coverage,
+    :max_all_peptide_coverage,
     :n_passing_runs,
     :n_score_gt_0_5,
     :n_score_gt_0_9,
@@ -90,9 +94,33 @@ end
 struct GlobalProteinInputs
     run_scores::Dict{GlobalProteinKey, Vector{GlobalProteinRunScore}}
     observed_peptides::Dict{GlobalProteinKey, Set{String}}
+    observed_common_peptides::Dict{GlobalProteinKey, Set{String}}
     max_n_peptides::Dict{GlobalProteinKey, Int}
+    max_n_common_peptides::Dict{GlobalProteinKey, Int}
     n_possible_unique_peptides::Dict{GlobalProteinKey, Int}
+    n_possible_common_unique_peptides::Dict{GlobalProteinKey, Int}
     folds::Dict{GlobalProteinKey, UInt8}
+end
+
+# Compatibility constructor for callers that predate the common/all split.
+# Their input is necessarily interpreted as all-common.
+function GlobalProteinInputs(
+    run_scores::Dict{GlobalProteinKey, Vector{GlobalProteinRunScore}},
+    observed_peptides::Dict{GlobalProteinKey, Set{String}},
+    max_n_peptides::Dict{GlobalProteinKey, Int},
+    n_possible_unique_peptides::Dict{GlobalProteinKey, Int},
+    folds::Dict{GlobalProteinKey, UInt8}
+)
+    return GlobalProteinInputs(
+        run_scores,
+        observed_peptides,
+        copy(observed_peptides),
+        max_n_peptides,
+        copy(max_n_peptides),
+        n_possible_unique_peptides,
+        copy(n_possible_unique_peptides),
+        folds
+    )
 end
 
 function _collect_global_protein_inputs(
@@ -105,13 +133,19 @@ function _collect_global_protein_inputs(
 )
     run_scores = Dict{GlobalProteinKey, Vector{GlobalProteinRunScore}}()
     observed_peptides = Dict{GlobalProteinKey, Set{String}}()
+    observed_common_peptides = Dict{GlobalProteinKey, Set{String}}()
     max_n_peptides = Dict{GlobalProteinKey, Int}()
+    max_n_common_peptides = Dict{GlobalProteinKey, Int}()
     n_possible_unique_peptides = Dict{GlobalProteinKey, Int}()
+    n_possible_common_unique_peptides = Dict{GlobalProteinKey, Int}()
     folds = Dict{GlobalProteinKey, UInt8}()
     sizehint!(run_scores, n_proteins)
     sizehint!(observed_peptides, n_proteins)
+    sizehint!(observed_common_peptides, n_proteins)
     sizehint!(max_n_peptides, n_proteins)
+    sizehint!(max_n_common_peptides, n_proteins)
     sizehint!(n_possible_unique_peptides, n_proteins)
+    sizehint!(n_possible_common_unique_peptides, n_proteins)
     sizehint!(folds, n_proteins)
 
     for ref in pg_refs
@@ -138,12 +172,32 @@ function _collect_global_protein_inputs(
                 Set{String}()
             end
             for peptide in split(table.peptide_list[row], ';')
-                push!(protein_peptides, String(peptide))
+                isempty(peptide) || push!(protein_peptides, String(peptide))
+            end
+
+            protein_common_peptides = get!(observed_common_peptides, key) do
+                Set{String}()
+            end
+            common_peptide_list = hasproperty(table, :common_peptide_list) ?
+                table.common_peptide_list[row] : table.peptide_list[row]
+            for peptide in split(common_peptide_list, ';')
+                isempty(peptide) ||
+                    push!(protein_common_peptides, String(peptide))
             end
 
             n_peptides = Int(table.n_peptides[row])
+            n_common_peptides = hasproperty(table, :n_common_peptides) ?
+                Int(table.n_common_peptides[row]) : n_peptides
             max_n_peptides[key] = max(get(max_n_peptides, key, 0), n_peptides)
+            max_n_common_peptides[key] = max(
+                get(max_n_common_peptides, key, 0),
+                n_common_peptides
+            )
             n_possible_unique_peptides[key] =
+                Int(table.n_possible_unique_peptides[row])
+            n_possible_common_unique_peptides[key] =
+                hasproperty(table, :n_possible_common_unique_peptides) ?
+                Int(table.n_possible_common_unique_peptides[row]) :
                 Int(table.n_possible_unique_peptides[row])
             folds[key] = protein_to_cv_fold[protein_name].cv_fold
         end
@@ -154,8 +208,11 @@ function _collect_global_protein_inputs(
     return GlobalProteinInputs(
         run_scores,
         observed_peptides,
+        observed_common_peptides,
         max_n_peptides,
+        max_n_common_peptides,
         n_possible_unique_peptides,
+        n_possible_common_unique_peptides,
         folds,
     )
 end
@@ -188,9 +245,14 @@ function _build_global_protein_feature_table(
         top2 = n_observed >= 2 ? sorted_scores[2] : 0.0f0
         top3 = n_observed >= 3 ? sorted_scores[3] : 0.0f0
         n_unique_peptides = length(inputs.observed_peptides[key])
+        n_common_unique_peptides =
+            length(inputs.observed_common_peptides[key])
         max_n_peptides = inputs.max_n_peptides[key]
+        max_n_common_peptides = inputs.max_n_common_peptides[key]
         n_possible_unique_peptides =
             inputs.n_possible_unique_peptides[key]
+        n_possible_common_unique_peptides =
+            inputs.n_possible_common_unique_peptides[key]
 
         feature_columns[:empirical_global_score][row] =
             _logodds_from_sorted(sorted_scores, top_run_count)
@@ -213,9 +275,21 @@ function _build_global_protein_feature_table(
         feature_columns[:n_unique_peptides_observed][row] = Float32(n_unique_peptides)
         feature_columns[:max_n_peptides_observed][row] = Float32(max_n_peptides)
         feature_columns[:global_peptide_coverage][row] =
-            Float32(n_unique_peptides) / Float32(n_possible_unique_peptides)
+            n_possible_common_unique_peptides > 0 ?
+            Float32(n_common_unique_peptides) /
+            Float32(n_possible_common_unique_peptides) : 0.0f0
         feature_columns[:max_peptide_coverage][row] =
-            Float32(max_n_peptides) / Float32(n_possible_unique_peptides)
+            n_possible_common_unique_peptides > 0 ?
+            Float32(max_n_common_peptides) /
+            Float32(n_possible_common_unique_peptides) : 0.0f0
+        feature_columns[:global_all_peptide_coverage][row] =
+            n_possible_unique_peptides > 0 ?
+            Float32(n_unique_peptides) / Float32(n_possible_unique_peptides) :
+            0.0f0
+        feature_columns[:max_all_peptide_coverage][row] =
+            n_possible_unique_peptides > 0 ?
+            Float32(max_n_peptides) / Float32(n_possible_unique_peptides) :
+            0.0f0
         feature_columns[:n_score_gt_0_5][row] = Float32(count(>(0.5f0), scores))
         feature_columns[:n_score_gt_0_9][row] = Float32(count(>(0.9f0), scores))
         feature_columns[:n_score_gt_0_99][row] = Float32(count(>(0.99f0), scores))

--- a/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/model_fit.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/model_fit.jl
@@ -118,6 +118,7 @@ const PROTEIN_MONOTONE_INCREASING_FEATURES = (
     :shared_peptide_coverage_logit,
     :shared_coverage_log_ratio,
     :peptide_coverage_logit,
+    :all_peptide_coverage_logit,
     :any_common_peps,
     :coverage_log_ratio,
     :precursor_consensus_prefix_shape,

--- a/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/protein_inference_pipeline.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/protein_inference_pipeline.jl
@@ -1444,10 +1444,12 @@ function group_psms_by_protein(
             target = Bool[],
             entrap_id = UInt8[],
             n_peptides = Int64[],
+            n_common_peptides = Int64[],
             n_non_mbr_peptides = Int64[],
             single_non_mbr_peptide = Bool[],
             single_non_mbr_prefix_shape = Float32[],
             peptide_list = String[],
+            common_peptide_list = String[],
             pg_score = Float32[],
             any_common_peps = Bool[],
             top_pep_peak_area = Float32[],
@@ -1465,10 +1467,12 @@ function group_psms_by_protein(
             target = Bool[],
             entrap_id = UInt8[],
             n_peptides = Int64[],
+            n_common_peptides = Int64[],
             n_non_mbr_peptides = Int64[],
             single_non_mbr_peptide = Bool[],
             single_non_mbr_prefix_shape = Float32[],
             peptide_list = String[],
+            common_peptide_list = String[],
             pg_score = Float32[],
             any_common_peps = Bool[],
             top_pep_peak_area = Float32[],
@@ -1517,19 +1521,30 @@ function group_psms_by_protein(
             precursor_consensus_prefix_shape = prefix_features.prefix_shape
         end
 
-        fully_enzymatic = hasproperty(gdf, :num_enzymatic_termini) ?
-            (gdf.num_enzymatic_termini .== 2) :
-            trues(nrow(gdf))
-        has_common = any(
-            quant_mask .&
-            (gdf.missed_cleavage .== 0) .&
-            fully_enzymatic .&
-            (gdf.Mox .== 0)
-        )
+        common_mask = BitVector(undef, nrow(gdf))
+        has_enzymatic_termini = hasproperty(gdf, :num_enzymatic_termini)
+        has_variable_modifications =
+            hasproperty(gdf, :num_variable_modifications)
+        @inbounds for row in eachindex(common_mask)
+            num_enzymatic_termini = has_enzymatic_termini ?
+                Int(gdf.num_enzymatic_termini[row]) : 2
+            # Legacy intermediate PSMs only recorded M oxidation. Preserve
+            # that historical fallback silently when exact metadata is absent.
+            num_variable_modifications = has_variable_modifications ?
+                Int(gdf.num_variable_modifications[row]) : Int(gdf.Mox[row])
+            common_mask[row] = quant_mask[row] && _is_common_peptide(
+                Int(gdf.missed_cleavage[row]),
+                num_enzymatic_termini,
+                num_variable_modifications
+            )
+        end
+        common_peptides = sort!(unique!(String.(gdf.sequence[common_mask])))
+        n_common_peptides = length(common_peptides)
 
         DataFrame(
             species = species,
             n_peptides = n_peptides,
+            n_common_peptides = n_common_peptides,
             n_non_mbr_peptides = mbr_summary.non_mbr_peptides,
             single_non_mbr_peptide = mbr_summary.non_mbr_peptides == 1,
             single_non_mbr_prefix_shape =
@@ -1537,8 +1552,9 @@ function group_psms_by_protein(
                 precursor_consensus_prefix_shape :
                 0.0f0,
             peptide_list = join(rollup.peptide_list, ";"),
+            common_peptide_list = join(common_peptides, ";"),
             pg_score = pg_score,
-            any_common_peps = has_common,
+            any_common_peps = n_common_peptides > 0,
             top_pep_peak_area = top_pep_peak_area,
             precursor_consensus_prefix_shape = precursor_consensus_prefix_shape,
             mbr_recovered_peptides = mbr_summary.recovered_peptides,
@@ -1746,10 +1762,9 @@ end
 """
     add_protein_features(protein_peptide_opportunities)
 
-Add unique and shared peptide coverage features using their corresponding
-experiment-wide theoretical opportunity denominators. The shared features
-include a smoothed logit and its smoothed detection-rate ratio to unique
-peptide coverage.
+Add common-only and all-peptide unique coverage features using their
+corresponding experiment-wide theoretical opportunity denominators. Shared
+coverage and its detection-rate ratio remain all-peptide features.
 """
 function add_protein_features(
     protein_peptide_opportunities::Dict{
@@ -1762,12 +1777,16 @@ function add_protein_features(
     op = function(df)
         n_rows = nrow(df)
         n_possible_unique = Vector{Int64}(undef, n_rows)
+        n_possible_common_unique = Vector{Int64}(undef, n_rows)
         n_possible_shared = Vector{Int64}(undef, n_rows)
         peptide_coverage = Vector{Float32}(undef, n_rows)
         peptide_coverage_logit = Vector{Float32}(undef, n_rows)
+        all_peptide_coverage = Vector{Float32}(undef, n_rows)
+        all_peptide_coverage_logit = Vector{Float32}(undef, n_rows)
         shared_peptide_coverage_logit = Vector{Float32}(undef, n_rows)
         shared_coverage_log_ratios = Vector{Float32}(undef, n_rows)
         has_ambiguous_peptide_count = hasproperty(df, :_ambiguous_peptide_count)
+        has_common_peptide_count = hasproperty(df, :n_common_peptides)
 
         for i in 1:n_rows
             key = ProteinKey(
@@ -1781,9 +1800,13 @@ function add_protein_features(
                 "$(repr(key.name)), target=$(key.is_target), entrap_id=$(key.entrap_id)"
             )
             n_possible_unique[i] = opportunities.n_unique_peptides
+            n_possible_common_unique[i] =
+                opportunities.n_common_unique_peptides
             n_possible_shared[i] = opportunities.n_shared_peptides
 
             observed_unique = Int(df.n_peptides[i])
+            observed_common_unique = has_common_peptide_count ?
+                Int(df.n_common_peptides[i]) : observed_unique
             observed_shared = has_ambiguous_peptide_count ?
                 Int(df._ambiguous_peptide_count[i]) : 0
             if observed_unique > n_possible_unique[i]
@@ -1794,6 +1817,16 @@ function add_protein_features(
                     "entrap_id=$(key.entrap_id) " *
                     "n_peptides=$(observed_unique) " *
                     "n_possible_unique_peptides=$(n_possible_unique[i])"
+                )
+            end
+            if observed_common_unique > n_possible_common_unique[i]
+                error(
+                    "Common unique protein feature count inconsistency: " *
+                    "protein_name=$(repr(key.name)) " *
+                    "target=$(key.is_target) " *
+                    "entrap_id=$(key.entrap_id) " *
+                    "n_common_peptides=$(observed_common_unique) " *
+                    "n_possible_common_unique_peptides=$(n_possible_common_unique[i])"
                 )
             end
             if observed_shared > n_possible_shared[i]
@@ -1807,14 +1840,27 @@ function add_protein_features(
                 )
             end
 
-            if n_possible_unique[i] > 0
+            if n_possible_common_unique[i] > 0
                 peptide_coverage[i] =
-                    Float32(observed_unique) / Float32(n_possible_unique[i])
+                    Float32(observed_common_unique) /
+                    Float32(n_possible_common_unique[i])
                 peptide_coverage_logit[i] =
-                    smoothed_coverage_logit(observed_unique, n_possible_unique[i])
+                    smoothed_coverage_logit(
+                        observed_common_unique,
+                        n_possible_common_unique[i]
+                    )
             else
                 peptide_coverage[i] = 0.0f0
                 peptide_coverage_logit[i] = 0.0f0
+            end
+            if n_possible_unique[i] > 0
+                all_peptide_coverage[i] =
+                    Float32(observed_unique) / Float32(n_possible_unique[i])
+                all_peptide_coverage_logit[i] =
+                    smoothed_coverage_logit(observed_unique, n_possible_unique[i])
+            else
+                all_peptide_coverage[i] = 0.0f0
+                all_peptide_coverage_logit[i] = 0.0f0
             end
             shared_peptide_coverage_logit[i] =
                 smoothed_coverage_logit(observed_shared, n_possible_shared[i])
@@ -1827,9 +1873,12 @@ function add_protein_features(
         end
 
         df.n_possible_unique_peptides = n_possible_unique
+        df.n_possible_common_unique_peptides = n_possible_common_unique
         df.n_possible_shared_peptides = n_possible_shared
         df.peptide_coverage = peptide_coverage
         df.peptide_coverage_logit = peptide_coverage_logit
+        df.all_peptide_coverage = all_peptide_coverage
+        df.all_peptide_coverage_logit = all_peptide_coverage_logit
         df.shared_peptide_coverage_logit = shared_peptide_coverage_logit
         df.shared_coverage_log_ratio = shared_coverage_log_ratios
 

--- a/src/structs/KoinaStructs/FastaTypes.jl
+++ b/src/structs/KoinaStructs/FastaTypes.jl
@@ -30,6 +30,7 @@ struct FastaEntry
     start_idx::Vector{UInt32}
     structural_mods::Union{Missing,Vector{PeptideMod}}
     isotopic_mods::Union{Missing,Vector{PeptideMod}}
+    num_variable_modifications::UInt8
     charge::UInt8
     num_enzymatic_termini::UInt8
     base_target_id::UInt32
@@ -53,33 +54,44 @@ get_entrapment_pair_id(entry::FastaEntry) = entry.entrapment_pair_id
 is_decoy(entry::FastaEntry) = entry.is_decoy
 get_isotopic_mods(entry::FastaEntry) = entry.isotopic_mods
 get_structural_mods(entry::FastaEntry) = entry.structural_mods
+get_num_variable_modifications(entry::FastaEntry) =
+    entry.num_variable_modifications
 get_charge(entry::FastaEntry) = entry.charge
 get_num_enzymatic_termini(entry::FastaEntry) = entry.num_enzymatic_termini
 
-"""Construct a FASTA entry with one protein-position mapping."""
+"""Construct a FASTA entry with exact modification and enzymatic metadata."""
 function FastaEntry(
-    accession::String,
-    description::String,
-    gene::String,
-    protein::String,
-    organism::String,
-    proteome::String,
-    sequence::String,
-    start_idx::Integer,
+    accession::AbstractString,
+    description::AbstractString,
+    gene::AbstractString,
+    protein::AbstractString,
+    organism::AbstractString,
+    proteome::AbstractString,
+    sequence::AbstractString,
+    start_idx,
     struct_mods::Union{Missing,Vector{PeptideMod}},
     iso_mods::Union{Missing,Vector{PeptideMod}},
+    num_variable_modifications::UInt8,
     charge::UInt8,
     num_enzymatic_termini::UInt8,
     base_target_id::UInt32,
     base_pep_id::UInt32,
-    entrapment_pair_id::UInt32,
+    entrapment_pair_id::Integer,
     is_decoy::Bool,
 )
+    starts = if start_idx isa Vector{UInt32}
+        start_idx
+    elseif start_idx isa Integer
+        UInt32[UInt32(start_idx)]
+    else
+        UInt32.(collect(start_idx))
+    end
     return FastaEntry(
-        accession, description, gene, protein, organism, proteome, sequence,
-        UInt32[UInt32(start_idx)], struct_mods, iso_mods, charge,
+        String(accession), String(description), String(gene), String(protein),
+        String(organism), String(proteome), String(sequence), starts,
+        struct_mods, iso_mods, num_variable_modifications, charge,
         num_enzymatic_termini, base_target_id, base_pep_id,
-        entrapment_pair_id, is_decoy,
+        UInt32(entrapment_pair_id), is_decoy,
     )
 end
 
@@ -114,9 +126,37 @@ function FastaEntry(
     is_decoy::Bool,
 )
     return FastaEntry(
-        String(accession), String(description), String(gene), String(protein), String(organism), String(proteome), String(sequence),
-        UInt32[start_idx], struct_mods, iso_mods, charge,
-        UInt8(2), base_target_id, base_pep_id, UInt32(entrapment_pair_id), is_decoy,
+        String(accession), String(description), String(gene), String(protein),
+        String(organism), String(proteome), String(sequence), start_idx,
+        struct_mods, iso_mods, zero(UInt8), charge, UInt8(2),
+        base_target_id, base_pep_id, UInt32(entrapment_pair_id), is_decoy,
+    )
+end
+
+"""Construct a FASTA entry with explicit enzymatic-termini metadata."""
+function FastaEntry(
+    accession::AbstractString,
+    description::AbstractString,
+    gene::AbstractString,
+    protein::AbstractString,
+    organism::AbstractString,
+    proteome::AbstractString,
+    sequence::AbstractString,
+    start_idx::UInt32,
+    struct_mods::Union{Missing,Vector{PeptideMod}},
+    iso_mods::Union{Missing,Vector{PeptideMod}},
+    charge::UInt8,
+    num_enzymatic_termini::UInt8,
+    base_target_id::UInt32,
+    base_pep_id::UInt32,
+    entrapment_pair_id::Integer,
+    is_decoy::Bool,
+)
+    return FastaEntry(
+        String(accession), String(description), String(gene), String(protein),
+        String(organism), String(proteome), String(sequence), start_idx,
+        struct_mods, iso_mods, zero(UInt8), charge, num_enzymatic_termini,
+        base_target_id, base_pep_id, UInt32(entrapment_pair_id), is_decoy,
     )
 end
 
@@ -148,8 +188,9 @@ function FastaEntry(
     is_decoy::Bool,
 )
     return FastaEntry(
-        String(accession), String(description), String(gene), String(protein), String(organism), String(proteome), String(sequence),
-        UInt32[start_idx], struct_mods, iso_mods, charge,
-        UInt8(2), base_target_id, base_pep_id, UInt32(entrapment_pair_id), is_decoy,
+        String(accession), String(description), String(gene), String(protein),
+        String(organism), String(proteome), String(sequence), start_idx,
+        struct_mods, iso_mods, zero(UInt8), charge, UInt8(2),
+        base_target_id, base_pep_id, UInt32(entrapment_pair_id), is_decoy,
     )
 end

--- a/src/structs/SpectralLibrary/precursors.jl
+++ b/src/structs/SpectralLibrary/precursors.jl
@@ -11,9 +11,19 @@ struct StandardLibraryPrecursors <: LibraryPrecursors
     n::Int64
     accession_numbers_to_pid::Dictionary{String, UInt32}
     pid_to_cv_fold::Vector{UInt8}
-    function StandardLibraryPrecursors(precursor_table::Arrow.Table)
+    inferred_num_variable_modifications::Union{Nothing, Vector{UInt8}}
+    function StandardLibraryPrecursors(
+        precursor_table::Arrow.Table,
+        inferred_num_variable_modifications::Union{Nothing, Vector{UInt8}} = nothing
+    )
         try
             n = length(precursor_table[:sequence])
+            if inferred_num_variable_modifications !== nothing
+                length(inferred_num_variable_modifications) == n ||
+                    throw(ArgumentError(
+                        "inferred_num_variable_modifications must match the precursor table length"
+                    ))
+            end
             accession_numbers = precursor_table[:accession_numbers]
             accession_keys = String[_accession_key(accs) for accs in accession_numbers]
 
@@ -43,7 +53,13 @@ struct StandardLibraryPrecursors <: LibraryPrecursors
                     pid_to_cv_fold[pid] = rand(cv_folds)
                 end
             end
-            new(precursor_table, n, accession_number_to_pgid, pid_to_cv_fold)
+            new(
+                precursor_table,
+                n,
+                accession_number_to_pgid,
+                pid_to_cv_fold,
+                inferred_num_variable_modifications
+            )
         catch e
             @user_warn "Failed to load precursor table"
             throw(e)
@@ -54,8 +70,71 @@ end
 _accession_key(accs::AbstractString) = String(accs)
 _accession_key(accs) = join(string.(collect(accs)), ";")
 
-function SetPrecursors(precursor_table::Arrow.Table)
-    return StandardLibraryPrecursors(precursor_table)
+@inline _count_mox(seq::AbstractString) = UInt8(count("Unimod:35", seq))
+@inline _count_mox(::Missing) = zero(UInt8)
+
+function _count_variable_modifications(
+    structural_mods::Union{Missing, AbstractString},
+    variable_mod_names::AbstractSet{String}
+)::UInt8
+    (ismissing(structural_mods) || isempty(structural_mods) ||
+     isempty(variable_mod_names)) && return zero(UInt8)
+
+    n_variable = 0
+    for mod_match in eachmatch(r"(?<=\().*?(?=\))", structural_mods)
+        mod_name_match = match(r"[^,]+(?=$)", mod_match.match)
+        mod_name_match === nothing && continue
+        String(mod_name_match.match) in variable_mod_names || continue
+        n_variable += 1
+    end
+    n_variable <= typemax(UInt8) ||
+        throw(ArgumentError("A precursor cannot have more than 255 variable modifications"))
+    return UInt8(n_variable)
+end
+
+_count_variable_modifications(::Any, ::Nothing) = nothing
+
+function _configured_variable_mod_names(config)::Union{Nothing, Set{String}}
+    config isa AbstractDict || return nothing
+    variable_mods = get(config, "variable_mods", nothing)
+    variable_mods isa AbstractDict || return nothing
+    names = get(variable_mods, "name", nothing)
+    names isa AbstractVector || return nothing
+    variable_names = Set(String.(names))
+    fixed_mods = get(config, "fixed_mods", nothing)
+    fixed_names = if fixed_mods isa AbstractDict
+        configured_fixed_names = get(fixed_mods, "name", nothing)
+        configured_fixed_names isa AbstractVector ?
+            Set(String.(configured_fixed_names)) : Set{String}()
+    else
+        Set{String}()
+    end
+    # An old table cannot distinguish fixed and variable instances when a
+    # name appears in both lists. Treat that configuration as unavailable and
+    # use the silent M-oxidation fallback instead of misclassifying fixed mods.
+    isempty(intersect(variable_names, fixed_names)) || return nothing
+    return variable_names
+end
+
+function SetPrecursors(
+    precursor_table::Arrow.Table;
+    variable_mod_names::Union{Nothing, AbstractSet{String}} = nothing
+)
+    inferred_num_variable_modifications = if !hasproperty(
+        precursor_table,
+        :num_variable_modifications
+    ) && variable_mod_names !== nothing
+        UInt8[
+            _count_variable_modifications(mods, variable_mod_names)
+            for mods in precursor_table[:structural_mods]
+        ]
+    else
+        nothing
+    end
+    return StandardLibraryPrecursors(
+        precursor_table,
+        inferred_num_variable_modifications
+    )
 end
 
 Base.length(lp::LibraryPrecursors) = lp.n
@@ -90,6 +169,24 @@ function getNumEnzymaticTermini(lp::LibraryPrecursors)
     # specific, so both termini are enzymatic by construction.
     return fill(UInt8(2), length(lp))
 end
+
+"""
+    getNumVariableModifications(lp::LibraryPrecursors)
+
+Return exact variable-modification counts stored in the library or inferred
+from its build configuration. Returns `nothing` for legacy libraries without
+either source of metadata; callers silently retain the historical
+M-oxidation-only behavior for those libraries.
+"""
+getNumVariableModifications(lp::LibraryPrecursors) =
+    hasproperty(lp.data, :num_variable_modifications) ?
+        lp.data[:num_variable_modifications] :
+        lp.inferred_num_variable_modifications
+
+@inline _num_variable_modifications_at(::Nothing, structural_mods, precursor_idx::Integer) =
+    _count_mox(structural_mods[precursor_idx])
+@inline _num_variable_modifications_at(values, structural_mods, precursor_idx::Integer) =
+    UInt8(values[precursor_idx])
 getIrt(lp::LibraryPrecursors)::Arrow.Primitive{Float32, Vector{Float32}} = lp.data[:irt]
 getSulfurCount(lp::LibraryPrecursors)::Arrow.Primitive{UInt8, Vector{UInt8}} = lp.data[:sulfur_count]
 getIsotopicMods(lp::LibraryPrecursors)::Arrow.List{Union{Missing, String}, Int32, Vector{UInt8}} = lp.data[:isotopic_mods]

--- a/src/structs/protein_inference_types.jl
+++ b/src/structs/protein_inference_types.jl
@@ -128,6 +128,24 @@ struct InferenceResult
     ambiguous_peptide_to_proteins::Dictionary{PeptideKey, Vector{ProteinKey}}
 end
 
+"""
+    _is_common_peptide(missed_cleavages, num_enzymatic_termini,
+                       num_variable_modifications)
+
+Return whether a peptide belongs to the stable, commonly observable coverage
+class: fully enzymatic, no missed cleavages, and no variable modifications.
+Fixed and isotopic modifications do not affect this classification.
+"""
+@inline function _is_common_peptide(
+    missed_cleavages::Integer,
+    num_enzymatic_termini::Integer,
+    num_variable_modifications::Integer
+)::Bool
+    return missed_cleavages == 0 &&
+        num_enzymatic_termini == 2 &&
+        num_variable_modifications == 0
+end
+
 InferenceResult(peptide_to_protein::Dictionary{PeptideKey, ProteinKey}) = InferenceResult(
     peptide_to_protein,
     Dictionary{PeptideKey, Vector{ProteinKey}}()
@@ -138,14 +156,26 @@ InferenceResult(peptide_to_protein::Dictionary{PeptideKey, ProteinKey}) = Infere
 
 Theoretical peptide opportunities for one retained final protein group.
 
-`n_unique_peptides` counts library peptide sequences that map to this group and
-no other retained final group. `n_shared_peptides` counts library peptide
-sequences that map to this group and at least one other retained final group.
+`n_unique_peptides` counts all library peptide sequences that map to this group
+and no other retained final group. `n_shared_peptides` counts all library
+peptide sequences that map to this group and at least one other retained final
+group. `n_common_unique_peptides` is the subset of unique opportunities with at
+least one fully enzymatic, zero-missed-cleavage, variable-unmodified precursor.
 """
 struct ProteinPeptideOpportunityCounts
     n_unique_peptides::Int
     n_shared_peptides::Int
+    n_common_unique_peptides::Int
 end
+
+ProteinPeptideOpportunityCounts(
+    n_unique_peptides::Int,
+    n_shared_peptides::Int
+) = ProteinPeptideOpportunityCounts(
+    n_unique_peptides,
+    n_shared_peptides,
+    n_unique_peptides
+)
 
 """
     ProteinGroupBuilder

--- a/test/Routines/BuildSpecLib/test_build_spec_lib.jl
+++ b/test/Routines/BuildSpecLib/test_build_spec_lib.jl
@@ -678,6 +678,32 @@ end
                 @info "precursors_file: $precursors_file"
                 if isfile(precursors_file)
                     precursors = Arrow.Table(precursors_file)
+                    @test hasproperty(
+                        precursors,
+                        :num_variable_modifications
+                    )
+                    variable_mod_names = params["variable_mods"]["name"]
+                    expected_variable_modifications = UInt8[
+                        max(0, sum(
+                            count(mod_name, coalesce(mods, ""))
+                            for mod_name in variable_mod_names;
+                            init = 0
+                        ) - sum(
+                            fixed_name in variable_mod_names ?
+                                count(Regex(fixed_pattern), sequence) : 0
+                            for (fixed_name, fixed_pattern) in zip(
+                                params["fixed_mods"]["name"],
+                                params["fixed_mods"]["pattern"]
+                            );
+                            init = 0
+                        ))
+                        for (mods, sequence) in zip(
+                            precursors[:structural_mods],
+                            precursors[:sequence]
+                        )
+                    ]
+                    @test collect(precursors[:num_variable_modifications]) ==
+                        expected_variable_modifications
                     
                     # Count unique sequences and modifications
                     unique_seqs = unique(precursors[:sequence])

--- a/test/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/test_global_protein_scoring.jl
+++ b/test/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/test_global_protein_scoring.jl
@@ -142,6 +142,8 @@
         @test table.max_n_peptides_observed[1] == 2.0f0
         @test table.global_peptide_coverage[1] == 0.5f0
         @test table.max_peptide_coverage[1] ≈ 1.0f0 / 3.0f0
+        @test table.global_all_peptide_coverage[1] == 0.5f0
+        @test table.max_all_peptide_coverage[1] ≈ 1.0f0 / 3.0f0
         @test table.n_passing_runs[1] == 1.0f0
         @test !hasproperty(table, :n_runs_observed)
         @test table.n_score_gt_0_5[1] == 2.0f0
@@ -157,10 +159,41 @@
         @test table.max_n_peptides_observed[2] == 1.0f0
         @test table.global_peptide_coverage[2] == 0.25f0
         @test table.max_peptide_coverage[2] == 0.25f0
+        @test table.global_all_peptide_coverage[2] == 0.25f0
+        @test table.max_all_peptide_coverage[2] == 0.25f0
         @test table.n_passing_runs[2] == 0.0f0
         @test table.observed_run_centrality_mean[2] == 0.0f0
         @test table.observed_run_centrality_max[2] == 0.0f0
         @test table.missing_run_similarity_mass_approx[2] == 0.0f0
+    end
+
+    @testset "global coverage separates common and all peptides" begin
+        key = ("P1", true, UInt8(0))
+        inputs = Pioneer.GlobalProteinInputs(
+            Dict(
+                key => Pioneer.GlobalProteinRunScore[
+                    Pioneer.GlobalProteinRunScore(UInt32(1), 0.9f0),
+                    Pioneer.GlobalProteinRunScore(UInt32(2), 0.8f0),
+                ],
+            ),
+            Dict(key => Set(["COMMON", "SEMI1", "SEMI2"])),
+            Dict(key => Set(["COMMON"])),
+            Dict(key => 2),
+            Dict(key => 1),
+            Dict(key => 6),
+            Dict(key => 2),
+            Dict(key => UInt8(0)),
+        )
+        table = Pioneer._build_global_protein_feature_table(inputs, 2, 0.5f0)
+
+        @test table.global_peptide_coverage[1] == 0.5f0
+        @test table.max_peptide_coverage[1] == 0.5f0
+        @test table.global_all_peptide_coverage[1] == 0.5f0
+        @test table.max_all_peptide_coverage[1] ≈ 1.0f0 / 3.0f0
+        @test :global_all_peptide_coverage in
+            Pioneer.GLOBAL_PROTEIN_MONOTONE_INCREASING_FEATURES
+        @test :max_all_peptide_coverage in
+            Pioneer.GLOBAL_PROTEIN_MONOTONE_INCREASING_FEATURES
     end
 
     @testset "run-level input collection" begin
@@ -174,8 +207,11 @@
                 file_idx = UInt32[2, 2],
                 pg_score = Float32[0.9, 0.4],
                 n_peptides = Int[2, 1],
+                n_common_peptides = Int[1, 0],
                 n_possible_unique_peptides = Int[4, 2],
+                n_possible_common_unique_peptides = Int[2, 1],
                 peptide_list = ["PEPA;PEPB", "PEPX"],
+                common_peptide_list = ["PEPA", ""],
             ))
             Arrow.write(run2_path, DataFrame(
                 protein_name = ["P1", "P3"],
@@ -184,8 +220,11 @@
                 file_idx = UInt32[4, 4],
                 pg_score = Float32[0.8, 0.3],
                 n_peptides = Int[2, 1],
+                n_common_peptides = Int[1, 1],
                 n_possible_unique_peptides = Int[4, 3],
+                n_possible_common_unique_peptides = Int[2, 2],
                 peptide_list = ["PEPB;PEPC", "PEPY"],
+                common_peptide_list = ["PEPC", "PEPY"],
             ))
             refs = Pioneer.ProteinGroupFileReference[
                 Pioneer.ProteinGroupFileReference(run1_path),
@@ -222,6 +261,11 @@
                   Set(["PEPA", "PEPB", "PEPC"])
             @test inputs.observed_peptides[("P2", false, UInt8(0))] == Set(["PEPX"])
             @test inputs.observed_peptides[("P3", false, UInt8(1))] == Set(["PEPY"])
+            @test inputs.observed_common_peptides[("P1", true, UInt8(0))] ==
+                Set(["PEPA", "PEPC"])
+            @test isempty(inputs.observed_common_peptides[("P2", false, UInt8(0))])
+            @test inputs.observed_common_peptides[("P3", false, UInt8(1))] ==
+                Set(["PEPY"])
             @test inputs.max_n_peptides == Dict(
                 ("P1", true, UInt8(0)) => 2,
                 ("P2", false, UInt8(0)) => 1,
@@ -231,6 +275,16 @@
                 ("P1", true, UInt8(0)) => 4,
                 ("P2", false, UInt8(0)) => 2,
                 ("P3", false, UInt8(1)) => 3,
+            )
+            @test inputs.max_n_common_peptides == Dict(
+                ("P1", true, UInt8(0)) => 1,
+                ("P2", false, UInt8(0)) => 0,
+                ("P3", false, UInt8(1)) => 1,
+            )
+            @test inputs.n_possible_common_unique_peptides == Dict(
+                ("P1", true, UInt8(0)) => 2,
+                ("P2", false, UInt8(0)) => 1,
+                ("P3", false, UInt8(1)) => 2,
             )
             @test inputs.folds == Dict(
                 ("P1", true, UInt8(0)) => UInt8(0),

--- a/test/UnitTests/ChronologerPrepTests.jl
+++ b/test/UnitTests/ChronologerPrepTests.jl
@@ -248,6 +248,26 @@
         @test any(mod -> mod.position == 6 && mod.aa == 'M' && mod.mod_name == "Oxidation", all_mods[both_mods])
         @test any(mod -> mod.position == 7 && mod.aa == 'S' && mod.mod_name == "Phospho", all_mods[both_mods])
     end
+
+    @testset "variable modification counts exclude fixed modifications" begin
+        peptide = FastaEntry(
+            "P1", "", "", "", "", "YEAST", "MCK",
+            UInt32(1), missing, missing, UInt8(0), UInt32(1),
+            UInt32(1), UInt8(0), false
+        )
+        variants = Pioneer.add_mods(
+            [peptide],
+            [(p = r"C", r = "Unimod:4")],
+            [(p = r"M", r = "Unimod:35")],
+            1
+        )
+        @test sort(Pioneer.get_num_variable_modifications.(variants)) ==
+            UInt8[0, 1]
+
+        charged = Pioneer.add_charge(variants, 2, 3)
+        @test sort(Pioneer.get_num_variable_modifications.(charged)) ==
+            UInt8[0, 0, 1, 1]
+    end
     
     #==========================================================================
     Tests for add_pair_indices!
@@ -286,4 +306,3 @@
         @test df[6, :partner_precursor_idx] == 5
     end
 end
-

--- a/test/UnitTests/FastaEntryConstructorsTests.jl
+++ b/test/UnitTests/FastaEntryConstructorsTests.jl
@@ -35,6 +35,7 @@ using Test
     @test get_charge(e1) == 0
     @test get_num_enzymatic_termini(e1) == 2
     @test get_start_idx(e1) == UInt32[1]
+    @test Pioneer.get_num_variable_modifications(e1) == 0
 
     # 16-arg compatibility constructor (base_prec_id ignored)
     e2 = FastaEntry(acc, desc, gene, prot, org, protm, seq,
@@ -43,12 +44,16 @@ using Test
     @test get_base_pep_id(e2) == 2
     @test get_entrapment_pair_id(e2) == 1
     @test get_num_enzymatic_termini(e2) == 2
+    @test Pioneer.get_num_variable_modifications(e2) == 0
 
-    # Explicit enzymatic-termini metadata uses the canonical field order.
+    # Exact variable-modification and enzymatic-termini metadata use the
+    # canonical field order.
     e3 = FastaEntry(String(acc), String(desc), String(gene), String(prot),
                     String(org), String(protm), String(seq), UInt32(1),
-                    missing, missing, UInt8(0), UInt8(1), UInt32(1),
-                    UInt32(2), UInt32(0), false)
+                    missing, missing, UInt8(2), UInt8(3), UInt8(1),
+                    UInt32(1), UInt32(2), UInt32(0), false)
+    @test Pioneer.get_num_variable_modifications(e3) == 2
+    @test get_charge(e3) == 3
     @test get_num_enzymatic_termini(e3) == 1
     @test get_start_idx(e3) == UInt32[1]
 end

--- a/test/UnitTests/test_enzymatic_termini_metadata.jl
+++ b/test/UnitTests/test_enzymatic_termini_metadata.jl
@@ -1,0 +1,109 @@
+using Arrow
+using Test
+
+using Pioneer: SetPrecursors, getNumEnzymaticTermini,
+    getNumVariableModifications
+using Pioneer: _num_variable_modifications_at,
+    _configured_variable_mod_names
+
+function _write_minimal_precursor_table(path; enzymatic_termini = nothing)
+    columns = (
+        sequence = ["PEPTIDEK", "SEMIPEP"],
+        accession_numbers = ["P1", "P2"],
+    )
+    table = enzymatic_termini === nothing ? columns : merge(
+        columns,
+        (num_enzymatic_termini = UInt8.(enzymatic_termini),),
+    )
+    Arrow.write(path, table)
+    return nothing
+end
+
+function _write_variable_modification_precursor_table(
+    path;
+    num_variable_modifications = nothing
+)
+    columns = (
+        sequence = ["FIXEDC", "OXM", "PHOSPHO"],
+        accession_numbers = ["P1", "P2", "P3"],
+        structural_mods = Union{Missing, String}[
+            "(5,C,Unimod:4)",
+            "(2,M,Unimod:35)",
+            "(3,S,Unimod:21)(7,C,Unimod:4)",
+        ],
+    )
+    table = num_variable_modifications === nothing ? columns : merge(
+        columns,
+        (
+            num_variable_modifications =
+                UInt8.(num_variable_modifications),
+        ),
+    )
+    Arrow.write(path, table)
+    return nothing
+end
+
+@testset "enzymatic termini precursor metadata" begin
+    mktempdir() do dir
+        current_path = joinpath(dir, "current.arrow")
+        _write_minimal_precursor_table(current_path; enzymatic_termini = [2, 1])
+        current = SetPrecursors(Arrow.Table(current_path))
+        current_values = getNumEnzymaticTermini(current)
+
+        @test collect(current_values) == UInt8[2, 1]
+
+        legacy_path = joinpath(dir, "legacy.arrow")
+        _write_minimal_precursor_table(legacy_path)
+        legacy = SetPrecursors(Arrow.Table(legacy_path))
+        legacy_values = getNumEnzymaticTermini(legacy)
+
+        @test legacy_values == UInt8[2, 2]
+    end
+end
+
+@testset "variable-modification precursor metadata" begin
+    mktempdir() do dir
+        current_path = joinpath(dir, "current.arrow")
+        _write_variable_modification_precursor_table(
+            current_path;
+            num_variable_modifications = [0, 1, 1]
+        )
+        current = SetPrecursors(Arrow.Table(current_path))
+        @test collect(getNumVariableModifications(current)) == UInt8[0, 1, 1]
+
+        inferred_path = joinpath(dir, "inferred.arrow")
+        _write_variable_modification_precursor_table(inferred_path)
+        inferred = SetPrecursors(
+            Arrow.Table(inferred_path);
+            variable_mod_names = Set(["Unimod:35", "Unimod:21"])
+        )
+        inferred_values = getNumVariableModifications(inferred)
+        @test inferred_values == UInt8[0, 1, 1]
+
+        legacy = SetPrecursors(Arrow.Table(inferred_path))
+        legacy_values = getNumVariableModifications(legacy)
+        structural_mods = Arrow.Table(inferred_path).structural_mods
+        @test legacy_values === nothing
+        @test _num_variable_modifications_at(
+            legacy_values,
+            structural_mods,
+            1
+        ) == UInt8(0)
+        @test _num_variable_modifications_at(
+            legacy_values,
+            structural_mods,
+            2
+        ) == UInt8(1)
+        # Legacy fallback is deliberately M-oxidation-only and silent.
+        @test _num_variable_modifications_at(
+            legacy_values,
+            structural_mods,
+            3
+        ) == UInt8(0)
+
+        @test _configured_variable_mod_names(Dict(
+            "variable_mods" => Dict("name" => ["Unimod:4"]),
+            "fixed_mods" => Dict("name" => ["Unimod:4"]),
+        )) === nothing
+    end
+end

--- a/test/UnitTests/test_protein_ambiguous_scoring.jl
+++ b/test/UnitTests/test_protein_ambiguous_scoring.jl
@@ -180,6 +180,54 @@ end
         @test opportunities[entrap_e] == ProteinPeptideOpportunityCounts(1, 0)
     end
 
+    @testset "common coverage is invariant to uncommon library expansion" begin
+        protein = ProteinKey("A", true, UInt8(0))
+        final_groups = Set([protein])
+        accessions = ["A", "A", "A", "A"]
+        sequences = ["COMMON", "SEMI", "VARIABLE", "SEMI_EXTRA"]
+        is_decoys = falses(4)
+        entrap_ids = zeros(UInt8, 4)
+
+        base_opportunities = count_protein_peptide_opportunities(
+            accessions[1:3],
+            sequences[1:3],
+            is_decoys[1:3],
+            entrap_ids[1:3],
+            final_groups;
+            common_precursor_mask = Bool[true, false, false]
+        )
+        expanded_opportunities = count_protein_peptide_opportunities(
+            accessions,
+            sequences,
+            is_decoys,
+            entrap_ids,
+            final_groups;
+            common_precursor_mask = Bool[true, false, false, false]
+        )
+
+        @test base_opportunities[protein] ==
+            ProteinPeptideOpportunityCounts(3, 0, 1)
+        @test expanded_opportunities[protein] ==
+            ProteinPeptideOpportunityCounts(4, 0, 1)
+
+        protein_groups = DataFrame(
+            protein_name = ["A"],
+            target = Bool[true],
+            entrap_id = UInt8[0],
+            n_peptides = Int64[3],
+            n_common_peptides = Int64[1],
+        )
+        add_protein_features(Dict(
+            protein => expanded_opportunities[protein]
+        )).second(protein_groups)
+
+        @test protein_groups.n_possible_common_unique_peptides == Int64[1]
+        @test protein_groups.peptide_coverage == Float32[1.0]
+        @test protein_groups.all_peptide_coverage == Float32[0.75]
+        @test protein_groups.peptide_coverage_logit[1] ≈ log(3.0f0)
+        @test protein_groups.all_peptide_coverage_logit[1] ≈ log(7.0f0 / 3.0f0)
+    end
+
     @testset "shared coverage logit distinguishes absent opportunities" begin
         protein_groups = DataFrame(
             protein_name = ["A", "B"],

--- a/test/UnitTests/test_protein_mbr_features.jl
+++ b/test/UnitTests/test_protein_mbr_features.jl
@@ -45,6 +45,7 @@ end
         @test !protein_groups.single_non_mbr_peptide[1]
         @test protein_groups.single_non_mbr_prefix_shape[1] == 0.0f0
         @test protein_groups.mbr_only_protein[1]
+        @test protein_groups.any_common_peps[1]
     end
 
     @testset "Mixed support tracks retained MBR evidence without changing pg_score input" begin
@@ -139,5 +140,68 @@ end
         @test !in(:mbr_best_transfer_confidence, features)
         @test !in(:mbr_sum_transfer_evidence, features)
         @test !in(:mbr_best_pair_prob, features)
+    end
+
+    @testset "common peptide evidence uses specificity, cleavage, and variable modifications" begin
+        psms = DataFrame(
+            inferred_protein_group =
+                ["P_SEMI", "P_FULL", "P_MISSED", "P_VARIABLE"],
+            species = fill("YEAST", 4),
+            target = trues(4),
+            entrap_id = zeros(UInt8, 4),
+            use_for_protein_quant = trues(4),
+            qval = zeros(Float32, 4),
+            global_qval = fill(0.001f0, 4),
+            precursor_idx = UInt32[40, 41, 42, 43],
+            prec_prob = fill(0.9f0, 4),
+            peak_area = fill(1000.0f0, 4),
+            base_pep_id = UInt32[401, 402, 403, 404],
+            sequence = ["SEMIPEP", "FULLPEP", "MISSEDPEP", "PHOSPEP"],
+            missed_cleavage = Int64[0, 0, 1, 0],
+            num_enzymatic_termini = UInt8[1, 2, 2, 2],
+            num_variable_modifications = UInt8[0, 0, 0, 1],
+            Mox = zeros(Int64, 4),
+            mbr_recovered = falses(4),
+        )
+
+        protein_groups = group_psms_by_protein(
+            psms;
+            precursor_consensus =
+                _empty_precursor_consensus_for_mbr_feature_tests(),
+            q_value_threshold = 0.01f0,
+        )
+        common_by_protein = Dict(
+            String(row.protein_name) => Bool(row.any_common_peps)
+            for row in eachrow(protein_groups)
+        )
+
+        @test !common_by_protein["P_SEMI"]
+        @test common_by_protein["P_FULL"]
+        @test !common_by_protein["P_MISSED"]
+        @test !common_by_protein["P_VARIABLE"]
+
+        full_row = only(eachrow(protein_groups[protein_groups.protein_name .== "P_FULL", :]))
+        @test full_row.n_common_peptides == 1
+        @test full_row.common_peptide_list == "FULLPEP"
+        for protein_name in ("P_SEMI", "P_MISSED", "P_VARIABLE")
+            row = only(eachrow(
+                protein_groups[protein_groups.protein_name .== protein_name, :]
+            ))
+            @test row.n_common_peptides == 0
+            @test isempty(row.common_peptide_list)
+        end
+    end
+
+    @testset "PSM models include enzymatic specificity" begin
+        @test :num_enzymatic_termini in Pioneer.PRESCORE_FEATURES
+        @test :num_enzymatic_termini in Pioneer.ADVANCED_FEATURE_SET
+    end
+
+    @testset "Run-level model separates common and all-peptide coverage" begin
+        features = run_level_protein_feature_names()
+        @test :peptide_coverage_logit in features
+        @test :all_peptide_coverage_logit in features
+        @test :all_peptide_coverage_logit in
+            Pioneer.PROTEIN_MONOTONE_INCREASING_FEATURES
     end
 end

--- a/test/UnitTests/test_protein_model_fit.jl
+++ b/test/UnitTests/test_protein_model_fit.jl
@@ -69,6 +69,7 @@ import Pioneer: DEBUG_CONSOLE_LEVEL
             :shared_peptide_coverage_logit,
             :shared_coverage_log_ratio,
             :peptide_coverage_logit,
+            :all_peptide_coverage_logit,
             :any_common_peps,
             :coverage_log_ratio,
             :precursor_consensus_prefix_shape,
@@ -80,7 +81,7 @@ import Pioneer: DEBUG_CONSOLE_LEVEL
         ]
         constraints =
             _protein_lightgbm_monotone_constraints(feature_names)
-        @test constraints == Int[0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, -1]
+        @test constraints == Int[0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, -1]
 
         classifier = build_lightgbm_classifier(
             ;

--- a/test/integration/test_buildspeclib_synthetic.jl
+++ b/test/integration/test_buildspeclib_synthetic.jl
@@ -8,6 +8,7 @@
 
 using Test
 using Pioneer
+using Arrow
 
 @testset "BuildSpecLib offline (SyntheticKoinaClient) — keap1.fasta" begin
     repo_root    = abspath(joinpath(@__DIR__, "..", ".."))
@@ -41,6 +42,11 @@ using Pioneer
     @test hasproperty(precursors, :start_idx)
     @test all(starts -> !isempty(starts), precursors.start_idx)
     @test all(starts -> eltype(starts) == UInt32, precursors.start_idx)
+    @test hasproperty(precursors, :num_variable_modifications)
+    @test collect(precursors.num_variable_modifications) == UInt8[
+        count("Unimod:35", coalesce(mods, ""))
+        for mods in precursors.structural_mods
+    ]
 
     # Cleanup
     safe_rmdir(lib_path)

--- a/test/runtests_part2_units.jl
+++ b/test/runtests_part2_units.jl
@@ -27,6 +27,7 @@ include("./UnitTests/test_whittaker_henderson.jl")
 include("./UnitTests/test_retention_time_index.jl")
 include("./UnitTests/test_arrow_psm_container.jl")
 include("./UnitTests/test_buildpionlib_index_filters.jl")
+include("./UnitTests/test_enzymatic_termini_metadata.jl")
 
 include("./UnitTests/isotopeSplines.jl")
 include("./UnitTests/testIsotopesJun13.jl")


### PR DESCRIPTION
## Summary

- Persist exact variable-modification counts in newly built spectral libraries and propagate them through PSM metadata.
- Infer variable-modification counts from compatible legacy library configs, with a silent M-oxidation fallback when exact inference is unavailable.
- Define common peptides as fully enzymatic, zero-missed-cleavage, and free of variable modifications.
- Keep the existing peptide-coverage features common-peptide-only and add separate run-level and global all-peptide coverage features.
- Add regression coverage for library construction, compatibility behavior, PSM feature propagation, protein opportunity counting, and run/global protein scoring.

## Why

Semi-tryptic libraries dramatically expand the theoretical peptide space. Using every library peptide in the normal protein coverage denominator compressed peptide coverage and reduced its usefulness for protein scoring, despite the search identifying substantially more precursors. The normal coverage feature should remain comparable across digestion specificities, while a separate all-peptide feature can retain the additional semi-tryptic evidence.

Exact variable-modification metadata is also needed so `any_common_peps` and common coverage reject every variable modification rather than only M oxidation.

## Impact

On the local three-replicate yeast comparison, the updated semi-tryptic search identified 85,958 unique precursors versus 66,123 for the fully tryptic search (+30.0%), while recovering 4,539 protein groups versus 4,542 (-0.07%). The previous pre-coverage-split result produced 4,482 groups.

The primary and all-peptide coverage features remain separately available to the protein models. Older libraries continue to work without emitting a compatibility warning.

## Validation

- `julia --startup-file=no --project=. test/runtests_part2_units.jl`
- `julia --startup-file=no --project=. test/runtests_part3_units.jl`
- `git diff --check`
