### PR TITLE
GUI round 2: drag-and-drop fixes, wider layout, version display

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pioneer-console",
-  "version": "0.1.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -2436,7 +2436,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pioneer-console"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "rusqlite",
  "serde",

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pioneer-console"
-version = "0.1.0"
+version = "0.9.0"
 description = "Pioneer desktop console"
 edition = "2021"
 rust-version = "1.77"

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -70,6 +70,13 @@ fn pioneer_info(app: AppHandle) -> Result<pioneer::PioneerInfo, String> {
     pioneer::resolve_home(resource_dir.as_deref())
 }
 
+/// The GUI's own version, for the sidebar footer. Compiled in rather than read
+/// at runtime, so it cannot disagree with the binary the user is running.
+#[tauri::command]
+fn app_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
 #[tauri::command]
 fn inspect_path(path: String) -> paths::PathInfo {
     paths::inspect(&path)
@@ -228,6 +235,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             pioneer_info,
+            app_version,
             inspect_path,
             read_config,
             library_info,

--- a/gui/src-tauri/src/pioneer.rs
+++ b/gui/src-tauri/src/pioneer.rs
@@ -70,6 +70,10 @@ pub struct PioneerInfo {
     pub executables: Vec<String>,
     /// True when the `pioneer` wrapper script is present.
     pub has_wrapper: bool,
+    /// Contents of the distribution's `VERSION` file, when it has one. The CLI
+    /// tools and the converter ship together, so this one string versions
+    /// both. None for a distribution built before the file existed.
+    pub version: Option<String>,
 }
 
 /// Where the platform installers put the CLI.
@@ -151,11 +155,17 @@ fn inspect(home: &Path, source: &str) -> Option<PioneerInfo> {
     if executables.is_empty() && !has_wrapper {
         return None;
     }
+    let version = std::fs::read_to_string(home.join("VERSION"))
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+
     Some(PioneerInfo {
         home: home.display().to_string(),
         source: source.to_string(),
         executables,
         has_wrapper,
+        version,
     })
 }
 

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -14,9 +14,9 @@
     "windows": [
       {
         "title": "Pioneer",
-        "width": 980,
+        "width": 1140,
         "height": 840,
-        "minWidth": 980,
+        "minWidth": 940,
         "minHeight": 620,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pioneer",
-  "version": "0.1.0",
+  "version": "0.9.0",
   "identifier": "org.pioneer.console",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -31,7 +31,7 @@ import {
 } from './lib/config'
 import { makeFastaRow, presetRegex } from './lib/fasta'
 import { moveQueuedJob } from './lib/queue'
-import { recentLibraries } from './lib/recent'
+import { libraryOf, recentLibraries } from './lib/recent'
 import {
   enforceRequiredMods,
   findMod,
@@ -74,7 +74,7 @@ import {
   convertOutputNote,
   fastaNote,
   libPathNote,
-  libraryNote,
+  pendingLibraryNote,
   libraryTargetPath,
   msDataNote,
   resultsNote,
@@ -667,14 +667,36 @@ export default function App() {
 
   const info = (k: string): PathInfo => pathInfos[k] ?? EMPTY_PATH_INFO
 
+  /** The library a queued or running build/download is about to produce, so a
+   *  search that consumes it can be queued behind it rather than waiting for
+   *  the folder to appear. Most recently queued wins when there are several. */
+  const pendingLibrary = useMemo(() => {
+    for (let i = jobs.length - 1; i >= 0; i--) {
+      const j = jobs[i]
+      if (j.status !== 'queued' && j.status !== 'running') continue
+      if (j.snapshot.cmd !== 'buildspeclib' && j.snapshot.cmd !== 'downloadspeclib') continue
+      const path = libraryOf(j)
+      if (path) return path
+    }
+    return null
+  }, [jobs])
+
+  // Fill an empty library field from that job. The Run handler already does
+  // this at the moment a build is queued; this also covers arriving at
+  // SearchDIA with the field cleared, or a build queued before it was.
+  useEffect(() => {
+    if (!pendingLibrary) return
+    setSearch((p) => (p.library.trim() ? p : { ...p, library: pendingLibrary }))
+  }, [pendingLibrary])
+
   const searchNotes = useMemo(
     () => ({
       msData: msDataNote(search.msData, info('msData')),
-      library: libraryNote(search.library, info('library')),
+      library: pendingLibraryNote(search.library, info('library'), pendingLibrary),
       results: resultsNote(search.results, info('results')),
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [search.msData, search.library, search.results, pathInfos],
+    [search.msData, search.library, search.results, pathInfos, pendingLibrary],
   )
 
   const fastaNotes = useMemo(
@@ -1229,7 +1251,7 @@ export default function App() {
       : isDownload
         ? validateDownloadRun(download, downloadTargetExists)
         : isSearch
-          ? validateSearchRun(search, searchNotes)
+          ? validateSearchRun(search, searchNotes, pendingLibrary)
           : validateBuildRun(build, fastaNotes, libNote, calibNote)
     if (block) {
       setRunError(block.msg)

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -1491,8 +1491,8 @@ export default function App() {
         {/* minHeight: 0 is load-bearing. A flex item defaults to min-height:auto,
             which refuses to shrink below its content, so without this the drawer
             would push the form off the bottom instead of taking space from it. */}
-        <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '24px 28px 40px' }}>
-          <div style={{ maxWidth: 680, margin: '0 auto' }}>
+        <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '24px 44px 40px' }}>
+          <div style={{ maxWidth: 740, margin: '0 auto' }}>
             {(runError || pioneerError) && (
               <div
                 style={{

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -280,6 +280,11 @@ export default function App() {
   const [modNote, setModNote] = useState({ fixed: '', variable: '' })
 
   const [jobs, setJobs] = useState<Job[]>([])
+
+  /** Shown in the sidebar footer. `pioneer` versions the CLI tools and the
+   *  converter together — they ship as one distribution — and `app` is this
+   *  window. Either can be blank: an older distribution has no VERSION file. */
+  const [versions, setVersions] = useState({ app: '', pioneer: '' })
   const [viewJobId, setViewJobId] = useState<string | null>(null)
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [drawerHeight, setDrawerHeight] = useState(300)
@@ -389,8 +394,15 @@ export default function App() {
     // the detail this used to print at the bottom of every page.
     backend
       .pioneerInfo()
-      .then(() => setPioneerError(''))
+      .then((info) => {
+        setPioneerError('')
+        setVersions((v) => ({ ...v, pioneer: info.version ?? '' }))
+      })
       .catch((e) => setPioneerError(String(e)))
+    backend
+      .appVersion()
+      .then((app) => setVersions((v) => ({ ...v, app })))
+      .catch(() => {})
   }, [])
 
   useEffect(() => {
@@ -1420,6 +1432,7 @@ export default function App() {
     >
       <Sidebar
         collapsed={navCollapsed}
+        versions={versions}
         selected={command}
         jobs={jobs}
         viewJobId={viewJobId}

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -597,7 +597,13 @@ export default function App() {
           setConvert((c) => ({ ...c, input: path, inputMode: isDir ? 'folder' : 'file' }))
           return
         }
-        onParam(key, path)
+        // `data-key` doubles as the scroll target for validation errors, and
+        // ConvertRAW's output field is keyed `convertOutput` while the state it
+        // writes is `outputDir`. Every other droppable field happens to use the
+        // same name for both, so a plain onParam(key, ...) silently wrote a
+        // field nothing reads and the drop appeared to do nothing at all.
+        const DROP_KEY_TO_FIELD: Record<string, string> = { convertOutput: 'outputDir' }
+        onParam(DROP_KEY_TO_FIELD[key] ?? key, path)
       })()
     }).then((un) => {
       if (cancelled) un()

--- a/gui/src/components/BuildSpecLibForm.tsx
+++ b/gui/src/components/BuildSpecLibForm.tsx
@@ -481,7 +481,7 @@ export function BuildSpecLibForm({
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-      <section style={CARD}>
+      <section style={CARD} data-drop="fastaAdd">
         <div
           style={{
             display: 'flex',

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -350,6 +350,9 @@ interface Props {
   onReorderQueued: (dragId: string, dropId: string) => void
   /** Give a run a different name. Collisions are resolved by the caller. */
   onRenameJob: (id: string, title: string) => void
+  /** Distribution version (CLI tools + converter) and this window's version.
+   *  Either may be blank when it could not be determined. */
+  versions: { app: string; pioneer: string }
 }
 
 export function Sidebar({
@@ -366,6 +369,7 @@ export function Sidebar({
   onJobAction,
   onReorderQueued,
   onRenameJob,
+  versions,
 }: Props) {
   const [themeOpen, setThemeOpen] = useState(false)
   const [query, setQuery] = useState('')
@@ -1062,8 +1066,35 @@ export function Sidebar({
         </div>
       </div>
 
-
-
+      {/* Which Pioneer this window is driving. Worth having on screen rather
+          than in an About box: the GUI runs whatever distribution it resolved,
+          which is not necessarily the one someone thinks they installed, and
+          the first question about any odd result is what version produced it.
+          Collapsed, the strip has no room for it -- the title carries it. */}
+      {!collapsed && (versions.pioneer || versions.app) && (
+        <div
+          title={[
+            versions.pioneer && `Pioneer CLI and converter ${versions.pioneer}`,
+            versions.app && `Console ${versions.app}`,
+          ]
+            .filter(Boolean)
+            .join('\n')}
+          style={{
+            flex: 'none',
+            padding: '8px 13px 10px',
+            borderTop: '1px solid var(--pio-nav-hair)',
+            color: 'var(--pio-nav-fg-dim)',
+            font: "11px 'IBM Plex Sans'",
+            letterSpacing: 0.2,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {versions.pioneer ? `Pioneer ${versions.pioneer}` : 'Pioneer'}
+          {versions.app && ` \u00b7 console ${versions.app}`}
+        </div>
+      )}
     </aside>
   )
 }

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -609,6 +609,11 @@ export function Sidebar({
                         lineHeight: 1.25,
                       }}
                     >
+                      {/* The name and its rename button share a line. The
+                          parent is a column -- name, descriptor, progress bar --
+                          so without this row the pencil stacks underneath the
+                          name instead of sitting after it. */}
+                      <span style={{ display: 'flex', alignItems: 'center', maxWidth: '100%' }}>
                       {editingJobId === j.id ? (
                         <input
                           autoFocus
@@ -660,6 +665,40 @@ export function Sidebar({
                           {j.title}
                         </span>
                       )}
+                      {editingJobId !== j.id && (
+                        <button
+                          type="button"
+                          className="pio-jobact pio-iconbtn"
+                          title="Rename"
+                          onClick={(e) => {
+                            // The name sits inside the row's open-this-run
+                            // click target, so the rename must not also open it.
+                            e.stopPropagation()
+                            setEditingJobId(j.id)
+                            setEditingTitle(j.title)
+                          }}
+                          style={{
+                            flex: 'none',
+                            border: 'none',
+                            background: 'none',
+                            cursor: 'pointer',
+                            padding: 0,
+                            marginLeft: 5,
+                            color: 'var(--pio-nav-fg-dim)',
+                            display: 'flex',
+                          }}
+                        >
+                          <svg width="11" height="11" viewBox="0 0 24 24" fill="none">
+                            <path
+                              d="M4 20h4L19 9a2.1 2.1 0 0 0-3-3L5 17v3Z"
+                              stroke="currentColor"
+                              strokeWidth="1.9"
+                              strokeLinejoin="round"
+                            />
+                          </svg>
+                        </button>
+                      )}
+                      </span>
                       {/* The descriptor is unconditional. It used to be the
                           else-branch of `running`, so the bar replaced it and a
                           running row was the one place the command and status
@@ -715,39 +754,6 @@ export function Sidebar({
                     </span>
                   )}
                 </div>
-                {/* Queued, running or finished alike: the name is a label, and
-                    the run worth renaming is often the one that already
-                    finished. Hidden until the row is hovered, like the other
-                    row actions. */}
-                {!collapsed && editingJobId !== j.id && (
-                  <button
-                    type="button"
-                    className="pio-jobact pio-iconbtn"
-                    onClick={() => {
-                      setEditingJobId(j.id)
-                      setEditingTitle(j.title)
-                    }}
-                    title="Rename"
-                    style={{
-                      flex: 'none',
-                      border: 'none',
-                      background: 'none',
-                      cursor: 'pointer',
-                      padding: 3,
-                      color: 'var(--pio-nav-fg-dim)',
-                      display: 'flex',
-                    }}
-                  >
-                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none">
-                      <path
-                        d="M4 20h4L19 9a2.1 2.1 0 0 0-3-3L5 17v3Z"
-                        stroke="currentColor"
-                        strokeWidth="1.8"
-                        strokeLinejoin="round"
-                      />
-                    </svg>
-                  </button>
-                )}
                 {pending && (
                   <button
                     type="button"

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -803,7 +803,7 @@ export function Sidebar({
   return (
     <aside
       style={{
-        width: collapsed ? 66 : 252,
+        width: collapsed ? 66 : 276,
         flex: 'none',
         background: 'var(--pio-nav)',
         color: 'var(--pio-nav-fg)',

--- a/gui/src/lib/backend.ts
+++ b/gui/src/lib/backend.ts
@@ -34,6 +34,8 @@ export interface ExitEvent {
 
 export const pioneerInfo = (): Promise<PioneerInfo> => invoke('pioneer_info')
 
+export const appVersion = (): Promise<string> => invoke('app_version')
+
 export const cpuCount = (): Promise<number> => invoke('cpu_count')
 
 export async function inspectPath(path: string): Promise<PathInfo> {

--- a/gui/src/lib/recent.ts
+++ b/gui/src/lib/recent.ts
@@ -13,7 +13,7 @@ import type { Job } from './types'
 import { downloadTargetPath, libraryTargetPath } from './validate'
 
 /** The library a run either used or produced, if any. */
-function libraryOf(job: Job): string {
+export function libraryOf(job: Job): string {
   switch (job.snapshot.cmd) {
     case 'searchdia':
       return job.snapshot.search.library.trim()

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -388,4 +388,6 @@ export interface PioneerInfo {
   source: string
   executables: string[]
   has_wrapper: boolean
+  /** From the distribution's VERSION file; absent on older distributions. */
+  version: string | null
 }

--- a/gui/src/lib/validate.ts
+++ b/gui/src/lib/validate.ts
@@ -131,6 +131,26 @@ export function msDataNote(value: string, info: PathInfo): Note {
   return NONE
 }
 
+/**
+ * `libraryNote`, except that the path a queued build or download is about to
+ * produce is reported as pending rather than missing.
+ *
+ * Without this the field contradicts the button: `validateSearchRun` lets the
+ * search be queued behind the job that makes its library, while the note under
+ * the field still calls the path an error.
+ */
+export function pendingLibraryNote(
+  value: string,
+  info: PathInfo,
+  pendingLibrary: string | null,
+): Note {
+  const note = libraryNote(value, info)
+  if (note.level !== 'error') return note
+  if (pendingLibrary === null || value.trim() !== pendingLibrary) return note
+  if (info.exists) return note
+  return { level: 'warn', msg: 'Being built by a queued run — this search will wait for it.' }
+}
+
 /** A spectral library is a *directory* of Arrow/JLD2/JLS tables, not a single
  *  file, so the design's extension test is not sufficient: an empty folder
  *  named `lib.poin` passes it and then fails deep inside Pioneer with
@@ -256,17 +276,33 @@ export interface RunBlock {
   msg: string
 }
 
+/**
+ * @param pendingLibrary Path a queued or running BuildSpecLib/DownloadSpecLib
+ *   job will produce, or null when no such job is waiting.
+ */
 export function validateSearchRun(
   values: { msData: string; library: string; results: string; qValue: string; nIsotopes: string; nce: string; minPeptides: string },
   notes: { msData: Note; library: Note; results: Note },
+  pendingLibrary: string | null = null,
 ): RunBlock | null {
   if (!values.msData.trim()) return { key: 'msData', msg: 'Set the MS data path before running.' }
   if (notes.msData.level === 'error') return { key: 'msData', msg: notes.msData.msg }
 
-  if (!values.library.trim()) {
-    return { key: 'library', msg: 'Set the spectral library path before running.' }
+  // A library that is still being predicted is not a missing library. With a
+  // build or download ahead of it in the queue, the search that consumes its
+  // output can be queued behind it -- the folder does not exist while the
+  // search sits in the queue, and does by the time it starts. Only that one
+  // path earns the exemption: any other path that does not exist is still the
+  // mistake it always was.
+  const awaitsPending =
+    pendingLibrary !== null && values.library.trim() === pendingLibrary
+
+  if (!awaitsPending) {
+    if (!values.library.trim()) {
+      return { key: 'library', msg: 'Set the spectral library path before running.' }
+    }
+    if (notes.library.level === 'error') return { key: 'library', msg: notes.library.msg }
   }
-  if (notes.library.level === 'error') return { key: 'library', msg: notes.library.msg }
 
   if (!values.results.trim()) {
     return { key: 'results', msg: 'Set the results path before running.' }


### PR DESCRIPTION
Seven items from Dennis.

- ConvertRAW's output field accepts drops (it was keyed `convertOutput` but wrote `outputDir`, so the drop set a property nothing reads).
- The whole FASTA card is a drop target, so several files can be added at once.
- Window 980 -> 1140, sidebar 252 -> 276, page gutters 34 -> 62px, content column 680 -> 740.
- A search can be queued behind the build or download that produces its library.
- Sidebar footer shows the Pioneer distribution version and the console version; GUI bumped 0.1.0 -> 0.9.0.
- The rename pencil moved onto the same line as the run name.

Verified in the running app: multi-FASTA drop, the version footer, and the widened layout. The ConvertRAW output drop and the pending-library queue are code-verified only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)