### PR TITLE
fix(docker): restore the apt index before installing the .deb

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,59 @@
+name: Docker image
+
+# The release workflow is the only other place this image is built, and it runs
+# after the GitHub Release has already been published -- so a Dockerfile defect
+# is discovered at the worst possible moment and cannot be fixed without either
+# a manual push or a new release. That is exactly what happened for v0.8.0.
+#
+# This builds the same image on any change to the Dockerfile, without pushing.
+# It pulls the .deb from the latest published release, so it validates the
+# Dockerfile against a real package rather than a synthetic one.
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+      - .github/workflows/docker.yml
+  push:
+    branches: [main, develop]
+    paths:
+      - Dockerfile
+      - .github/workflows/docker.yml
+  workflow_dispatch:
+    inputs:
+      pioneer_version:
+        description: "Release tag to build against; defaults to latest"
+        type: string
+        default: latest
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build image (no push)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image
+        run: |
+          docker build \
+            --build-arg PIONEER_VERSION=${{ inputs.pioneer_version || 'latest' }} \
+            -t pioneer:ci .
+
+      # The Dockerfile's own `RUN pioneer search --help` proves the CLI starts
+      # during the build. This proves it still works in the finished image, and
+      # reports the size, since the .deb pulls GUI libraries a CLI-only
+      # container cannot use (libwebkit2gtk-4.1-0 alone is ~91 MB installed).
+      - name: Smoke test
+        run: |
+          docker run --rm pioneer:ci pioneer --version
+          docker run --rm pioneer:ci pioneer search --help > /dev/null
+          echo "image size: $(docker image inspect pioneer:ci --format '{{.Size}}' | numfmt --to=iec)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM ubuntu:24.04
 
+# The apt lists are deliberately kept until the .deb is installed below. They
+# used to be deleted here, which left the next layer with no package index: the
+# .deb's dependencies then reported as "not installable" even though they are in
+# noble's main component. That was latent until the package first declared any
+# Depends at all, and it failed the v0.8.0 Docker publish.
 RUN apt-get update \
-    && apt-get install -y curl ca-certificates jq libicu-dev \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y curl ca-certificates jq libicu-dev
 
 ARG PIONEER_VERSION=latest
 
@@ -16,8 +20,10 @@ RUN if [ "$PIONEER_VERSION" = "latest" ]; then \
     FILE_NAME=$(curl -s "$RELEASE_URL" \
         | jq -r '.assets[] | select(.name | endswith(".deb")) | .name') && \
     curl -L "https://github.com/nwamsley1/Pioneer.jl/releases/download/${TAG_NAME}/${FILE_NAME}" -o /tmp/${FILE_NAME} && \
+    apt-get update && \
     apt-get install -y /tmp/${FILE_NAME} && \
-    rm /tmp/${FILE_NAME}
+    rm /tmp/${FILE_NAME} && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/usr/local/pioneer/bin:$PATH"
 


### PR DESCRIPTION
The first layer ended by deleting `/var/lib/apt/lists/*`, and the layer that installs the release `.deb` never ran `apt-get update`. With no package index, apt could not resolve the package's dependencies and reported them as *"not installable"* — a message about a missing index, not a missing package. `docker build` exited 100 and the v0.8.0 Docker publish failed while every other release job succeeded.

Latent until the `.deb` first declared any `Depends`. `build_app_linux.yml` now injects the Tauri GUI's libraries into the control file, so v0.8.0 was the first release to carry any. I confirmed against the published asset:

```
$ curl -r 0-262143 <v0.8.0 .deb> | ar x - control.tar.zst
Package: pioneer
Depends: libwebkit2gtk-4.1-0, libgtk-3-0
```

**Both are in noble's `main`**, so no extra repository is needed — the index simply had to exist. An earlier diagnosis suspected `universe`; I checked, and it isn't.

## Also: the image is only ever built at release time

That's why a deterministic defect surfaced at the worst possible moment, and it can't be corrected afterwards without a manual push or a new release. This adds a `Docker image` workflow that builds on any change to the `Dockerfile` (plus `workflow_dispatch` against a chosen tag) and smoke-tests the CLI in the finished image. It pulls the `.deb` from the latest published release, so it validates against a real package rather than a synthetic one.

**I could not build this locally — there is no Docker on the machine I'm working from, the same gap that left the original diagnosis unverified.** This PR's own new workflow is therefore the first real test of the fix; watch that check rather than assuming.

## Deliberately not addressed

Whether a CLI-only container should carry GUI libraries at all. `libwebkit2gtk-4.1-0` alone is **~91 MB installed** before its own dependency tree, and the image's only smoke test is `pioneer search --help`. Moving those to `Recommends` and installing with `--no-install-recommends` would keep the container lean while leaving desktop `.deb` installs unchanged, since apt honours `Recommends` by default. That's a packaging decision rather than a bug fix, so it's left for you and Dennis.

Once merged, the v0.8.0 image can be built and pushed by hand without re-tagging — the `Dockerfile` takes `PIONEER_VERSION` as a build arg and pulls from the published release assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)