### PR TITLE
Resolve the .deb's dependencies when validating the Linux installer

### DIFF
--- a/.github/workflows/validate_installers.yml
+++ b/.github/workflows/validate_installers.yml
@@ -105,7 +105,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          sudo dpkg -i installer/*.deb
+          # apt-get, not dpkg -i. dpkg installs one file and refuses to resolve
+          # anything it depends on, so the GUI's libwebkit2gtk-4.1-0 -- correctly
+          # declared by the .deb, and present in the archive -- came back as
+          # "not installed" and the whole Linux validation stopped before the
+          # smoke test ran. Same failure the Dockerfile hit, fixed there in
+          # 47384dda1; this is the path that was left behind.
+          #
+          # apt needs a current index to resolve against, and the runner image
+          # ships without one.
+          sudo apt-get update
+          sudo apt-get install -y ./installer/*.deb
 
       - name: Cache RAW fixture
         id: raw_fixture_cache


### PR DESCRIPTION
Nightly's Linux validation has been failing at the install step:

```
sudo dpkg -i installer/*.deb
pioneer depends on libwebkit2gtk-4.1-0; however:
  Package libwebkit2gtk-4.1-0 is not installed.
```

`dpkg -i` installs one file and refuses to resolve anything it depends on. The GUI's `libwebkit2gtk-4.1-0` is correctly declared by the `.deb` and is present in the archive — it just was never fetched. `apt-get install ./…deb` resolves it, and needs a current index to resolve against, which the runner image ships without.

**This is a CI bug, not a packaging bug.** The `.deb` declares its dependencies properly and `apt install ./pioneer.deb` has always worked; only the validation step used an install method that cannot succeed.

The same failure hit the Dockerfile and was fixed in `47384dda1`, whose own comment describes it — *"the .deb's dependencies then reported as 'not installable' even though they are in the index"*. This is the path that was left behind.

## Why it matters for a release

Everything after the install step was skipped, including **Run Linux smoke validation**. So the Linux installer has been built but never actually exercised — the build is green and the thing it produced is unverified. Windows and both macOS validations were unaffected and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)