### PR TITLE
fix: route release regressions through SLURM

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,9 +1,7 @@
 name: Regression Tests (LSF)
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  # LSF regressions are manual-only. Automated releases use the SLURM workflow.
   workflow_dispatch:
     inputs:
       regression_set:

--- a/.github/workflows/regression_slurm.yml
+++ b/.github/workflows/regression_slurm.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - develop
-    tags:
-      - 'v*.*.*'
+  # Human-published releases start this workflow directly. The automated release
+  # workflow dispatches it after publication so the release exists before reporting.
   release:
     types: [published]
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
     environment: production
     permissions:
       contents: write
-      actions: read
+      actions: write
     steps:
       - name: Checkout just the publish-release action
         uses: actions/checkout@v7
@@ -86,6 +86,18 @@ jobs:
           version: ${{ needs.linux.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Start SLURM release regressions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.linux.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run regression_slurm.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$RELEASE_TAG" \
+            --field regression_set=all \
+            --field delete_results=true
 
   docker:
     name: Publish Docker Images


### PR DESCRIPTION
## Summary

- make the LSF regression workflow manual-only
- stop starting SLURM regressions on release tag pushes
- dispatch the SLURM regression workflow after the GitHub release is published
- preserve manual regression dispatches against release tags

## Root cause

The release tag push started both regression workflows, but release-specific metric synchronization and release-note reporting only ran for `release` events or manual tag dispatches. The automated release was created with `GITHUB_TOKEN`, so its `release.published` event did not start another workflow. The completed tag-push regression therefore skipped both release post-processing steps.

## Impact

Automated releases now start exactly the SLURM regression workflow after publication. When that run finishes, the existing release-metrics and release-notes steps recognize the tag-scoped `workflow_dispatch` event and run normally. Manual tag dispatch behavior is unchanged.

## Validation

- parsed all three changed workflow files as YAML
- asserted the intended LSF, SLURM, release, and manual-tag event matrix
- ran `git diff --check`
