### PR TITLE
feat: add MST run normalization and MBR protein counterfactuals

### DIFF
--- a/src/Routines/SearchDIA/SearchMethods/MBR/pipeline.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MBR/pipeline.jl
@@ -202,6 +202,8 @@ function _write_mbr_recovery_sidecars_from_candidates!(
     cand_ftr_pep   = candidates[!, :ftr_pep_true]
     cand_tot_q     = candidates[!, :mbr_total_error_qval_true]
     cand_tot_r     = candidates[!, :mbr_total_error_rate_true]
+    cand_cf_prob   = candidates[!, MBR_COUNTERFACTUAL_DECOY_PROB_COLUMN]
+    cand_cf_idx    = candidates[!, MBR_COUNTERFACTUAL_DECOY_INDEX_COLUMN]
     cursor = 0
     for (file_idx, path) in enumerate(file_paths)
         main = Arrow.Table(path)
@@ -216,6 +218,8 @@ function _write_mbr_recovery_sidecars_from_candidates!(
         ftr_pep   = fill(NaN32, n)
         tot_q     = fill(NaN32, n)
         tot_r     = fill(NaN32, n)
+        cf_prob   = fill(NaN32, n)
+        cf_idx    = zeros(UInt8, n)
         @inbounds for row in 1:n
             mask[row] || continue
             cursor += 1
@@ -230,6 +234,8 @@ function _write_mbr_recovery_sidecars_from_candidates!(
             ftr_pep[row]   = cand_ftr_pep[cursor]
             tot_q[row]     = cand_tot_q[cursor]
             tot_r[row]     = cand_tot_r[cursor]
+            cf_prob[row]   = cand_cf_prob[cursor]
+            cf_idx[row]    = cand_cf_idx[cursor]
         end
         writeArrow(path * RECOVERY_SIDECAR_SUFFIX, DataFrame(
             precursor_idx = UInt32.(main.precursor_idx),
@@ -241,6 +247,8 @@ function _write_mbr_recovery_sidecars_from_candidates!(
             ftr_pep_true = ftr_pep,
             mbr_total_error_qval_true = tot_q,
             mbr_total_error_rate_true = tot_r,
+            mbr_counterfactual_decoy_prob = cf_prob,
+            mbr_counterfactual_decoy_index = cf_idx,
         ))
     end
     cursor == nrow(candidates) ||
@@ -281,6 +289,12 @@ function _write_mbr_recovery_sidecars!(
                 Float32.(frame.mbr_total_error_qval_true[rows]),
             mbr_total_error_rate_true =
                 Float32.(frame.mbr_total_error_rate_true[rows]),
+            mbr_counterfactual_decoy_prob = Float32.(
+                frame[rows, MBR_COUNTERFACTUAL_DECOY_PROB_COLUMN]
+            ),
+            mbr_counterfactual_decoy_index = UInt8.(
+                frame[rows, MBR_COUNTERFACTUAL_DECOY_INDEX_COLUMN]
+            ),
         )
         writeArrow(path * RECOVERY_SIDECAR_SUFFIX, recovery)
         offset += n
@@ -406,6 +420,16 @@ function _merge_mbr_recoveries!(
             _copy_sidecar_column!(Vector{Float32}(undef, n), recovery.mbr_total_error_qval_true)
         main[!, :mbr_total_error_rate_true] =
             _copy_sidecar_column!(Vector{Float32}(undef, n), recovery.mbr_total_error_rate_true)
+        main[!, MBR_COUNTERFACTUAL_DECOY_PROB_COLUMN] =
+            _copy_sidecar_column!(
+                Vector{Float32}(undef, n),
+                Tables.getcolumn(recovery, MBR_COUNTERFACTUAL_DECOY_PROB_COLUMN),
+            )
+        main[!, MBR_COUNTERFACTUAL_DECOY_INDEX_COLUMN] =
+            _copy_sidecar_column!(
+                Vector{UInt8}(undef, n),
+                Tables.getcolumn(recovery, MBR_COUNTERFACTUAL_DECOY_INDEX_COLUMN),
+            )
         _mmark(:mr_copycols)
 
         # Same hoist as the alignment check above: these were three DataFrame `getproperty` calls per
@@ -423,12 +447,22 @@ function _merge_mbr_recoveries!(
             recovered = main[!, :mbr_recovered]
             transfer = main[!, :mbr_target_decoy_prob]
             prec_prob = main[!, :prec_prob]
+            counterfactual = main[!, MBR_COUNTERFACTUAL_DECOY_PROB_COLUMN]
+            counterfactual_prec_prob = fill(NaN32, nrow(main))
             @inbounds for row in eachindex(recovered)
-                Bool(recovered[row]) || continue
-                transfer_score =
-                    clamp(Float32(transfer[row]), 0.0f0, 1.0f0)
-                prec_prob[row] = score_floor + width * transfer_score
+                if Bool(recovered[row])
+                    transfer_score =
+                        clamp(Float32(transfer[row]), 0.0f0, 1.0f0)
+                    prec_prob[row] = score_floor + width * transfer_score
+                end
+                counterfactual_score = Float32(counterfactual[row])
+                if isfinite(counterfactual_score)
+                    counterfactual_prec_prob[row] = score_floor + width *
+                        clamp(counterfactual_score, 0.0f0, 1.0f0)
+                end
             end
+            main[!, MBR_COUNTERFACTUAL_DECOY_PRECURSOR_PROB_COLUMN] =
+                counterfactual_prec_prob
         end
         writeArrow(path, main)
         _mmark(:mr_write)
@@ -464,14 +498,32 @@ function _remap_mbr_scores!(
         path = file_path(ref)
         main = DataFrame(Tables.columntable(Arrow.Table(path)))
         hasproperty(main, :mbr_recovered) || continue
+        has_counterfactual =
+            hasproperty(main, MBR_COUNTERFACTUAL_DECOY_PROB_COLUMN)
+        counterfactual_prec_prob = has_counterfactual ?
+            fill(NaN32, nrow(main)) : Float32[]
         @inbounds for row in 1:nrow(main)
-            Bool(main.mbr_recovered[row]) || continue
-            transfer_score = clamp(
-                Float32(main.mbr_target_decoy_prob[row]),
-                0.0f0,
-                1.0f0,
-            )
-            main.prec_prob[row] = score_floor + width * transfer_score
+            if Bool(main.mbr_recovered[row])
+                transfer_score = clamp(
+                    Float32(main.mbr_target_decoy_prob[row]),
+                    0.0f0,
+                    1.0f0,
+                )
+                main.prec_prob[row] = score_floor + width * transfer_score
+            end
+            if has_counterfactual
+                counterfactual_score = Float32(
+                    main[row, MBR_COUNTERFACTUAL_DECOY_PROB_COLUMN]
+                )
+                if isfinite(counterfactual_score)
+                    counterfactual_prec_prob[row] = score_floor + width *
+                        clamp(counterfactual_score, 0.0f0, 1.0f0)
+                end
+            end
+        end
+        if has_counterfactual
+            main[!, MBR_COUNTERFACTUAL_DECOY_PRECURSOR_PROB_COLUMN] =
+                counterfactual_prec_prob
         end
         writeArrow(path, main)
     end

--- a/src/Routines/SearchDIA/SearchMethods/MBR/rescoring.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MBR/rescoring.jl
@@ -956,12 +956,13 @@ function _mbr_semisupervised_oof(
     return best_state, present
 end
 
-function _mbr_top_counterfactual_scores(
+function _mbr_top_counterfactual_controls(
     scores::Vector{Float32},
     present::BitMatrix,
 )
     n_candidates, n_counterfactuals = size(present)
     top_scores = fill(-Inf32, n_candidates)
+    top_indices = zeros(UInt8, n_candidates)
     @inbounds for candidate_idx in 1:n_candidates
         for counterfactual_idx in 1:n_counterfactuals
             present[candidate_idx, counterfactual_idx] || continue
@@ -970,10 +971,18 @@ function _mbr_top_counterfactual_scores(
             ]
             if isfinite(score) && score > top_scores[candidate_idx]
                 top_scores[candidate_idx] = score
+                top_indices[candidate_idx] = UInt8(counterfactual_idx)
             end
         end
     end
-    return top_scores
+    return (scores = top_scores, indices = top_indices)
+end
+
+function _mbr_top_counterfactual_scores(
+    scores::Vector{Float32},
+    present::BitMatrix,
+)
+    return _mbr_top_counterfactual_controls(scores, present).scores
 end
 
 function _mbr_combined_error_recovery(
@@ -1128,6 +1137,8 @@ function apply_postintegration_mbr_rescoring!(
     frame[!, :ftr_pep_true] = fill(NaN32, n)
     frame[!, :mbr_total_error_qval_true] = fill(NaN32, n)
     frame[!, :mbr_total_error_rate_true] = fill(NaN32, n)
+    frame[!, MBR_COUNTERFACTUAL_DECOY_PROB_COLUMN] = fill(NaN32, n)
+    frame[!, MBR_COUNTERFACTUAL_DECOY_INDEX_COLUMN] = zeros(UInt8, n)
     n == 0 && return (
         n_candidates = 0,
         n_recovered = 0,
@@ -1204,10 +1215,11 @@ function apply_postintegration_mbr_rescoring!(
         evaluated_top[candidate_idx] ||
             (real_scores[candidate_idx] = NaN32)
     end
-    false_scores = _mbr_top_counterfactual_scores(
+    counterfactual_controls = _mbr_top_counterfactual_controls(
         best_state.scores,
         present,
     )
+    false_scores = counterfactual_controls.scores
     combined = _mbr_combined_error_recovery(
         real_scores,
         BitVector(candidates.target),
@@ -1232,6 +1244,17 @@ function apply_postintegration_mbr_rescoring!(
             combined.qvalues[candidate_position]
         frame[row, :mbr_total_error_rate_true] =
             combined.rates[candidate_position]
+        if Bool(candidates.target[candidate_position]) &&
+           isfinite(combined.threshold) &&
+           isfinite(real_scores[candidate_position]) &&
+           isfinite(false_scores[candidate_position]) &&
+           real_scores[candidate_position] >= combined.threshold &&
+           false_scores[candidate_position] >= combined.threshold
+            frame[row, MBR_COUNTERFACTUAL_DECOY_PROB_COLUMN] =
+                false_scores[candidate_position]
+            frame[row, MBR_COUNTERFACTUAL_DECOY_INDEX_COLUMN] =
+                counterfactual_controls.indices[candidate_position]
+        end
     end
 
     internal_targets = combined.mbr_targets

--- a/src/Routines/SearchDIA/SearchMethods/MBR/types.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MBR/types.jl
@@ -32,6 +32,17 @@ const PASS1_SIDECAR_SUFFIX = ".pass1_sidecar.arrow"
 const MBR_SIDECAR_SUFFIX = ".mbr_sidecar.arrow"
 const RECOVERY_SIDECAR_SUFFIX = ".recovery_sidecar.arrow"
 
+# Training-only counterfactual evidence retained from the MBR transfer model.
+# The raw score and counterfactual block index are transient; the remapped
+# precursor probability survives into protein scoring so target-backed shadow
+# protein groups can be constructed on the same scale as real transfers.
+const MBR_COUNTERFACTUAL_DECOY_PROB_COLUMN =
+    :mbr_counterfactual_decoy_prob
+const MBR_COUNTERFACTUAL_DECOY_INDEX_COLUMN =
+    :mbr_counterfactual_decoy_index
+const MBR_COUNTERFACTUAL_DECOY_PRECURSOR_PROB_COLUMN =
+    :mbr_counterfactual_decoy_prec_prob
+
 const MBR_SMOOTHED_SPECTRUM_EMPTY_SQRT = ntuple(_ -> 0.0f0, 8)
 const MBR_INTEGRATED_FRAGMENT_SQRT_COLUMNS = ntuple(
     rank -> Symbol("MBR_integrated_frag$(rank)_sqrt"),

--- a/src/Routines/SearchDIA/SearchMethods/MaxLFQSearch/MaxLFQSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MaxLFQSearch/MaxLFQSearch.jl
@@ -165,9 +165,13 @@ function summarize_results!(
     # MaxLFQ expects).
     indexed_paths = get_all_indexed_paths(getPassingPsms, search_context)
     existing_passing_psm_paths = String[]
-    for (_, path) in indexed_paths
+    existing_passing_psm_run_ids = UInt32[]
+    for (file_idx, path) in indexed_paths
         ref = PSMFileReference(path)
-        row_count(ref) > 0 && push!(existing_passing_psm_paths, path)
+        if row_count(ref) > 0
+            push!(existing_passing_psm_paths, path)
+            push!(existing_passing_psm_run_ids, UInt32(file_idx))
+        end
     end
 
     # Get all file names (needed for LFQ indexing by experiment ID)
@@ -192,11 +196,20 @@ function summarize_results!(
     # IntegrateChromatograms already populates :peak_area_normalized with
     # placeholder zeros, so a missing column never breaks downstream.
     if params.run_to_run_normalization
+        precursor_scoring_results = get_results(
+            search_context,
+            PrecursorScoringSearch,
+        )
+        run_similarity_atlas =
+            precursor_scoring_results isa PrecursorScoringSearchResults ?
+            precursor_scoring_results.run_similarity[] : nothing
         normalizeQuant(
             [file_path(ref) for ref in psm_refs],
             :peak_area,
             N = MAXLFQ_NORM_N_RT_BINS,
-            spline_n_knots = MAXLFQ_NORM_SPLINE_N_KNOTS
+            spline_n_knots = MAXLFQ_NORM_SPLINE_N_KNOTS,
+            run_ids = existing_passing_psm_run_ids,
+            run_similarity_atlas = run_similarity_atlas,
         )
     end
 

--- a/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/PrecursorScoringSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/PrecursorScoringSearch.jl
@@ -205,6 +205,10 @@ const PRECSCORE_DROPPABLE_COLUMNS = Symbol[
     # :mbr_recovered survives and is the flag that says whether a row was transferred.
     :mbr_target_decoy_prob, :mbr_total_error_qval_true, :mbr_total_error_rate_true,
     :ftr_qval_true, :ftr_pep_true,
+    # Defined in MBR/types.jl, which is loaded after this module file. Keep the
+    # literals here so the raw controls are dropped only after protein scoring
+    # has consumed their remapped probability.
+    :mbr_counterfactual_decoy_prob, :mbr_counterfactual_decoy_index,
     # Same physical measurement as :rt_fwhm but in library iRT units, which are only interpretable
     # relative to the library. :rt_fwhm is kept, in minutes.
     :irt_fwhm,

--- a/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/model_fit.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/model_fit.jl
@@ -655,7 +655,8 @@ function _protein_model_training_data_sufficient(
     all_protein_groups::DataFrame,
     cv_folds::Vector{UInt8},
 )
-    targets = all_protein_groups.target
+    targets = hasproperty(all_protein_groups, :training_label) ?
+        all_protein_groups.training_label : all_protein_groups.target
     folds = all_protein_groups.cv_fold
     for test_fold in cv_folds
         n_train_targets = 0
@@ -744,12 +745,18 @@ function perform_protein_scoring_multifold(
             train_mask = all_protein_groups.cv_fold .!= test_fold
             train_df = all_protein_groups[train_mask, :]
 
-            y_train = train_df.target
+            y_train = hasproperty(train_df, :training_label) ?
+                train_df.training_label : train_df.target
             initial_scores_train = train_df.pg_score
             context = "protein_lightgbm_multifold_fold_$(test_fold)"
+            plot_df = train_df
+            if write_qc_plots && hasproperty(train_df, :training_label)
+                plot_df = copy(train_df)
+                plot_df[!, :target] = Bool.(train_df.training_label)
+            end
             iteration_debug_callback = write_qc_plots ?
                 make_protein_iteration_plot_callback(
-                    train_df,
+                    plot_df,
                     test_fold,
                     qc_folder;
                     context = context,
@@ -805,7 +812,15 @@ function perform_protein_scoring_multifold(
         )
     end
     
-    # Clean up temporary column
-    select!(all_protein_groups, Not(:cv_fold))
+    # Clean up temporary columns.
+    columns_to_remove = Symbol[:cv_fold]
+    for column in (
+        :training_label,
+        :protein_shadow_negative,
+    )
+        hasproperty(all_protein_groups, column) &&
+            push!(columns_to_remove, column)
+    end
+    select!(all_protein_groups, Not(columns_to_remove))
     return use_model_scores
 end

--- a/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/protein_inference_pipeline.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/protein_inference_pipeline.jl
@@ -1907,6 +1907,75 @@ High-Level Interface
 ==========================================================#
 
 """
+    _mbr_counterfactual_shadow_psms(psms; q_value_threshold = 0.01f0)
+
+Create one training-only counterfactual PSM for each target protein/run whose
+quantitative support consists entirely of MBR recoveries. The hardest retained
+counterfactual transfer is selected and its remapped probability replaces
+`prec_prob`. Protein identity is deliberately preserved so the shadow and the
+real protein are assigned to the same cross-validation fold.
+"""
+function _mbr_counterfactual_shadow_psms(
+    psms::DataFrame;
+    q_value_threshold::Float32 = 0.01f0,
+)
+    required_columns = (
+        :inferred_protein_group,
+        :target,
+        :entrap_id,
+        :use_for_protein_quant,
+        :mbr_recovered,
+        :prec_prob,
+        MBR_COUNTERFACTUAL_DECOY_PRECURSOR_PROB_COLUMN,
+    )
+    all(column -> hasproperty(psms, column), required_columns) ||
+        return DataFrame()
+
+    selected_rows = Int[]
+    for protein_psms in groupby(
+        psms,
+        [:inferred_protein_group, :target, :entrap_id],
+    )
+        Bool(protein_psms.target[1]) || continue
+        UInt8(protein_psms.entrap_id[1]) == zero(UInt8) || continue
+        ismissing(protein_psms.inferred_protein_group[1]) && continue
+
+        quant_mask = _protein_rollup_quant_mask(
+            protein_psms;
+            q_value_threshold = q_value_threshold,
+        )
+        quant_rows = findall(quant_mask)
+        isempty(quant_rows) && continue
+        all(row -> Bool(protein_psms.mbr_recovered[row]), quant_rows) ||
+            continue
+
+        best_local_row = 0
+        best_probability = -Inf32
+        @inbounds for row in quant_rows
+            probability = Float32(
+                protein_psms[
+                    row,
+                    MBR_COUNTERFACTUAL_DECOY_PRECURSOR_PROB_COLUMN,
+                ]
+            )
+            if isfinite(probability) && probability > best_probability
+                best_probability = probability
+                best_local_row = row
+            end
+        end
+        best_local_row == 0 && continue
+        push!(selected_rows, parentindices(protein_psms)[1][best_local_row])
+    end
+
+    isempty(selected_rows) && return DataFrame()
+    shadows = copy(psms[selected_rows, :])
+    shadows[!, :prec_prob] = Float32.(
+        shadows[!, MBR_COUNTERFACTUAL_DECOY_PRECURSOR_PROB_COLUMN]
+    )
+    return shadows
+end
+
+"""
     build_protein_group_tables(
         psm_refs,
         output_folder,
@@ -1948,6 +2017,7 @@ function build_protein_group_tables(
     pg_refs = ProteinGroupFileReference[]
     psm_to_pg_mapping = Dict{String, String}()
     protein_to_cv_fold = Dictionary{String, @NamedTuple{best_score::Float32, cv_fold::UInt8}}()
+    counterfactual_shadow_protein_groups = DataFrame()
     indexed_refs = collect(enumerate(psm_refs))
 
     precursor_consensus = build_precursor_consensus(
@@ -1966,6 +2036,11 @@ function build_protein_group_tables(
         updated_psms = load_dataframe(psm_ref)
         _update_protein_cv_fold_mapping!(protein_to_cv_fold, updated_psms, precursors)
         peak_area_calibration = estimate_peak_area_detection_model(updated_psms)
+
+        shadow_psms = _mbr_counterfactual_shadow_psms(
+            updated_psms;
+            q_value_threshold = q_value_threshold,
+        )
 
         protein_groups_df = group_psms_by_protein(
             updated_psms;
@@ -2006,6 +2081,53 @@ function build_protein_group_tables(
             protein_groups_df = op(protein_groups_df)
         end
 
+        if nrow(shadow_psms) > 0
+            shadow_groups = group_psms_by_protein(
+                shadow_psms;
+                precursor_consensus = precursor_consensus,
+                current_run_order = Int64(idx),
+                q_value_threshold = q_value_threshold,
+            )
+            for (desc, op) in post_inference_pipeline.operations
+                shadow_groups = op(shadow_groups)
+            end
+
+            shadow_shared_precursor_peak_areas =
+                Dict{ProteinKey, Dict{UInt32, Float32}}()
+            add_ambiguous_pg_score!(
+                shadow_groups,
+                shadow_psms,
+                protein_ambiguity_candidates;
+                q_value_threshold = q_value_threshold,
+                shared_precursor_peak_areas =
+                    shadow_shared_precursor_peak_areas,
+            )
+            add_shared_precursor_consensus_shape!(
+                shadow_groups,
+                shadow_shared_precursor_peak_areas,
+                precursor_consensus.shared;
+                current_run_order = Int64(idx),
+            )
+            for (desc, op) in feature_pipeline.operations
+                shadow_groups = op(shadow_groups)
+            end
+            if nrow(shadow_groups) > 0
+                run_idx = hasproperty(updated_psms, :ms_file_idx) ?
+                    Int64(updated_psms.ms_file_idx[1]) : Int64(idx)
+                shadow_groups[!, :file_idx] =
+                    fill(run_idx, nrow(shadow_groups))
+                if ncol(counterfactual_shadow_protein_groups) == 0
+                    counterfactual_shadow_protein_groups = shadow_groups
+                else
+                    append!(
+                        counterfactual_shadow_protein_groups,
+                        shadow_groups;
+                        cols = :union,
+                    )
+                end
+            end
+        end
+
         pg_filename = "protein_groups_$(lpad(idx, 3, '0')).arrow"
         pg_path = joinpath(output_folder, pg_filename)
 
@@ -2023,5 +2145,12 @@ function build_protein_group_tables(
         end
     end
 
-    return pg_refs, psm_to_pg_mapping, protein_to_cv_fold
+    @debug_l1 "Built $(nrow(counterfactual_shadow_protein_groups)) " *
+              "target-backed counterfactual shadow protein negatives"
+    return (
+        pg_refs,
+        psm_to_pg_mapping,
+        protein_to_cv_fold,
+        counterfactual_shadow_protein_groups,
+    )
 end

--- a/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/run_protein_scoring.jl
+++ b/src/Routines/SearchDIA/SearchMethods/ProteinScoringSearch/run_protein_scoring.jl
@@ -66,6 +66,52 @@ function load_run_level_protein_training_rows(
 end
 
 """
+    prepare_run_level_protein_training_rows(actual, counterfactual_shadows)
+
+Attach explicit labels for run-level protein training. Existing protein-group
+rows retain their ordinary target/decoy labels. Counterfactual shadow rows
+retain the target protein identity (and therefore its CV fold) while carrying
+a negative training label.
+"""
+function prepare_run_level_protein_training_rows(
+    actual::DataFrame,
+    counterfactual_shadows::DataFrame,
+)
+    prepared_actual = copy(actual)
+    n_actual = nrow(prepared_actual)
+    prepared_actual[!, :training_label] = Bool.(prepared_actual.target)
+    prepared_actual[!, :protein_shadow_negative] = falses(n_actual)
+
+    if nrow(counterfactual_shadows) == 0
+        return (
+            rows = prepared_actual,
+            n_shadows = 0,
+        )
+    end
+
+    actual_columns = Symbol.(names(actual))
+    missing_columns = [
+        column for column in actual_columns
+        if !hasproperty(counterfactual_shadows, column)
+    ]
+    isempty(missing_columns) || error(
+        "Counterfactual shadow protein rows are missing columns: " *
+        string(missing_columns),
+    )
+    prepared_shadows = select(copy(counterfactual_shadows), actual_columns)
+    prepared_shadows[!, :training_label] =
+        falses(nrow(prepared_shadows))
+    prepared_shadows[!, :protein_shadow_negative] =
+        trues(nrow(prepared_shadows))
+
+    append!(prepared_actual, prepared_shadows)
+    return (
+        rows = prepared_actual,
+        n_shadows = nrow(prepared_shadows),
+    )
+end
+
+"""
     perform_run_level_protein_scoring(pg_refs::Vector{ProteinGroupFileReference},
                                       max_in_memory_rows::Int64,
                                       qc_folder::String,
@@ -88,6 +134,7 @@ function perform_run_level_protein_scoring(
     max_in_memory_rows::Int64,
     qc_folder::String,
     precursors::LibraryPrecursors;
+    counterfactual_shadow_protein_groups::DataFrame = DataFrame(),
     protein_to_cv_fold::Dictionary{String, @NamedTuple{best_score::Float32, cv_fold::UInt8}},
     file_idx_to_name::Union{Nothing, AbstractDict{Int64, String}} = nothing,
     write_qc_plots::Bool = true,
@@ -101,6 +148,7 @@ function perform_run_level_protein_scoring(
             total_protein_groups += row_count(ref)
         end
     end
+    total_protein_groups += nrow(counterfactual_shadow_protein_groups)
 
     max_protein_groups_in_memory_limit = max(max_in_memory_rows, 100_000)
 
@@ -108,14 +156,24 @@ function perform_run_level_protein_scoring(
         error("Run-level protein scoring does not support out-of-memory fitting. total_protein_groups=$(total_protein_groups) exceeds max_protein_groups_in_memory_limit=$(max_protein_groups_in_memory_limit).")
     end
 
-    all_protein_groups = load_run_level_protein_training_rows(
+    actual_protein_groups = load_run_level_protein_training_rows(
         pg_refs;
         include_qc_plot_columns = write_qc_plots
     )
+    prepared = prepare_run_level_protein_training_rows(
+        actual_protein_groups,
+        counterfactual_shadow_protein_groups,
+    )
+    all_protein_groups = prepared.rows
+    @debug_l1 "Run-level protein training controls: " *
+              "counterfactual shadows=$(prepared.n_shadows)"
 
-    n_targets = sum(all_protein_groups.target)
-    n_decoys = sum(.!all_protein_groups.target)
-    skip_scoring = !(n_targets > 50 && n_decoys > 50 && nrow(all_protein_groups) > 1000)
+    labels = all_protein_groups.training_label
+    n_targets = count(labels)
+    n_decoys = count(.!labels)
+    skip_scoring = !(
+        n_targets > 50 && n_decoys > 50 && nrow(all_protein_groups) > 1000
+    )
 
     return perform_protein_scoring_multifold(
         all_protein_groups,
@@ -166,7 +224,12 @@ function run_protein_scoring!(
         file_idx_to_name[Int64(file_idx)] = String(file_name)
     end
 
-    pg_refs, psm_to_pg_mapping, protein_to_cv_fold = build_protein_group_tables(
+    (
+        pg_refs,
+        psm_to_pg_mapping,
+        protein_to_cv_fold,
+        counterfactual_shadow_protein_groups,
+    ) = build_protein_group_tables(
         passing_refs,
         passing_proteins_folder,
         protein_peptide_opportunities,
@@ -194,6 +257,8 @@ function run_protein_scoring!(
         max_in_memory_rows,
         qc_folder,
         precursors;
+        counterfactual_shadow_protein_groups =
+            counterfactual_shadow_protein_groups,
         protein_to_cv_fold = protein_to_cv_fold,
         file_idx_to_name = file_idx_to_name,
         write_qc_plots = write_qc_plots,

--- a/src/utils/normalizeQuant.jl
+++ b/src/utils/normalizeQuant.jl
@@ -120,76 +120,26 @@ function _file_precursor_log2_quant(
 end
 
 """
-    _weighted_median(values, weights)
-
-Return the weighted median of `values`. When the cumulative weight lands
-exactly at half of the total, return the mean of the two adjacent values so
-that equal weights reproduce `Statistics.median`, including for even-length
-vectors.
-"""
-function _weighted_median(
-    values::AbstractVector{<:Real},
-    weights::AbstractVector{<:Real},
-)
-    length(values) == length(weights) || throw(DimensionMismatch(
-        "values and weights must have the same length"
-    ))
-    isempty(values) && throw(ArgumentError(
-        "weighted median requires at least one value"
-    ))
-
-    total_weight = 0.0
-    first_weight = Float64(first(weights))
-    equal_weights = true
-    @inbounds for weight in weights
-        w = Float64(weight)
-        (isfinite(w) && w > 0.0) || throw(ArgumentError(
-            "weighted median requires finite positive weights"
-        ))
-        equal_weights &= w == first_weight
-        total_weight += w
-    end
-    equal_weights && return Float64(median(values))
-
-    order = sortperm(values)
-    half_weight = total_weight / 2.0
-    cumulative_weight = 0.0
-    @inbounds for (position, index) in enumerate(order)
-        cumulative_weight += Float64(weights[index])
-        if cumulative_weight > half_weight
-            return Float64(values[index])
-        elseif cumulative_weight == half_weight && position < length(order)
-            return (Float64(values[index]) + Float64(values[order[position + 1]])) / 2.0
-        end
-    end
-    return Float64(values[last(order)])
-end
-
-"""
-    getPrecursorQuantReference(psms_paths, quant_col_name;
+    getPrecursorQuantConsensus(psms_paths, quant_col_name;
         precursor_col_name=:precursor_idx,
         min_run_fraction=QUANT_MIN_ANCHOR_RUN_FRACTION)
 
-Build cross-run reference abundances and completeness weights for matched
-precursors. Each reference is the median log2 abundance across runs in which
-the precursor was quantified. Its weight is the fraction of all runs in which
-it was quantified. Only precursors observed in at least `min_run_fraction` of
-runs (and at least two runs when multiple runs are present) are retained.
+Build a cross-run reference abundance for matched precursors. Each precursor's
+reference is the median log2 abundance across runs in which it was quantified.
+Only precursors observed in at least `min_run_fraction` of runs (and at least two
+runs when multiple runs are present) are retained as normalization anchors.
 
 The run-level de-duplication is deliberate: a precursor contributes at most one
-value per run to the reference and completeness count.
+value per run to the consensus.
 """
-function getPrecursorQuantReference(
+function getPrecursorQuantConsensus(
     psms_paths::Vector{String},
     quant_col_name::Symbol;
     precursor_col_name::Symbol = :precursor_idx,
     min_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION,
 )
-    n_runs = length(psms_paths)
-    required_runs = _required_anchor_runs(n_runs, min_run_fraction)
-    if required_runs == 0
-        return Dict{UInt32, Float32}(), Dict{UInt32, Float32}()
-    end
+    required_runs = _required_anchor_runs(length(psms_paths), min_run_fraction)
+    required_runs == 0 && return Dict{UInt32, Float32}()
 
     values_by_precursor = Dict{UInt32, Vector{Float32}}()
     for fpath in psms_paths
@@ -205,38 +155,11 @@ function getPrecursorQuantReference(
     end
 
     consensus = Dict{UInt32, Float32}()
-    completeness_weights = Dict{UInt32, Float32}()
     sizehint!(consensus, length(values_by_precursor))
-    sizehint!(completeness_weights, length(values_by_precursor))
     for (pid, values) in values_by_precursor
         length(values) >= required_runs || continue
         consensus[pid] = Float32(median(values))
-        completeness_weights[pid] = Float32(length(values) / n_runs)
     end
-    return consensus, completeness_weights
-end
-
-"""
-    getPrecursorQuantConsensus(psms_paths, quant_col_name;
-        precursor_col_name=:precursor_idx,
-        min_run_fraction=QUANT_MIN_ANCHOR_RUN_FRACTION)
-
-Return only the cross-run median log2 abundance from
-`getPrecursorQuantReference`. Retained for callers that do not need the
-completeness weights.
-"""
-function getPrecursorQuantConsensus(
-    psms_paths::Vector{String},
-    quant_col_name::Symbol;
-    precursor_col_name::Symbol = :precursor_idx,
-    min_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION,
-)
-    consensus, _ = getPrecursorQuantReference(
-        psms_paths,
-        quant_col_name;
-        precursor_col_name = precursor_col_name,
-        min_run_fraction = min_run_fraction,
-    )
     return consensus
 end
 
@@ -253,9 +176,7 @@ configurable fraction of runs. For each file, it then computes
 
 for those matched anchors, bins the residuals by observed iRT into bins of at
 least `min_bin_occupancy` anchors (at most `N` bins), and fits a `UniformSpline`
-mapping iRT to their completeness-weighted median residual. An anchor's weight
-is its observed-run fraction, so consistently quantified precursors have more
-influence without introducing a tuning parameter.
+mapping iRT to the median matched-precursor residual.
 
 Files whose matched-anchor count cannot support
 `_min_bins_for_spline(spline_n_knots)` such bins get no entry in the returned
@@ -272,7 +193,7 @@ function getQuantSplines(psms_paths::Vector{String},
     min_bin_occupancy::Int = QUANT_MIN_BIN_OCCUPANCY,
     min_anchor_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION,
     precursor_col_name::Symbol = :precursor_idx)
-    precursor_consensus, precursor_weights = getPrecursorQuantReference(
+    precursor_consensus = getPrecursorQuantConsensus(
         psms_paths,
         quant_col_name;
         precursor_col_name = precursor_col_name,
@@ -294,11 +215,8 @@ function getQuantSplines(psms_paths::Vector{String},
 
         anchor_rts = Float64[]
         anchor_residuals = Float64[]
-        anchor_weights = Float64[]
-        n_possible_anchors = min(length(file_values), length(precursor_consensus))
-        sizehint!(anchor_rts, n_possible_anchors)
-        sizehint!(anchor_residuals, n_possible_anchors)
-        sizehint!(anchor_weights, n_possible_anchors)
+        sizehint!(anchor_rts, min(length(file_values), length(precursor_consensus)))
+        sizehint!(anchor_residuals, min(length(file_values), length(precursor_consensus)))
         precursor_idx = psms[!, precursor_col_name]
         irt_obs = psms[!, :irt_obs]
         seen = Set{UInt32}()
@@ -317,13 +235,11 @@ function getQuantSplines(psms_paths::Vector{String},
             push!(seen, pid)
             push!(anchor_rts, rt)
             push!(anchor_residuals, Float64(file_logq - reference_logq))
-            push!(anchor_weights, Float64(precursor_weights[pid]))
         end
 
         order = sortperm(anchor_rts)
         anchor_rts = anchor_rts[order]
         anchor_residuals = anchor_residuals[order]
-        anchor_weights = anchor_weights[order]
         nanchors = length(anchor_rts)
 
         bins = _occupancy_bins(nanchors, min_bin_occupancy, N)
@@ -352,10 +268,7 @@ function getQuantSplines(psms_paths::Vector{String},
         median_rts = Vector{Float64}(undef, length(bins))
         for (i, b) in enumerate(bins)
             median_rts[i] = median(@view(anchor_rts[b]))
-            median_quant[i] = _weighted_median(
-                @view(anchor_residuals[b]),
-                @view(anchor_weights[b]),
-            )
+            median_quant[i] = median(@view(anchor_residuals[b]))
         end
 
         splinefit = UniformSpline(median_quant, median_rts, 3, spline_n_knots)
@@ -450,9 +363,9 @@ end
     normalizeQuant(second_quant_folder, quant_col_name; N=100, spline_n_knots=7)
 
 End-to-end RT-dependent quantification normalization. Reads all Arrow files,
-constructs a cross-run matched-precursor reference, fits completeness-weighted
-per-file residual splines, computes the cross-file median, and writes corrected
-abundances back to each file.
+constructs a cross-run matched-precursor reference, fits per-file residual
+splines, computes the cross-file median, and writes corrected abundances back
+to each file.
 
 This corrects systematic RT-dependent intensity differences between MS runs
 without forcing the marginal observed intensity distributions to match.

--- a/src/utils/normalizeQuant.jl
+++ b/src/utils/normalizeQuant.jl
@@ -32,6 +32,13 @@ reduces to the identity correction.
 const QUANT_MIN_ANCHOR_RUN_FRACTION = 0.5
 
 """
+Minimum matched precursors required to estimate a run-wide loading offset.
+Unlike an RT spline, a single robust median does not require multiple bins, but
+it still needs enough anchors to avoid applying a noisy constant correction.
+"""
+const QUANT_MIN_GLOBAL_ANCHORS = 100
+
+"""
     _min_bins_for_spline(spline_n_knots) -> Int
 
 Fewest RT bins that may be handed to `UniformSpline`.
@@ -164,111 +171,161 @@ function getPrecursorQuantConsensus(
 end
 
 """
-    getQuantSplines(psms_paths, quant_col_name; N=100, spline_n_knots=7,
-                    min_bin_occupancy=QUANT_MIN_BIN_OCCUPANCY,
-                    min_anchor_run_fraction=QUANT_MIN_ANCHOR_RUN_FRACTION)
+    getMatchedGlobalOffsets(psms_paths, quant_col_name;
+        precursor_col_name=:precursor_idx,
+        min_run_fraction=QUANT_MIN_ANCHOR_RUN_FRACTION,
+        min_anchors=QUANT_MIN_GLOBAL_ANCHORS)
 
-Fit matched-precursor RT-dependent quantification splines for each MS file.
-First builds a cross-run median log2 abundance for precursors observed in a
-configurable fraction of runs. For each file, it then computes
+Estimate one global log2 loading offset per run from matched precursor ratios.
+For every run, computes the median of
 
 `log2(file abundance) - precursor consensus`
 
-for those matched anchors, bins the residuals by observed iRT into bins of at
-least `min_bin_occupancy` anchors (at most `N` bins), and fits a `UniformSpline`
-mapping iRT to the median matched-precursor residual.
-
-Files whose matched-anchor count cannot support
-`_min_bins_for_spline(spline_n_knots)` such bins get no entry in the returned
-dictionary: they are left uncorrected and excluded from the cross-file median.
-`applyNormalization!` handles the absent key.
-
-Returns `(splines_dict, (min_rt, max_rt))` where `splines_dict` maps file path to
-fitted spline, and the RT range spans only the files that got one.
+over eligible anchors, then subtracts the median run offset so that the
+experiment-wide correction remains centered at zero. Runs with fewer than
+`min_anchors` matched precursors are omitted and therefore left uncorrected.
 """
-function getQuantSplines(psms_paths::Vector{String},
+function getMatchedGlobalOffsets(
+    psms_paths::Vector{String},
     quant_col_name::Symbol;
-    N::Int = 100,
-    spline_n_knots::Int = 7,
-    min_bin_occupancy::Int = QUANT_MIN_BIN_OCCUPANCY,
-    min_anchor_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION,
-    precursor_col_name::Symbol = :precursor_idx)
+    precursor_col_name::Symbol = :precursor_idx,
+    min_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION,
+    min_anchors::Int = QUANT_MIN_GLOBAL_ANCHORS,
+)
+    min_anchors > 0 || throw(ArgumentError(
+        "min_anchors must be positive, got $min_anchors"
+    ))
     precursor_consensus = getPrecursorQuantConsensus(
         psms_paths,
         quant_col_name;
         precursor_col_name = precursor_col_name,
-        min_run_fraction = min_anchor_run_fraction,
+        min_run_fraction = min_run_fraction,
     )
+
+    raw_offsets = Dictionary{String, Float64}()
+    raw_offset_values = Float64[]
+    for fpath in psms_paths
+        psms = DataFrame(Tables.columntable(Arrow.Table(fpath)))
+        file_values = _file_precursor_log2_quant(
+            psms,
+            quant_col_name,
+            precursor_col_name,
+        )
+        residuals = Float64[]
+        sizehint!(residuals, min(length(file_values), length(precursor_consensus)))
+        for (pid, file_logq) in file_values
+            reference_logq = get(precursor_consensus, pid, nothing)
+            reference_logq === nothing && continue
+            push!(residuals, Float64(file_logq - reference_logq))
+        end
+
+        if length(residuals) < min_anchors
+            @user_warn "Skipping quant normalization for $(basename(fpath)): " *
+                       "$(length(residuals)) matched precursor anchors are " *
+                       "below the $min_anchors required for a global loading " *
+                       "offset. Abundances are left uncorrected."
+            continue
+        end
+
+        raw_offset = median(residuals)
+        insert!(raw_offsets, fpath, raw_offset)
+        push!(raw_offset_values, raw_offset)
+    end
+
+    isempty(raw_offsets) && return raw_offsets
+    experiment_center = median(raw_offset_values)
+    offsets = Dictionary{String, Float64}()
+    for (fpath, raw_offset) in pairs(raw_offsets)
+        insert!(offsets, fpath, raw_offset - experiment_center)
+    end
+    return offsets
+end
+
+"""
+    getQuantSplines(psms_paths, quant_col_name; N=100, spline_n_knots=7,
+                    min_bin_occupancy=QUANT_MIN_BIN_OCCUPANCY)
+
+Fit marginal RT-dependent log2-intensity splines for each MS file. All valid
+observed precursors contribute to the shape estimator. Rows are sorted by
+observed iRT, divided into bins of at least `min_bin_occupancy` observations,
+and summarized by the median RT and log2 median abundance.
+
+These splines still contain both a run-wide level and an RT shape.
+`getRTShapeCorrections` removes the run-wide level before comparing shapes;
+the global loading correction comes separately from matched precursors.
+
+Files whose observed precursor count cannot support
+`_min_bins_for_spline(spline_n_knots)` such bins get no entry in the returned
+dictionary. They can still receive a constant matched global correction.
+
+Returns `(splines_dict, (min_rt, max_rt))` where `splines_dict` maps file path to
+fitted spline, and the RT range spans only the files that got one.
+"""
+function getQuantSplines(
+    psms_paths::Vector{String},
+    quant_col_name::Symbol;
+    N::Int = 100,
+    spline_n_knots::Int = 7,
+    min_bin_occupancy::Int = QUANT_MIN_BIN_OCCUPANCY,
+)
     quant_splines = Dictionary{String, UniformSpline}()
     min_rt, max_rt = typemax(Float32), typemin(Float32)
     min_bins = _min_bins_for_spline(spline_n_knots)
     for fpath in psms_paths
         psms = DataFrame(Tables.columntable(Arrow.Table(fpath)))
         hasproperty(psms, :irt_obs) || throw(ArgumentError(
-            "Matched-precursor quant normalization requires column irt_obs."
+            "RT-dependent quant normalization requires column irt_obs."
         ))
-        file_values = _file_precursor_log2_quant(
-            psms,
-            quant_col_name,
-            precursor_col_name,
-        )
+        hasproperty(psms, quant_col_name) || throw(ArgumentError(
+            "Quant normalization requires column $(quant_col_name)."
+        ))
 
-        anchor_rts = Float64[]
-        anchor_residuals = Float64[]
-        sizehint!(anchor_rts, min(length(file_values), length(precursor_consensus)))
-        sizehint!(anchor_residuals, min(length(file_values), length(precursor_consensus)))
-        precursor_idx = psms[!, precursor_col_name]
+        observed_rts = Float64[]
+        observed_quant = Float64[]
         irt_obs = psms[!, :irt_obs]
-        seen = Set{UInt32}()
-        sizehint!(seen, length(file_values))
-        @inbounds for i in eachindex(precursor_idx, irt_obs)
-            pid = UInt32(precursor_idx[i])
-            pid in seen && continue
-            reference_logq = get(precursor_consensus, pid, nothing)
-            reference_logq === nothing && continue
-            file_logq = get(file_values, pid, nothing)
-            file_logq === nothing && continue
+        quant = psms[!, quant_col_name]
+        sizehint!(observed_rts, length(irt_obs))
+        sizehint!(observed_quant, length(quant))
+        @inbounds for i in eachindex(irt_obs, quant)
             rt_raw = irt_obs[i]
-            ismissing(rt_raw) && continue
+            quant_raw = quant[i]
+            (ismissing(rt_raw) || ismissing(quant_raw)) && continue
             rt = Float64(rt_raw)
-            isfinite(rt) || continue
-            push!(seen, pid)
-            push!(anchor_rts, rt)
-            push!(anchor_residuals, Float64(file_logq - reference_logq))
+            abundance = Float64(quant_raw)
+            (isfinite(rt) && isfinite(abundance) && abundance > 0.0) || continue
+            push!(observed_rts, rt)
+            push!(observed_quant, abundance)
         end
 
-        order = sortperm(anchor_rts)
-        anchor_rts = anchor_rts[order]
-        anchor_residuals = anchor_residuals[order]
-        nanchors = length(anchor_rts)
+        order = sortperm(observed_rts)
+        observed_rts = observed_rts[order]
+        observed_quant = observed_quant[order]
+        nobservations = length(observed_rts)
 
-        bins = _occupancy_bins(nanchors, min_bin_occupancy, N)
+        bins = _occupancy_bins(nobservations, min_bin_occupancy, N)
         if length(bins) < min_bins
-            @user_warn "Skipping quant normalization for $(basename(fpath)): " *
-                       "$nanchors matched precursor anchors support only " *
+            @user_warn "Skipping RT-shape estimation for $(basename(fpath)): " *
+                       "$nobservations observed precursors support only " *
                        "$(length(bins)) RT bin(s) at >= $min_bin_occupancy " *
-                       "anchors each, and a " *
+                       "precursors each, and a " *
                        "$(_n_spline_coeffs(spline_n_knots))-coefficient spline needs at least " *
-                       "$min_bins. Abundances are left uncorrected and excluded " *
-                       "from the cross-file median."
+                       "$min_bins. Only the matched global correction will be " *
+                       "applied when available."
             continue
         end
 
-        # Only files that get a spline define the correction grid. A skipped file
-        # receives no correction, so widening the grid to its RT range would only
-        # extrapolate the surviving splines further than their data supports.
-        if first(anchor_rts) < min_rt
-            min_rt = first(anchor_rts)
+        if first(observed_rts) < min_rt
+            min_rt = first(observed_rts)
         end
-        if last(anchor_rts) > max_rt
-            max_rt = last(anchor_rts)
+        if last(observed_rts) > max_rt
+            max_rt = last(observed_rts)
         end
 
         median_quant = Vector{Float64}(undef, length(bins))
         median_rts = Vector{Float64}(undef, length(bins))
         for (i, b) in enumerate(bins)
-            median_rts[i] = median(@view(anchor_rts[b]))
-            median_quant[i] = median(@view(anchor_residuals[b]))
+            median_rts[i] = median(@view(observed_rts[b]))
+            median_quant[i] = log2(median(@view(observed_quant[b])))
         end
 
         splinefit = UniformSpline(median_quant, median_rts, 3, spline_n_knots)
@@ -283,6 +340,11 @@ end
 Compute per-file RT-dependent correction offsets. Evaluates each file's spline
 on a grid, computes the cross-file median at each RT point, and returns a
 dictionary of interpolated offset functions (file_spline - global_median).
+
+This is the original full marginal correction and is retained as a baseline.
+The decomposed `normalizeQuant` pipeline instead calls
+`getRTShapeCorrections`, which removes marginal run levels before constructing
+the RT component.
 
 Returns an empty dictionary when no file got a spline: there is no cross-file
 median to correct toward, and `rt_range` is still the empty-range sentinel
@@ -311,15 +373,98 @@ function getQuantCorrections(
         for (i, rt) in enumerate(rt_grid)
             offset[i] = spline(rt) - median_interp(rt)
         end
-        # Censoring can leave no matched anchors at one or both RT boundaries.
-        # Rows outside the anchor-supported range still need a correction; hold
-        # the nearest supported value constant instead of extrapolating a trend
-        # that was never observed (or throwing on an out-of-range lookup).
+        # Rows outside the spline grid still need a correction. Hold the nearest
+        # supported value constant instead of extrapolating an unobserved trend
+        # (or throwing on an out-of-range lookup).
         insert!(corrections, key, linear_interpolation(
             rt_grid,
             offset;
             extrapolation_bc = Interpolations.Flat(),
         ))
+    end
+    return corrections
+end
+
+function _median_polish_interactions!(
+    values::Matrix{Float64};
+    max_iterations::Int = 20,
+    tolerance::Float64 = 1.0e-7,
+)
+    for _ in 1:max_iterations
+        row_centers = median(values, dims = 2)
+        values .-= row_centers
+        column_centers = median(values, dims = 1)
+        values .-= column_centers
+        max_adjustment = max(
+            maximum(abs, row_centers),
+            maximum(abs, column_centers),
+        )
+        max_adjustment <= tolerance && break
+    end
+    return values
+end
+
+"""
+    getRTShapeCorrections(quant_splines, rt_range; N=100)
+
+Extract only run-specific RT shape differences from marginal intensity splines.
+Spline values on a common RT grid are robustly double-centered with median
+polish: per-run levels and the common across-run RT profile are removed. The
+remaining interaction has approximately zero median across RT for each run and
+zero median across runs at each RT, so it cannot replace the matched global
+loading estimate.
+"""
+function getRTShapeCorrections(
+    quant_splines::Dictionary{String, UniformSpline},
+    rt_range::Tuple{AbstractFloat, AbstractFloat};
+    N::Int = 100,
+)
+    isempty(quant_splines) && return Dictionary{String, Any}()
+    rt_grid = collect(LinRange(first(rt_range), last(rt_range), N))
+    file_paths = String[]
+    spline_values = Matrix{Float64}(undef, length(quant_splines), N)
+    for (row, (fpath, spline)) in enumerate(pairs(quant_splines))
+        push!(file_paths, fpath)
+        @inbounds for (column, rt) in enumerate(rt_grid)
+            spline_values[row, column] = spline(rt)
+        end
+    end
+
+    _median_polish_interactions!(spline_values)
+    corrections = Dictionary{String, Any}()
+    for (row, fpath) in enumerate(file_paths)
+        insert!(corrections, fpath, linear_interpolation(
+            rt_grid,
+            copy(@view(spline_values[row, :]));
+            extrapolation_bc = Interpolations.Flat(),
+        ))
+    end
+    return corrections
+end
+
+"""
+    combineQuantCorrections(global_offsets, rt_shape_corrections)
+
+Combine the matched run-wide offset with the centered marginal RT shape.
+Only files with a supported matched global offset are normalized. If their RT
+shape spline was skipped, they receive the constant global correction alone.
+"""
+function combineQuantCorrections(
+    global_offsets::Dictionary{String, Float64},
+    rt_shape_corrections::Dictionary{String, Any},
+)
+    corrections = Dictionary{String, Any}()
+    for (fpath, global_offset) in pairs(global_offsets)
+        rt_shape = get(rt_shape_corrections, fpath, nothing)
+        if rt_shape === nothing
+            let offset = global_offset
+                insert!(corrections, fpath, _ -> offset)
+            end
+        else
+            let offset = global_offset, shape = rt_shape
+                insert!(corrections, fpath, rt -> offset + shape(rt))
+            end
+        end
     end
     return corrections
 end
@@ -339,9 +484,9 @@ function applyNormalization!(
     for fpath in psms_paths
         psms = DataFrame(Tables.columntable(Arrow.Table(fpath)))
         norm_quant_col = Symbol(string(quant_col) * "_normalized")
-        # getQuantSplines skips files that cannot support a spline, so this key may
-        # be absent. Emit the column unchanged rather than omitting it: downstream
-        # readers assume every file carries the same schema.
+        # A file without enough matched anchors receives no correction. Emit the
+        # column unchanged rather than omitting it: downstream readers assume
+        # every file carries the same schema.
         correction_spline = get(corrections, fpath, nothing)
         if correction_spline === nothing
             psms[!, norm_quant_col] = Float64.(psms[!, quant_col])
@@ -362,13 +507,15 @@ end
 """
     normalizeQuant(second_quant_folder, quant_col_name; N=100, spline_n_knots=7)
 
-End-to-end RT-dependent quantification normalization. Reads all Arrow files,
-constructs a cross-run matched-precursor reference, fits per-file residual
-splines, computes the cross-file median, and writes corrected abundances back
-to each file.
+End-to-end decomposed quantification normalization. Matched precursor ratios
+estimate one global loading offset per run. All observed precursors estimate a
+separate marginal RT spline whose run-wide level and common RT profile are
+removed by median polish. The constant matched offset and centered RT shape are
+then combined and written back to each file.
 
-This corrects systematic RT-dependent intensity differences between MS runs
-without forcing the marginal observed intensity distributions to match.
+This uses precursor matching where differential missingness is most damaging
+(global loading) while retaining the larger observed population for the local
+RT shape.
 """
 function normalizeQuant(
     psms_paths::Vector{String},
@@ -377,18 +524,32 @@ function normalizeQuant(
     spline_n_knots::Int = 7,
     min_anchor_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION)
 
-    quant_splines_dict, rt_range = getQuantSplines(
+    global_offsets = getMatchedGlobalOffsets(
         psms_paths,
+        quant_col_name;
+        min_run_fraction = min_anchor_run_fraction,
+    )
+
+    shape_paths = String[
+        fpath for fpath in psms_paths if haskey(global_offsets, fpath)
+    ]
+    quant_splines, rt_range = getQuantSplines(
+        shape_paths,
         quant_col_name;
         N = N,
         spline_n_knots = spline_n_knots,
-        min_anchor_run_fraction = min_anchor_run_fraction,
+    )
+    rt_shape_corrections = getRTShapeCorrections(
+        quant_splines,
+        rt_range;
+        N = N,
+    )
+    quant_corrections = combineQuantCorrections(
+        global_offsets,
+        rt_shape_corrections,
     )
 
-    quant_corrections_dict = getQuantCorrections(
-        quant_splines_dict, rt_range, N = N)
-
-    applyNormalization!(psms_paths, quant_col_name, quant_corrections_dict)
+    applyNormalization!(psms_paths, quant_col_name, quant_corrections)
     return nothing
 end
 

--- a/src/utils/normalizeQuant.jl
+++ b/src/utils/normalizeQuant.jl
@@ -32,13 +32,6 @@ reduces to the identity correction.
 const QUANT_MIN_ANCHOR_RUN_FRACTION = 0.5
 
 """
-Minimum matched precursors required to estimate a run-wide loading offset.
-Unlike an RT spline, a single robust median does not require multiple bins, but
-it still needs enough anchors to avoid applying a noisy constant correction.
-"""
-const QUANT_MIN_GLOBAL_ANCHORS = 100
-
-"""
     _min_bins_for_spline(spline_n_knots) -> Int
 
 Fewest RT bins that may be handed to `UniformSpline`.
@@ -127,26 +120,76 @@ function _file_precursor_log2_quant(
 end
 
 """
-    getPrecursorQuantConsensus(psms_paths, quant_col_name;
+    _weighted_median(values, weights)
+
+Return the weighted median of `values`. When the cumulative weight lands
+exactly at half of the total, return the mean of the two adjacent values so
+that equal weights reproduce `Statistics.median`, including for even-length
+vectors.
+"""
+function _weighted_median(
+    values::AbstractVector{<:Real},
+    weights::AbstractVector{<:Real},
+)
+    length(values) == length(weights) || throw(DimensionMismatch(
+        "values and weights must have the same length"
+    ))
+    isempty(values) && throw(ArgumentError(
+        "weighted median requires at least one value"
+    ))
+
+    total_weight = 0.0
+    first_weight = Float64(first(weights))
+    equal_weights = true
+    @inbounds for weight in weights
+        w = Float64(weight)
+        (isfinite(w) && w > 0.0) || throw(ArgumentError(
+            "weighted median requires finite positive weights"
+        ))
+        equal_weights &= w == first_weight
+        total_weight += w
+    end
+    equal_weights && return Float64(median(values))
+
+    order = sortperm(values)
+    half_weight = total_weight / 2.0
+    cumulative_weight = 0.0
+    @inbounds for (position, index) in enumerate(order)
+        cumulative_weight += Float64(weights[index])
+        if cumulative_weight > half_weight
+            return Float64(values[index])
+        elseif cumulative_weight == half_weight && position < length(order)
+            return (Float64(values[index]) + Float64(values[order[position + 1]])) / 2.0
+        end
+    end
+    return Float64(values[last(order)])
+end
+
+"""
+    getPrecursorQuantReference(psms_paths, quant_col_name;
         precursor_col_name=:precursor_idx,
         min_run_fraction=QUANT_MIN_ANCHOR_RUN_FRACTION)
 
-Build a cross-run reference abundance for matched precursors. Each precursor's
-reference is the median log2 abundance across runs in which it was quantified.
-Only precursors observed in at least `min_run_fraction` of runs (and at least two
-runs when multiple runs are present) are retained as normalization anchors.
+Build cross-run reference abundances and completeness weights for matched
+precursors. Each reference is the median log2 abundance across runs in which
+the precursor was quantified. Its weight is the fraction of all runs in which
+it was quantified. Only precursors observed in at least `min_run_fraction` of
+runs (and at least two runs when multiple runs are present) are retained.
 
 The run-level de-duplication is deliberate: a precursor contributes at most one
-value per run to the consensus.
+value per run to the reference and completeness count.
 """
-function getPrecursorQuantConsensus(
+function getPrecursorQuantReference(
     psms_paths::Vector{String},
     quant_col_name::Symbol;
     precursor_col_name::Symbol = :precursor_idx,
     min_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION,
 )
-    required_runs = _required_anchor_runs(length(psms_paths), min_run_fraction)
-    required_runs == 0 && return Dict{UInt32, Float32}()
+    n_runs = length(psms_paths)
+    required_runs = _required_anchor_runs(n_runs, min_run_fraction)
+    if required_runs == 0
+        return Dict{UInt32, Float32}(), Dict{UInt32, Float32}()
+    end
 
     values_by_precursor = Dict{UInt32, Vector{Float32}}()
     for fpath in psms_paths
@@ -162,170 +205,157 @@ function getPrecursorQuantConsensus(
     end
 
     consensus = Dict{UInt32, Float32}()
+    completeness_weights = Dict{UInt32, Float32}()
     sizehint!(consensus, length(values_by_precursor))
+    sizehint!(completeness_weights, length(values_by_precursor))
     for (pid, values) in values_by_precursor
         length(values) >= required_runs || continue
         consensus[pid] = Float32(median(values))
+        completeness_weights[pid] = Float32(length(values) / n_runs)
     end
-    return consensus
+    return consensus, completeness_weights
 end
 
 """
-    getMatchedGlobalOffsets(psms_paths, quant_col_name;
+    getPrecursorQuantConsensus(psms_paths, quant_col_name;
         precursor_col_name=:precursor_idx,
-        min_run_fraction=QUANT_MIN_ANCHOR_RUN_FRACTION,
-        min_anchors=QUANT_MIN_GLOBAL_ANCHORS)
+        min_run_fraction=QUANT_MIN_ANCHOR_RUN_FRACTION)
 
-Estimate one global log2 loading offset per run from matched precursor ratios.
-For every run, computes the median of
-
-`log2(file abundance) - precursor consensus`
-
-over eligible anchors, then subtracts the median run offset so that the
-experiment-wide correction remains centered at zero. Runs with fewer than
-`min_anchors` matched precursors are omitted and therefore left uncorrected.
+Return only the cross-run median log2 abundance from
+`getPrecursorQuantReference`. Retained for callers that do not need the
+completeness weights.
 """
-function getMatchedGlobalOffsets(
+function getPrecursorQuantConsensus(
     psms_paths::Vector{String},
     quant_col_name::Symbol;
     precursor_col_name::Symbol = :precursor_idx,
     min_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION,
-    min_anchors::Int = QUANT_MIN_GLOBAL_ANCHORS,
 )
-    min_anchors > 0 || throw(ArgumentError(
-        "min_anchors must be positive, got $min_anchors"
-    ))
-    precursor_consensus = getPrecursorQuantConsensus(
+    consensus, _ = getPrecursorQuantReference(
         psms_paths,
         quant_col_name;
         precursor_col_name = precursor_col_name,
         min_run_fraction = min_run_fraction,
     )
-
-    raw_offsets = Dictionary{String, Float64}()
-    raw_offset_values = Float64[]
-    for fpath in psms_paths
-        psms = DataFrame(Tables.columntable(Arrow.Table(fpath)))
-        file_values = _file_precursor_log2_quant(
-            psms,
-            quant_col_name,
-            precursor_col_name,
-        )
-        residuals = Float64[]
-        sizehint!(residuals, min(length(file_values), length(precursor_consensus)))
-        for (pid, file_logq) in file_values
-            reference_logq = get(precursor_consensus, pid, nothing)
-            reference_logq === nothing && continue
-            push!(residuals, Float64(file_logq - reference_logq))
-        end
-
-        if length(residuals) < min_anchors
-            @user_warn "Skipping quant normalization for $(basename(fpath)): " *
-                       "$(length(residuals)) matched precursor anchors are " *
-                       "below the $min_anchors required for a global loading " *
-                       "offset. Abundances are left uncorrected."
-            continue
-        end
-
-        raw_offset = median(residuals)
-        insert!(raw_offsets, fpath, raw_offset)
-        push!(raw_offset_values, raw_offset)
-    end
-
-    isempty(raw_offsets) && return raw_offsets
-    experiment_center = median(raw_offset_values)
-    offsets = Dictionary{String, Float64}()
-    for (fpath, raw_offset) in pairs(raw_offsets)
-        insert!(offsets, fpath, raw_offset - experiment_center)
-    end
-    return offsets
+    return consensus
 end
 
 """
     getQuantSplines(psms_paths, quant_col_name; N=100, spline_n_knots=7,
-                    min_bin_occupancy=QUANT_MIN_BIN_OCCUPANCY)
+                    min_bin_occupancy=QUANT_MIN_BIN_OCCUPANCY,
+                    min_anchor_run_fraction=QUANT_MIN_ANCHOR_RUN_FRACTION)
 
-Fit marginal RT-dependent log2-intensity splines for each MS file. All valid
-observed precursors contribute to the shape estimator. Rows are sorted by
-observed iRT, divided into bins of at least `min_bin_occupancy` observations,
-and summarized by the median RT and log2 median abundance.
+Fit matched-precursor RT-dependent quantification splines for each MS file.
+First builds a cross-run median log2 abundance for precursors observed in a
+configurable fraction of runs. For each file, it then computes
 
-These splines still contain both a run-wide level and an RT shape.
-`getRTShapeCorrections` removes the run-wide level before comparing shapes;
-the global loading correction comes separately from matched precursors.
+`log2(file abundance) - precursor consensus`
 
-Files whose observed precursor count cannot support
+for those matched anchors, bins the residuals by observed iRT into bins of at
+least `min_bin_occupancy` anchors (at most `N` bins), and fits a `UniformSpline`
+mapping iRT to their completeness-weighted median residual. An anchor's weight
+is its observed-run fraction, so consistently quantified precursors have more
+influence without introducing a tuning parameter.
+
+Files whose matched-anchor count cannot support
 `_min_bins_for_spline(spline_n_knots)` such bins get no entry in the returned
-dictionary. They can still receive a constant matched global correction.
+dictionary: they are left uncorrected and excluded from the cross-file median.
+`applyNormalization!` handles the absent key.
 
 Returns `(splines_dict, (min_rt, max_rt))` where `splines_dict` maps file path to
 fitted spline, and the RT range spans only the files that got one.
 """
-function getQuantSplines(
-    psms_paths::Vector{String},
+function getQuantSplines(psms_paths::Vector{String},
     quant_col_name::Symbol;
     N::Int = 100,
     spline_n_knots::Int = 7,
     min_bin_occupancy::Int = QUANT_MIN_BIN_OCCUPANCY,
-)
+    min_anchor_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION,
+    precursor_col_name::Symbol = :precursor_idx)
+    precursor_consensus, precursor_weights = getPrecursorQuantReference(
+        psms_paths,
+        quant_col_name;
+        precursor_col_name = precursor_col_name,
+        min_run_fraction = min_anchor_run_fraction,
+    )
     quant_splines = Dictionary{String, UniformSpline}()
     min_rt, max_rt = typemax(Float32), typemin(Float32)
     min_bins = _min_bins_for_spline(spline_n_knots)
     for fpath in psms_paths
         psms = DataFrame(Tables.columntable(Arrow.Table(fpath)))
         hasproperty(psms, :irt_obs) || throw(ArgumentError(
-            "RT-dependent quant normalization requires column irt_obs."
+            "Matched-precursor quant normalization requires column irt_obs."
         ))
-        hasproperty(psms, quant_col_name) || throw(ArgumentError(
-            "Quant normalization requires column $(quant_col_name)."
-        ))
+        file_values = _file_precursor_log2_quant(
+            psms,
+            quant_col_name,
+            precursor_col_name,
+        )
 
-        observed_rts = Float64[]
-        observed_quant = Float64[]
+        anchor_rts = Float64[]
+        anchor_residuals = Float64[]
+        anchor_weights = Float64[]
+        n_possible_anchors = min(length(file_values), length(precursor_consensus))
+        sizehint!(anchor_rts, n_possible_anchors)
+        sizehint!(anchor_residuals, n_possible_anchors)
+        sizehint!(anchor_weights, n_possible_anchors)
+        precursor_idx = psms[!, precursor_col_name]
         irt_obs = psms[!, :irt_obs]
-        quant = psms[!, quant_col_name]
-        sizehint!(observed_rts, length(irt_obs))
-        sizehint!(observed_quant, length(quant))
-        @inbounds for i in eachindex(irt_obs, quant)
+        seen = Set{UInt32}()
+        sizehint!(seen, length(file_values))
+        @inbounds for i in eachindex(precursor_idx, irt_obs)
+            pid = UInt32(precursor_idx[i])
+            pid in seen && continue
+            reference_logq = get(precursor_consensus, pid, nothing)
+            reference_logq === nothing && continue
+            file_logq = get(file_values, pid, nothing)
+            file_logq === nothing && continue
             rt_raw = irt_obs[i]
-            quant_raw = quant[i]
-            (ismissing(rt_raw) || ismissing(quant_raw)) && continue
+            ismissing(rt_raw) && continue
             rt = Float64(rt_raw)
-            abundance = Float64(quant_raw)
-            (isfinite(rt) && isfinite(abundance) && abundance > 0.0) || continue
-            push!(observed_rts, rt)
-            push!(observed_quant, abundance)
+            isfinite(rt) || continue
+            push!(seen, pid)
+            push!(anchor_rts, rt)
+            push!(anchor_residuals, Float64(file_logq - reference_logq))
+            push!(anchor_weights, Float64(precursor_weights[pid]))
         end
 
-        order = sortperm(observed_rts)
-        observed_rts = observed_rts[order]
-        observed_quant = observed_quant[order]
-        nobservations = length(observed_rts)
+        order = sortperm(anchor_rts)
+        anchor_rts = anchor_rts[order]
+        anchor_residuals = anchor_residuals[order]
+        anchor_weights = anchor_weights[order]
+        nanchors = length(anchor_rts)
 
-        bins = _occupancy_bins(nobservations, min_bin_occupancy, N)
+        bins = _occupancy_bins(nanchors, min_bin_occupancy, N)
         if length(bins) < min_bins
-            @user_warn "Skipping RT-shape estimation for $(basename(fpath)): " *
-                       "$nobservations observed precursors support only " *
+            @user_warn "Skipping quant normalization for $(basename(fpath)): " *
+                       "$nanchors matched precursor anchors support only " *
                        "$(length(bins)) RT bin(s) at >= $min_bin_occupancy " *
-                       "precursors each, and a " *
+                       "anchors each, and a " *
                        "$(_n_spline_coeffs(spline_n_knots))-coefficient spline needs at least " *
-                       "$min_bins. Only the matched global correction will be " *
-                       "applied when available."
+                       "$min_bins. Abundances are left uncorrected and excluded " *
+                       "from the cross-file median."
             continue
         end
 
-        if first(observed_rts) < min_rt
-            min_rt = first(observed_rts)
+        # Only files that get a spline define the correction grid. A skipped file
+        # receives no correction, so widening the grid to its RT range would only
+        # extrapolate the surviving splines further than their data supports.
+        if first(anchor_rts) < min_rt
+            min_rt = first(anchor_rts)
         end
-        if last(observed_rts) > max_rt
-            max_rt = last(observed_rts)
+        if last(anchor_rts) > max_rt
+            max_rt = last(anchor_rts)
         end
 
         median_quant = Vector{Float64}(undef, length(bins))
         median_rts = Vector{Float64}(undef, length(bins))
         for (i, b) in enumerate(bins)
-            median_rts[i] = median(@view(observed_rts[b]))
-            median_quant[i] = log2(median(@view(observed_quant[b])))
+            median_rts[i] = median(@view(anchor_rts[b]))
+            median_quant[i] = _weighted_median(
+                @view(anchor_residuals[b]),
+                @view(anchor_weights[b]),
+            )
         end
 
         splinefit = UniformSpline(median_quant, median_rts, 3, spline_n_knots)
@@ -340,11 +370,6 @@ end
 Compute per-file RT-dependent correction offsets. Evaluates each file's spline
 on a grid, computes the cross-file median at each RT point, and returns a
 dictionary of interpolated offset functions (file_spline - global_median).
-
-This is the original full marginal correction and is retained as a baseline.
-The decomposed `normalizeQuant` pipeline instead calls
-`getRTShapeCorrections`, which removes marginal run levels before constructing
-the RT component.
 
 Returns an empty dictionary when no file got a spline: there is no cross-file
 median to correct toward, and `rt_range` is still the empty-range sentinel
@@ -373,98 +398,15 @@ function getQuantCorrections(
         for (i, rt) in enumerate(rt_grid)
             offset[i] = spline(rt) - median_interp(rt)
         end
-        # Rows outside the spline grid still need a correction. Hold the nearest
-        # supported value constant instead of extrapolating an unobserved trend
-        # (or throwing on an out-of-range lookup).
+        # Censoring can leave no matched anchors at one or both RT boundaries.
+        # Rows outside the anchor-supported range still need a correction; hold
+        # the nearest supported value constant instead of extrapolating a trend
+        # that was never observed (or throwing on an out-of-range lookup).
         insert!(corrections, key, linear_interpolation(
             rt_grid,
             offset;
             extrapolation_bc = Interpolations.Flat(),
         ))
-    end
-    return corrections
-end
-
-function _median_polish_interactions!(
-    values::Matrix{Float64};
-    max_iterations::Int = 20,
-    tolerance::Float64 = 1.0e-7,
-)
-    for _ in 1:max_iterations
-        row_centers = median(values, dims = 2)
-        values .-= row_centers
-        column_centers = median(values, dims = 1)
-        values .-= column_centers
-        max_adjustment = max(
-            maximum(abs, row_centers),
-            maximum(abs, column_centers),
-        )
-        max_adjustment <= tolerance && break
-    end
-    return values
-end
-
-"""
-    getRTShapeCorrections(quant_splines, rt_range; N=100)
-
-Extract only run-specific RT shape differences from marginal intensity splines.
-Spline values on a common RT grid are robustly double-centered with median
-polish: per-run levels and the common across-run RT profile are removed. The
-remaining interaction has approximately zero median across RT for each run and
-zero median across runs at each RT, so it cannot replace the matched global
-loading estimate.
-"""
-function getRTShapeCorrections(
-    quant_splines::Dictionary{String, UniformSpline},
-    rt_range::Tuple{AbstractFloat, AbstractFloat};
-    N::Int = 100,
-)
-    isempty(quant_splines) && return Dictionary{String, Any}()
-    rt_grid = collect(LinRange(first(rt_range), last(rt_range), N))
-    file_paths = String[]
-    spline_values = Matrix{Float64}(undef, length(quant_splines), N)
-    for (row, (fpath, spline)) in enumerate(pairs(quant_splines))
-        push!(file_paths, fpath)
-        @inbounds for (column, rt) in enumerate(rt_grid)
-            spline_values[row, column] = spline(rt)
-        end
-    end
-
-    _median_polish_interactions!(spline_values)
-    corrections = Dictionary{String, Any}()
-    for (row, fpath) in enumerate(file_paths)
-        insert!(corrections, fpath, linear_interpolation(
-            rt_grid,
-            copy(@view(spline_values[row, :]));
-            extrapolation_bc = Interpolations.Flat(),
-        ))
-    end
-    return corrections
-end
-
-"""
-    combineQuantCorrections(global_offsets, rt_shape_corrections)
-
-Combine the matched run-wide offset with the centered marginal RT shape.
-Only files with a supported matched global offset are normalized. If their RT
-shape spline was skipped, they receive the constant global correction alone.
-"""
-function combineQuantCorrections(
-    global_offsets::Dictionary{String, Float64},
-    rt_shape_corrections::Dictionary{String, Any},
-)
-    corrections = Dictionary{String, Any}()
-    for (fpath, global_offset) in pairs(global_offsets)
-        rt_shape = get(rt_shape_corrections, fpath, nothing)
-        if rt_shape === nothing
-            let offset = global_offset
-                insert!(corrections, fpath, _ -> offset)
-            end
-        else
-            let offset = global_offset, shape = rt_shape
-                insert!(corrections, fpath, rt -> offset + shape(rt))
-            end
-        end
     end
     return corrections
 end
@@ -484,9 +426,9 @@ function applyNormalization!(
     for fpath in psms_paths
         psms = DataFrame(Tables.columntable(Arrow.Table(fpath)))
         norm_quant_col = Symbol(string(quant_col) * "_normalized")
-        # A file without enough matched anchors receives no correction. Emit the
-        # column unchanged rather than omitting it: downstream readers assume
-        # every file carries the same schema.
+        # getQuantSplines skips files that cannot support a spline, so this key may
+        # be absent. Emit the column unchanged rather than omitting it: downstream
+        # readers assume every file carries the same schema.
         correction_spline = get(corrections, fpath, nothing)
         if correction_spline === nothing
             psms[!, norm_quant_col] = Float64.(psms[!, quant_col])
@@ -507,15 +449,13 @@ end
 """
     normalizeQuant(second_quant_folder, quant_col_name; N=100, spline_n_knots=7)
 
-End-to-end decomposed quantification normalization. Matched precursor ratios
-estimate one global loading offset per run. All observed precursors estimate a
-separate marginal RT spline whose run-wide level and common RT profile are
-removed by median polish. The constant matched offset and centered RT shape are
-then combined and written back to each file.
+End-to-end RT-dependent quantification normalization. Reads all Arrow files,
+constructs a cross-run matched-precursor reference, fits completeness-weighted
+per-file residual splines, computes the cross-file median, and writes corrected
+abundances back to each file.
 
-This uses precursor matching where differential missingness is most damaging
-(global loading) while retaining the larger observed population for the local
-RT shape.
+This corrects systematic RT-dependent intensity differences between MS runs
+without forcing the marginal observed intensity distributions to match.
 """
 function normalizeQuant(
     psms_paths::Vector{String},
@@ -524,32 +464,18 @@ function normalizeQuant(
     spline_n_knots::Int = 7,
     min_anchor_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION)
 
-    global_offsets = getMatchedGlobalOffsets(
+    quant_splines_dict, rt_range = getQuantSplines(
         psms_paths,
-        quant_col_name;
-        min_run_fraction = min_anchor_run_fraction,
-    )
-
-    shape_paths = String[
-        fpath for fpath in psms_paths if haskey(global_offsets, fpath)
-    ]
-    quant_splines, rt_range = getQuantSplines(
-        shape_paths,
         quant_col_name;
         N = N,
         spline_n_knots = spline_n_knots,
-    )
-    rt_shape_corrections = getRTShapeCorrections(
-        quant_splines,
-        rt_range;
-        N = N,
-    )
-    quant_corrections = combineQuantCorrections(
-        global_offsets,
-        rt_shape_corrections,
+        min_anchor_run_fraction = min_anchor_run_fraction,
     )
 
-    applyNormalization!(psms_paths, quant_col_name, quant_corrections)
+    quant_corrections_dict = getQuantCorrections(
+        quant_splines_dict, rt_range, N = N)
+
+    applyNormalization!(psms_paths, quant_col_name, quant_corrections_dict)
     return nothing
 end
 

--- a/src/utils/normalizeQuant.jl
+++ b/src/utils/normalizeQuant.jl
@@ -85,6 +85,22 @@ end
     return min(n_runs, max(2, ceil(Int, n_runs * min_run_fraction)))
 end
 
+@inline function _is_normalization_anchor_row(
+    row::Int,
+    target,
+    mbr_recovered,
+)
+    if target !== nothing
+        value = target[row]
+        (ismissing(value) || !Bool(value)) && return false
+    end
+    if mbr_recovered !== nothing
+        value = mbr_recovered[row]
+        !ismissing(value) && Bool(value) && return false
+    end
+    return true
+end
+
 function _file_precursor_log2_quant(
     psms::DataFrame,
     quant_col_name::Symbol,
@@ -100,10 +116,14 @@ function _file_precursor_log2_quant(
 
     precursor_idx = psms[!, precursor_col_name]
     quant = psms[!, quant_col_name]
+    target = hasproperty(psms, :target) ? psms[!, :target] : nothing
+    mbr_recovered = hasproperty(psms, :mbr_recovered) ?
+        psms[!, :mbr_recovered] : nothing
     values = Dict{UInt32, Float32}()
     sizehint!(values, length(precursor_idx))
 
     @inbounds for i in eachindex(precursor_idx, quant)
+        _is_normalization_anchor_row(i, target, mbr_recovered) || continue
         q_raw = quant[i]
         ismissing(q_raw) && continue
         q = Float64(q_raw)
@@ -117,6 +137,54 @@ function _file_precursor_log2_quant(
         values[pid] = max(get(values, pid, -Inf32), logq)
     end
     return values
+end
+
+struct QuantRunAnchor
+    log2_quant::Float32
+    irt::Float32
+end
+
+function _file_precursor_quant_anchors(
+    psms::DataFrame,
+    quant_col_name::Symbol,
+    precursor_col_name::Symbol,
+)
+    hasproperty(psms, :irt_obs) || throw(ArgumentError(
+        "Pairwise quant normalization requires column irt_obs."
+    ))
+    hasproperty(psms, precursor_col_name) || throw(ArgumentError(
+        "Pairwise quant normalization requires column $(precursor_col_name)."
+    ))
+    hasproperty(psms, quant_col_name) || throw(ArgumentError(
+        "Quant normalization requires column $(quant_col_name)."
+    ))
+
+    precursor_idx = psms[!, precursor_col_name]
+    quant = psms[!, quant_col_name]
+    irt_obs = psms[!, :irt_obs]
+    target = hasproperty(psms, :target) ? psms[!, :target] : nothing
+    mbr_recovered = hasproperty(psms, :mbr_recovered) ?
+        psms[!, :mbr_recovered] : nothing
+    anchors = Dict{UInt32, QuantRunAnchor}()
+    sizehint!(anchors, length(precursor_idx))
+
+    @inbounds for row in eachindex(precursor_idx, quant, irt_obs)
+        _is_normalization_anchor_row(row, target, mbr_recovered) || continue
+        quant_raw = quant[row]
+        irt_raw = irt_obs[row]
+        (ismissing(quant_raw) || ismissing(irt_raw)) && continue
+        abundance = Float64(quant_raw)
+        irt = Float64(irt_raw)
+        (isfinite(abundance) && abundance > 0.0 && isfinite(irt)) || continue
+
+        pid = UInt32(precursor_idx[row])
+        anchor = QuantRunAnchor(Float32(log2(abundance)), Float32(irt))
+        previous = get(anchors, pid, nothing)
+        if previous === nothing || anchor.log2_quant > previous.log2_quant
+            anchors[pid] = anchor
+        end
+    end
+    return anchors
 end
 
 """
@@ -219,9 +287,13 @@ function getQuantSplines(psms_paths::Vector{String},
         sizehint!(anchor_residuals, min(length(file_values), length(precursor_consensus)))
         precursor_idx = psms[!, precursor_col_name]
         irt_obs = psms[!, :irt_obs]
+        target = hasproperty(psms, :target) ? psms[!, :target] : nothing
+        mbr_recovered = hasproperty(psms, :mbr_recovered) ?
+            psms[!, :mbr_recovered] : nothing
         seen = Set{UInt32}()
         sizehint!(seen, length(file_values))
         @inbounds for i in eachindex(precursor_idx, irt_obs)
+            _is_normalization_anchor_row(i, target, mbr_recovered) || continue
             pid = UInt32(precursor_idx[i])
             pid in seen && continue
             reference_logq = get(precursor_consensus, pid, nothing)
@@ -275,6 +347,280 @@ function getQuantSplines(psms_paths::Vector{String},
         insert!(quant_splines, fpath, splinefit)
     end
     return quant_splines, (min_rt, max_rt)
+end
+
+struct PairwiseQuantSpline
+    left_position::Int
+    right_position::Int
+    similarity::Float32
+    nanchors::Int
+    min_rt::Float64
+    max_rt::Float64
+    spline::UniformSpline
+end
+
+function _fit_pairwise_quant_spline(
+    left_position::Int,
+    right_position::Int,
+    similarity::Float32,
+    left_anchors::Dict{UInt32, QuantRunAnchor},
+    right_anchors::Dict{UInt32, QuantRunAnchor};
+    N::Int,
+    spline_n_knots::Int,
+    min_bin_occupancy::Int,
+)
+    anchor_rts = Float64[]
+    anchor_residuals = Float64[]
+    npossible = min(length(left_anchors), length(right_anchors))
+    sizehint!(anchor_rts, npossible)
+    sizehint!(anchor_residuals, npossible)
+
+    iterated_anchors, lookup_anchors = length(left_anchors) <= length(right_anchors) ?
+        (left_anchors, right_anchors) : (right_anchors, left_anchors)
+    @inbounds for pid in keys(iterated_anchors)
+        haskey(lookup_anchors, pid) || continue
+        left_anchor = left_anchors[pid]
+        right_anchor = right_anchors[pid]
+        push!(anchor_rts, (Float64(left_anchor.irt) + Float64(right_anchor.irt)) / 2.0)
+        push!(
+            anchor_residuals,
+            Float64(left_anchor.log2_quant - right_anchor.log2_quant),
+        )
+    end
+
+    order = sortperm(anchor_rts)
+    anchor_rts = anchor_rts[order]
+    anchor_residuals = anchor_residuals[order]
+    nanchors = length(anchor_rts)
+    bins = _occupancy_bins(nanchors, min_bin_occupancy, N)
+    length(bins) >= _min_bins_for_spline(spline_n_knots) || return nothing
+
+    median_residuals = Vector{Float64}(undef, length(bins))
+    median_rts = Vector{Float64}(undef, length(bins))
+    for (bin_idx, bin) in enumerate(bins)
+        median_rts[bin_idx] = median(@view(anchor_rts[bin]))
+        median_residuals[bin_idx] = median(@view(anchor_residuals[bin]))
+    end
+
+    return PairwiseQuantSpline(
+        left_position,
+        right_position,
+        similarity,
+        nanchors,
+        first(anchor_rts),
+        last(anchor_rts),
+        UniformSpline(median_residuals, median_rts, 3, spline_n_knots),
+    )
+end
+
+@inline function _quant_tree_root!(parent::Vector{Int}, node::Int)
+    root = node
+    while parent[root] != root
+        root = parent[root]
+    end
+    while parent[node] != node
+        next_node = parent[node]
+        parent[node] = root
+        node = next_node
+    end
+    return root
+end
+
+"""
+    getPairwiseQuantTree(psms_paths, quant_col_name, run_ids,
+                         run_similarity_atlas; ...)
+
+Build a maximum-similarity spanning forest for pairwise quant normalization.
+Candidate run pairs are ordered by the maximum directional containment in the
+existing run-similarity atlas. An edge is accepted only when exact, non-MBR,
+target precursor matches can support the requested RT spline. Kruskal's
+algorithm therefore returns a maximum spanning tree when the supported graph
+is connected, or a maximum spanning forest otherwise.
+
+Only candidate edges that could connect two current components are fitted, so
+the expensive exact-match work normally stops after `n_runs - 1` successful
+pairwise fits.
+"""
+function getPairwiseQuantTree(
+    psms_paths::Vector{String},
+    quant_col_name::Symbol,
+    run_ids::Vector{UInt32},
+    run_similarity_atlas;
+    N::Int = 100,
+    spline_n_knots::Int = 7,
+    min_bin_occupancy::Int = QUANT_MIN_BIN_OCCUPANCY,
+    precursor_col_name::Symbol = :precursor_idx,
+)
+    length(psms_paths) == length(run_ids) || throw(DimensionMismatch(
+        "psms_paths and run_ids must have the same length"
+    ))
+    length(unique(run_ids)) == length(run_ids) || throw(ArgumentError(
+        "run_ids must be unique"
+    ))
+    run_similarity_atlas === nothing && throw(ArgumentError(
+        "pairwise quant normalization requires a run-similarity atlas"
+    ))
+
+    run_anchors = Vector{Dict{UInt32, QuantRunAnchor}}(undef, length(psms_paths))
+    for (position, fpath) in enumerate(psms_paths)
+        psms = DataFrame(Tables.columntable(Arrow.Table(fpath)))
+        run_anchors[position] = _file_precursor_quant_anchors(
+            psms,
+            quant_col_name,
+            precursor_col_name,
+        )
+    end
+
+    candidates = Tuple{Float32, Int, Int}[]
+    n_runs = length(psms_paths)
+    n_runs <= 1 && return PairwiseQuantSpline[]
+    sizehint!(candidates, n_runs * max(n_runs - 1, 0) ÷ 2)
+    for left_position in 1:(n_runs - 1)
+        left_run = run_ids[left_position]
+        for right_position in (left_position + 1):n_runs
+            right_run = run_ids[right_position]
+            similarity = max(
+                run_similarity(run_similarity_atlas, left_run, right_run),
+                run_similarity(run_similarity_atlas, right_run, left_run),
+            )
+            push!(candidates, (similarity, left_position, right_position))
+        end
+    end
+    sort!(
+        candidates;
+        by = candidate -> (
+            -Float64(candidate[1]),
+            run_ids[candidate[2]],
+            run_ids[candidate[3]],
+        ),
+    )
+
+    parent = collect(1:n_runs)
+    component_size = ones(Int, n_runs)
+    tree = PairwiseQuantSpline[]
+    sizehint!(tree, max(n_runs - 1, 0))
+    for (similarity, left_position, right_position) in candidates
+        left_root = _quant_tree_root!(parent, left_position)
+        right_root = _quant_tree_root!(parent, right_position)
+        left_root == right_root && continue
+
+        pairwise_spline = _fit_pairwise_quant_spline(
+            left_position,
+            right_position,
+            similarity,
+            run_anchors[left_position],
+            run_anchors[right_position];
+            N = N,
+            spline_n_knots = spline_n_knots,
+            min_bin_occupancy = min_bin_occupancy,
+        )
+        pairwise_spline === nothing && continue
+        push!(tree, pairwise_spline)
+
+        if component_size[left_root] < component_size[right_root]
+            left_root, right_root = right_root, left_root
+        end
+        parent[right_root] = left_root
+        component_size[left_root] += component_size[right_root]
+        length(tree) == n_runs - 1 && break
+    end
+    return tree
+end
+
+function _quant_tree_traversal(
+    n_runs::Int,
+    tree::Vector{PairwiseQuantSpline},
+)
+    adjacency = [Tuple{Int, Int}[] for _ in 1:n_runs]
+    for (edge_idx, edge) in enumerate(tree)
+        push!(adjacency[edge.left_position], (edge.right_position, edge_idx))
+        push!(adjacency[edge.right_position], (edge.left_position, edge_idx))
+    end
+
+    parent = zeros(Int, n_runs)
+    parent_edge = zeros(Int, n_runs)
+    components = Vector{Vector{Int}}()
+    orders = Vector{Vector{Int}}()
+    for root in 1:n_runs
+        parent[root] == 0 || continue
+        parent[root] = root
+        component = Int[root]
+        order = Int[root]
+        next_idx = 1
+        while next_idx <= length(order)
+            node = order[next_idx]
+            next_idx += 1
+            for (neighbor, edge_idx) in adjacency[node]
+                parent[neighbor] == 0 || continue
+                parent[neighbor] = node
+                parent_edge[neighbor] = edge_idx
+                push!(component, neighbor)
+                push!(order, neighbor)
+            end
+        end
+        push!(components, component)
+        push!(orders, order)
+    end
+    return parent, parent_edge, components, orders
+end
+
+"""
+    getPairwiseQuantCorrections(psms_paths, tree; N=100)
+
+Propagate pairwise log2 differences through a maximum spanning forest and
+return per-file correction functions. For every RT grid point, each connected
+component is centered independently at its median; this fixes the additive
+degree of freedom without inventing a relationship between disconnected run
+groups.
+
+Returns `(corrections, components)` where components contain path positions.
+"""
+function getPairwiseQuantCorrections(
+    psms_paths::Vector{String},
+    tree::Vector{PairwiseQuantSpline};
+    N::Int = 100,
+)
+    n_runs = length(psms_paths)
+    n_runs == 0 && return Dictionary{String, Any}(), Vector{Vector{Int}}()
+    parent, parent_edge, components, orders = _quant_tree_traversal(n_runs, tree)
+    isempty(tree) && return Dictionary{String, Any}(), components
+    N >= 2 || throw(ArgumentError("N must be at least 2, got $N"))
+
+    min_rt = minimum(edge.min_rt for edge in tree)
+    max_rt = maximum(edge.max_rt for edge in tree)
+    rt_grid = collect(LinRange(min_rt, max_rt, N))
+    offsets = zeros(Float64, n_runs, N)
+    for (rt_idx, rt) in enumerate(rt_grid)
+        for (component, order) in zip(components, orders)
+            root = first(order)
+            offsets[root, rt_idx] = 0.0
+            for node in @view(order[2:end])
+                parent_node = parent[node]
+                edge = tree[parent_edge[node]]
+                edge_rt = clamp(rt, edge.min_rt, edge.max_rt)
+                difference = Float64(edge.spline(edge_rt))
+                if parent_node == edge.left_position
+                    offsets[node, rt_idx] = offsets[parent_node, rt_idx] - difference
+                else
+                    offsets[node, rt_idx] = offsets[parent_node, rt_idx] + difference
+                end
+            end
+            center = median(@view(offsets[component, rt_idx]))
+            for node in component
+                offsets[node, rt_idx] -= center
+            end
+        end
+    end
+
+    corrections = Dictionary{String, Any}()
+    for (position, fpath) in enumerate(psms_paths)
+        insert!(corrections, fpath, linear_interpolation(
+            rt_grid,
+            copy(@view(offsets[position, :]));
+            extrapolation_bc = Interpolations.Flat(),
+        ))
+    end
+    return corrections, components
 end
 
 """
@@ -360,12 +706,16 @@ function applyNormalization!(
 end
 
 """
-    normalizeQuant(second_quant_folder, quant_col_name; N=100, spline_n_knots=7)
+    normalizeQuant(psms_paths, quant_col_name; N=100, spline_n_knots=7,
+                   run_ids=nothing, run_similarity_atlas=nothing)
 
-End-to-end RT-dependent quantification normalization. Reads all Arrow files,
-constructs a cross-run matched-precursor reference, fits per-file residual
-splines, computes the cross-file median, and writes corrected abundances back
-to each file.
+End-to-end RT-dependent quantification normalization. When a run-similarity
+atlas is supplied, fits exact-match pairwise splines only along a supported
+maximum spanning tree, propagates their differences to run corrections, and
+median-centers the tree at each RT. MBR-recovered rows never serve as anchors.
+
+Without an atlas, retains the experiment-wide matched-precursor estimator as a
+fallback.
 
 This corrects systematic RT-dependent intensity differences between MS runs
 without forcing the marginal observed intensity distributions to match.
@@ -375,7 +725,40 @@ function normalizeQuant(
     quant_col_name::Symbol;
     N::Int = 100,
     spline_n_knots::Int = 7,
-    min_anchor_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION)
+    min_anchor_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION,
+    run_ids::Union{Nothing, Vector{UInt32}} = nothing,
+    run_similarity_atlas = nothing)
+
+    if run_similarity_atlas !== nothing
+        resolved_run_ids = run_ids === nothing ?
+            UInt32.(eachindex(psms_paths)) : run_ids
+        pairwise_tree = getPairwiseQuantTree(
+            psms_paths,
+            quant_col_name,
+            resolved_run_ids,
+            run_similarity_atlas;
+            N = N,
+            spline_n_knots = spline_n_knots,
+        )
+        if !isempty(pairwise_tree) || length(psms_paths) <= 1
+            quant_corrections, components = getPairwiseQuantCorrections(
+                psms_paths,
+                pairwise_tree;
+                N = N,
+            )
+            if length(components) > 1
+                @user_warn "Pairwise quant normalization formed " *
+                           "$(length(components)) disconnected run groups. " *
+                           "Each group is normalized and centered independently."
+            end
+            applyNormalization!(psms_paths, quant_col_name, quant_corrections)
+            return nothing
+        end
+
+        @user_warn "No run pair had enough exact non-MBR precursor matches " *
+                   "to support an RT spline. Falling back to the " *
+                   "experiment-wide matched-precursor normalizer."
+    end
 
     quant_splines_dict, rt_range = getQuantSplines(
         psms_paths,
@@ -397,7 +780,9 @@ function normalizeQuant(
     quant_col_name::Symbol;
     N::Int = 100,
     spline_n_knots::Int = 7,
-    min_anchor_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION)
+    min_anchor_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION,
+    run_ids::Union{Nothing, Vector{UInt32}} = nothing,
+    run_similarity_atlas = nothing)
 
     psms_paths = [fpath for fpath in readdir(second_quant_folder, join=true) if endswith(fpath, ".arrow")]
     normalizeQuant(
@@ -406,5 +791,7 @@ function normalizeQuant(
         N = N,
         spline_n_knots = spline_n_knots,
         min_anchor_run_fraction = min_anchor_run_fraction,
+        run_ids = run_ids,
+        run_similarity_atlas = run_similarity_atlas,
     )
 end

--- a/src/utils/normalizeQuant.jl
+++ b/src/utils/normalizeQuant.jl
@@ -24,6 +24,14 @@ correction was noise. See dev_docs/quant_spline_guard.
 const QUANT_MIN_BIN_OCCUPANCY = 100
 
 """
+Minimum fraction of runs in which a precursor must be quantified to serve as a
+normalization anchor. With two or more runs, at least two observations are
+always required; a one-run analysis uses its own precursors and therefore
+reduces to the identity correction.
+"""
+const QUANT_MIN_ANCHOR_RUN_FRACTION = 0.5
+
+"""
     _min_bins_for_spline(spline_n_knots) -> Int
 
 Fewest RT bins that may be handed to `UniformSpline`.
@@ -68,18 +76,112 @@ function _occupancy_bins(n::Int, min_occupancy::Int, max_bins::Int)
     return bins
 end
 
+@inline function _required_anchor_runs(n_runs::Int, min_run_fraction::Real)
+    n_runs <= 0 && return 0
+    0.0 < min_run_fraction <= 1.0 || throw(ArgumentError(
+        "min_run_fraction must be in (0, 1], got $min_run_fraction"
+    ))
+    n_runs == 1 && return 1
+    return min(n_runs, max(2, ceil(Int, n_runs * min_run_fraction)))
+end
+
+function _file_precursor_log2_quant(
+    psms::DataFrame,
+    quant_col_name::Symbol,
+    precursor_col_name::Symbol,
+)
+    hasproperty(psms, precursor_col_name) || throw(ArgumentError(
+        "Matched-precursor quant normalization requires column " *
+        "$(precursor_col_name)."
+    ))
+    hasproperty(psms, quant_col_name) || throw(ArgumentError(
+        "Quant normalization requires column $(quant_col_name)."
+    ))
+
+    precursor_idx = psms[!, precursor_col_name]
+    quant = psms[!, quant_col_name]
+    values = Dict{UInt32, Float32}()
+    sizehint!(values, length(precursor_idx))
+
+    @inbounds for i in eachindex(precursor_idx, quant)
+        q_raw = quant[i]
+        ismissing(q_raw) && continue
+        q = Float64(q_raw)
+        (isfinite(q) && q > 0.0) || continue
+        pid = UInt32(precursor_idx[i])
+        logq = Float32(log2(q))
+
+        # Passing-PSM tables normally contain one row per precursor. If a
+        # duplicate is present, keep one run-level value so that run cannot
+        # receive extra weight in the cross-run precursor consensus.
+        values[pid] = max(get(values, pid, -Inf32), logq)
+    end
+    return values
+end
+
+"""
+    getPrecursorQuantConsensus(psms_paths, quant_col_name;
+        precursor_col_name=:precursor_idx,
+        min_run_fraction=QUANT_MIN_ANCHOR_RUN_FRACTION)
+
+Build a cross-run reference abundance for matched precursors. Each precursor's
+reference is the median log2 abundance across runs in which it was quantified.
+Only precursors observed in at least `min_run_fraction` of runs (and at least two
+runs when multiple runs are present) are retained as normalization anchors.
+
+The run-level de-duplication is deliberate: a precursor contributes at most one
+value per run to the consensus.
+"""
+function getPrecursorQuantConsensus(
+    psms_paths::Vector{String},
+    quant_col_name::Symbol;
+    precursor_col_name::Symbol = :precursor_idx,
+    min_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION,
+)
+    required_runs = _required_anchor_runs(length(psms_paths), min_run_fraction)
+    required_runs == 0 && return Dict{UInt32, Float32}()
+
+    values_by_precursor = Dict{UInt32, Vector{Float32}}()
+    for fpath in psms_paths
+        psms = DataFrame(Tables.columntable(Arrow.Table(fpath)))
+        file_values = _file_precursor_log2_quant(
+            psms,
+            quant_col_name,
+            precursor_col_name,
+        )
+        for (pid, logq) in file_values
+            push!(get!(() -> Float32[], values_by_precursor, pid), logq)
+        end
+    end
+
+    consensus = Dict{UInt32, Float32}()
+    sizehint!(consensus, length(values_by_precursor))
+    for (pid, values) in values_by_precursor
+        length(values) >= required_runs || continue
+        consensus[pid] = Float32(median(values))
+    end
+    return consensus
+end
+
 """
     getQuantSplines(psms_paths, quant_col_name; N=100, spline_n_knots=7,
-                    min_bin_occupancy=QUANT_MIN_BIN_OCCUPANCY)
+                    min_bin_occupancy=QUANT_MIN_BIN_OCCUPANCY,
+                    min_anchor_run_fraction=QUANT_MIN_ANCHOR_RUN_FRACTION)
 
-Fit RT-dependent quantification splines for each MS file. For each Arrow file,
-bins PSMs by observed iRT into bins of at least `min_bin_occupancy` rows (at most
-`N` bins), computes median log2-abundance per bin, and fits a `UniformSpline`
-mapping iRT -> median log2-abundance.
+Fit matched-precursor RT-dependent quantification splines for each MS file.
+First builds a cross-run median log2 abundance for precursors observed in a
+configurable fraction of runs. For each file, it then computes
 
-Files whose PSM count cannot support `_min_bins_for_spline(spline_n_knots)` such
-bins get no entry in the returned dictionary: they are left uncorrected and
-excluded from the cross-file median. `applyNormalization!` handles the absent key.
+`log2(file abundance) - precursor consensus`
+
+for those matched anchors, bins the residuals by observed iRT into bins of at
+least `min_bin_occupancy` anchors (at most `N` bins), and fits a `UniformSpline`
+mapping iRT to the median matched-precursor residual.
+
+Files whose matched-anchor count cannot support
+`_min_bins_for_spline(spline_n_knots)` such bins get no entry in the returned
+dictionary: they are left uncorrected and excluded from the cross-file median.
+`applyNormalization!` handles the absent key.
 
 Returns `(splines_dict, (min_rt, max_rt))` where `splines_dict` maps file path to
 fitted spline, and the RT range spans only the files that got one.
@@ -88,20 +190,64 @@ function getQuantSplines(psms_paths::Vector{String},
     quant_col_name::Symbol;
     N::Int = 100,
     spline_n_knots::Int = 7,
-    min_bin_occupancy::Int = QUANT_MIN_BIN_OCCUPANCY)
+    min_bin_occupancy::Int = QUANT_MIN_BIN_OCCUPANCY,
+    min_anchor_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION,
+    precursor_col_name::Symbol = :precursor_idx)
+    precursor_consensus = getPrecursorQuantConsensus(
+        psms_paths,
+        quant_col_name;
+        precursor_col_name = precursor_col_name,
+        min_run_fraction = min_anchor_run_fraction,
+    )
     quant_splines = Dictionary{String, UniformSpline}()
     min_rt, max_rt = typemax(Float32), typemin(Float32)
     min_bins = _min_bins_for_spline(spline_n_knots)
     for fpath in psms_paths
         psms = DataFrame(Tables.columntable(Arrow.Table(fpath)))
-        fast_df_sort!(psms, (:irt_obs,))
-        nprecs = size(psms, 1)
+        hasproperty(psms, :irt_obs) || throw(ArgumentError(
+            "Matched-precursor quant normalization requires column irt_obs."
+        ))
+        file_values = _file_precursor_log2_quant(
+            psms,
+            quant_col_name,
+            precursor_col_name,
+        )
 
-        bins = _occupancy_bins(nprecs, min_bin_occupancy, N)
+        anchor_rts = Float64[]
+        anchor_residuals = Float64[]
+        sizehint!(anchor_rts, min(length(file_values), length(precursor_consensus)))
+        sizehint!(anchor_residuals, min(length(file_values), length(precursor_consensus)))
+        precursor_idx = psms[!, precursor_col_name]
+        irt_obs = psms[!, :irt_obs]
+        seen = Set{UInt32}()
+        sizehint!(seen, length(file_values))
+        @inbounds for i in eachindex(precursor_idx, irt_obs)
+            pid = UInt32(precursor_idx[i])
+            pid in seen && continue
+            reference_logq = get(precursor_consensus, pid, nothing)
+            reference_logq === nothing && continue
+            file_logq = get(file_values, pid, nothing)
+            file_logq === nothing && continue
+            rt_raw = irt_obs[i]
+            ismissing(rt_raw) && continue
+            rt = Float64(rt_raw)
+            isfinite(rt) || continue
+            push!(seen, pid)
+            push!(anchor_rts, rt)
+            push!(anchor_residuals, Float64(file_logq - reference_logq))
+        end
+
+        order = sortperm(anchor_rts)
+        anchor_rts = anchor_rts[order]
+        anchor_residuals = anchor_residuals[order]
+        nanchors = length(anchor_rts)
+
+        bins = _occupancy_bins(nanchors, min_bin_occupancy, N)
         if length(bins) < min_bins
             @user_warn "Skipping quant normalization for $(basename(fpath)): " *
-                       "$nprecs PSMs support only $(length(bins)) RT bin(s) at " *
-                       ">= $min_bin_occupancy PSMs each, and a " *
+                       "$nanchors matched precursor anchors support only " *
+                       "$(length(bins)) RT bin(s) at >= $min_bin_occupancy " *
+                       "anchors each, and a " *
                        "$(_n_spline_coeffs(spline_n_knots))-coefficient spline needs at least " *
                        "$min_bins. Abundances are left uncorrected and excluded " *
                        "from the cross-file median."
@@ -111,18 +257,18 @@ function getQuantSplines(psms_paths::Vector{String},
         # Only files that get a spline define the correction grid. A skipped file
         # receives no correction, so widening the grid to its RT range would only
         # extrapolate the surviving splines further than their data supports.
-        if minimum(psms[!,:irt_obs]) < min_rt
-            min_rt = minimum(psms[!,:irt_obs])
+        if first(anchor_rts) < min_rt
+            min_rt = first(anchor_rts)
         end
-        if maximum(psms[!,:irt_obs]) > max_rt
-            max_rt = maximum(psms[!,:irt_obs])
+        if last(anchor_rts) > max_rt
+            max_rt = last(anchor_rts)
         end
 
         median_quant = Vector{Float64}(undef, length(bins))
         median_rts = Vector{Float64}(undef, length(bins))
         for (i, b) in enumerate(bins)
-            median_rts[i] = median(@view(psms[b, :irt_obs]))
-            median_quant[i] = log2(median(@view(psms[b, quant_col_name])))
+            median_rts[i] = median(@view(anchor_rts[b]))
+            median_quant[i] = median(@view(anchor_residuals[b]))
         end
 
         splinefit = UniformSpline(median_quant, median_rts, 3, spline_n_knots)
@@ -165,7 +311,15 @@ function getQuantCorrections(
         for (i, rt) in enumerate(rt_grid)
             offset[i] = spline(rt) - median_interp(rt)
         end
-        insert!(corrections, key, linear_interpolation(rt_grid, offset))
+        # Censoring can leave no matched anchors at one or both RT boundaries.
+        # Rows outside the anchor-supported range still need a correction; hold
+        # the nearest supported value constant instead of extrapolating a trend
+        # that was never observed (or throwing on an out-of-range lookup).
+        insert!(corrections, key, linear_interpolation(
+            rt_grid,
+            offset;
+            extrapolation_bc = Interpolations.Flat(),
+        ))
     end
     return corrections
 end
@@ -208,21 +362,28 @@ end
 """
     normalizeQuant(second_quant_folder, quant_col_name; N=100, spline_n_knots=7)
 
-End-to-end RT-dependent quantification normalization. Reads all Arrow files
-in `second_quant_folder`, fits per-file splines, computes cross-file median,
-and writes corrected abundances back to each file.
+End-to-end RT-dependent quantification normalization. Reads all Arrow files,
+constructs a cross-run matched-precursor reference, fits per-file residual
+splines, computes the cross-file median, and writes corrected abundances back
+to each file.
 
-This corrects for systematic RT-dependent intensity differences between MS runs,
-ensuring that the same protein at the same RT has comparable abundance across files.
+This corrects systematic RT-dependent intensity differences between MS runs
+without forcing the marginal observed intensity distributions to match.
 """
 function normalizeQuant(
     psms_paths::Vector{String},
     quant_col_name::Symbol;
     N::Int = 100,
-    spline_n_knots::Int = 7)
+    spline_n_knots::Int = 7,
+    min_anchor_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION)
 
     quant_splines_dict, rt_range = getQuantSplines(
-        psms_paths, quant_col_name, N = N, spline_n_knots = spline_n_knots)
+        psms_paths,
+        quant_col_name;
+        N = N,
+        spline_n_knots = spline_n_knots,
+        min_anchor_run_fraction = min_anchor_run_fraction,
+    )
 
     quant_corrections_dict = getQuantCorrections(
         quant_splines_dict, rt_range, N = N)
@@ -235,8 +396,15 @@ function normalizeQuant(
     second_quant_folder::String,
     quant_col_name::Symbol;
     N::Int = 100,
-    spline_n_knots::Int = 7)
+    spline_n_knots::Int = 7,
+    min_anchor_run_fraction::Real = QUANT_MIN_ANCHOR_RUN_FRACTION)
 
     psms_paths = [fpath for fpath in readdir(second_quant_folder, join=true) if endswith(fpath, ".arrow")]
-    normalizeQuant(psms_paths, quant_col_name; N = N, spline_n_knots = spline_n_knots)
+    normalizeQuant(
+        psms_paths,
+        quant_col_name;
+        N = N,
+        spline_n_knots = spline_n_knots,
+        min_anchor_run_fraction = min_anchor_run_fraction,
+    )
 end

--- a/test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_file_aware_decoys.jl
+++ b/test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_file_aware_decoys.jl
@@ -425,6 +425,26 @@ end
     @test all(isfinite, frame.ftr_pep_true[candidate_rows])
 end
 
+@testset "hardest MBR counterfactual control retains score and block index" begin
+    # Scores are block-stacked: real, false-1, false-2, false-3.
+    scores = Float32[
+        0.9, 0.8,
+        0.2, 0.7,
+        0.6, 0.4,
+        0.5, 0.95,
+    ]
+    present = BitMatrix(Bool[
+        true true true
+        true false true
+    ])
+    controls = Pioneer._mbr_top_counterfactual_controls(scores, present)
+
+    @test controls.scores == Float32[0.6, 0.95]
+    @test controls.indices == UInt8[2, 3]
+    @test Pioneer._mbr_top_counterfactual_scores(scores, present) ==
+        controls.scores
+end
+
 @testset "MBR training caps bound work, not just output" begin
     # The capped branch used to push every eligible row index into per-class Vector{Int}s and then
     # sample those down, so hitting the cap allocated 8 bytes per *available* row to keep `limit` of

--- a/test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_postintegration_pipeline.jl
+++ b/test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_postintegration_pipeline.jl
@@ -77,6 +77,7 @@ end
                 prec_prob = Float32[0.90, 0.10],
                 mbr_recovered = Bool[false, true],
                 mbr_target_decoy_prob = Float32[NaN, 0.50],
+                mbr_counterfactual_decoy_prob = Float32[NaN, 0.25],
             ),
         )
         frozen_qvalue = score ->
@@ -96,6 +97,9 @@ end
         @test remapped.prec_prob[1] == 0.90f0
         @test remapped.prec_prob[2] < 0.80f0
         @test remapped.prec_prob[2] ≈ 0.40f0 atol = 1.0f-4
+        @test remapped.mbr_counterfactual_decoy_prec_prob[1] |> isnan
+        @test remapped.mbr_counterfactual_decoy_prec_prob[2] ≈
+            0.20f0 atol = 1.0f-4
     end
 end
 

--- a/test/UnitTests/test_normalizeQuant.jl
+++ b/test/UnitTests/test_normalizeQuant.jl
@@ -28,10 +28,63 @@ function _write_quant_arrow(path::String, n::Int, offset::Float64;
     # Apply multiplicative offset (in log2 space)
     abundance = Float32.(base .* 2.0^offset)
     df = DataFrame(
+        precursor_idx = UInt32.(1:n),
         irt_obs = rts,
         abundance = abundance,
     )
     Arrow.write(path, df)
+end
+
+# Create the left-censored loading example that motivated the matched-precursor
+# normalizer. Run 2 is shifted down in log2 space, and values that fall below
+# the limit of detection are absent rather than represented as zeros.
+function _write_censored_quant_pair(
+    dir::String;
+    n::Int = 10_000,
+    loading_offset::Float32 = 3.0f0,
+    log2_lod::Float32 = 4.0f0,
+)
+    precursor_idx = UInt32.(1:n)
+    rts = Float32.(collect(LinRange(0.0, 100.0, n)))
+    base_log2 = Float32[4.0f0 + 6.0f0 * ((i - 1) % 101) / 100 for i in 1:n]
+
+    path1 = joinpath(dir, "complete.arrow")
+    Arrow.write(path1, DataFrame(
+        precursor_idx = precursor_idx,
+        irt_obs = rts,
+        abundance = 2.0f0 .^ base_log2,
+    ))
+
+    run2_log2 = base_log2 .- loading_offset
+    observed = run2_log2 .>= log2_lod
+    path2 = joinpath(dir, "censored.arrow")
+    Arrow.write(path2, DataFrame(
+        precursor_idx = precursor_idx[observed],
+        irt_obs = rts[observed],
+        abundance = 2.0f0 .^ run2_log2[observed],
+    ))
+    return path1, path2, observed
+end
+
+function _write_rt_bias_quant_pair(dir::String; n::Int = 5_000)
+    precursor_idx = UInt32.(1:n)
+    rts = Float32.(collect(LinRange(0.0, 100.0, n)))
+    base_log2 = Float32[8.0f0 + 0.5f0 * sin(Float32(i) / 17.0f0) for i in 1:n]
+    rt_bias = @. -2.0f0 + 0.04f0 * rts
+
+    path1 = joinpath(dir, "rt_reference.arrow")
+    path2 = joinpath(dir, "rt_biased.arrow")
+    Arrow.write(path1, DataFrame(
+        precursor_idx = precursor_idx,
+        irt_obs = rts,
+        abundance = 2.0f0 .^ base_log2,
+    ))
+    Arrow.write(path2, DataFrame(
+        precursor_idx = precursor_idx,
+        irt_obs = rts,
+        abundance = 2.0f0 .^ (base_log2 .+ rt_bias),
+    ))
+    return path1, path2
 end
 
 @testset "normalizeQuant" begin
@@ -149,6 +202,75 @@ end
 end
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Differential missingness — normalize matched precursors, not marginals
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@testset "left-censored run uses matched precursor ratios" begin
+    mktempdir() do dir
+        path1, path2, observed = _write_censored_quant_pair(dir)
+
+        before1 = copy(DataFrame(Arrow.Table(path1)).abundance)
+        before2 = copy(DataFrame(Arrow.Table(path2)).abundance)
+        raw_matched_shift = median(
+            log2.(before1[observed]) .- log2.(before2)
+        )
+        @test raw_matched_shift ≈ 3.0 atol=0.02
+
+        Pioneer.normalizeQuant(
+            [path1, path2],
+            :abundance;
+            N=100,
+            spline_n_knots=7,
+        )
+
+        after1 = DataFrame(Arrow.Table(path1))
+        after2 = DataFrame(Arrow.Table(path2))
+        matched_shift = median(
+            log2.(after1.abundance_normalized[observed]) .-
+            log2.(after2.abundance_normalized)
+        )
+
+        # The shared precursors align even though the observed marginal
+        # distributions do not: run 2 is still missing its low-abundance tail.
+        @test abs(matched_shift) < 0.05
+        @test abs(
+            median(log2.(after1.abundance_normalized)) -
+            median(log2.(after2.abundance_normalized))
+        ) > 1.0
+        @test (
+            maximum(log2.(after2.abundance_normalized)) -
+            minimum(log2.(after2.abundance_normalized))
+        ) < (
+            maximum(log2.(after1.abundance_normalized)) -
+            minimum(log2.(after1.abundance_normalized))
+        )
+    end
+end
+
+@testset "matched residual spline corrects RT-dependent bias" begin
+    mktempdir() do dir
+        path1, path2 = _write_rt_bias_quant_pair(dir)
+        Pioneer.normalizeQuant(
+            [path1, path2],
+            :abundance;
+            N=50,
+            spline_n_knots=7,
+        )
+
+        run1 = DataFrame(Arrow.Table(path1))
+        run2 = DataFrame(Arrow.Table(path2))
+        normalized_difference = log2.(run2.abundance_normalized) .-
+                                log2.(run1.abundance_normalized)
+
+        # Check local agreement throughout the gradient, not just the global
+        # median. The injected bias ranges from -2 to +2 log2 units.
+        for bin in Pioneer._occupancy_bins(length(normalized_difference), 500, 10)
+            @test abs(median(@view(normalized_difference[bin]))) < 0.05
+        end
+    end
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Edge case: single file — normalization should be near-identity
 # ═══════════════════════════════════════════════════════════════════════════════
 
@@ -198,6 +320,30 @@ end
             # Correction factor 1.0: abundances pass through untouched.
             @test all(df.abundance_normalized .≈ Float64.(df.abundance))
         end
+    end
+end
+
+@testset "no matched precursor overlap" begin
+    mktempdir() do dir
+        path1 = joinpath(dir, "run1.arrow")
+        path2 = joinpath(dir, "run2.arrow")
+        _write_quant_arrow(path1, 1000, 0.0)
+        _write_quant_arrow(path2, 1000, 2.0)
+
+        # Copy before replacing the backing Arrow file; Arrow columns may be
+        # memory-mapped on macOS.
+        run2 = DataFrame(Arrow.Table(path2); copycols=true)
+        run2.precursor_idx .+= UInt32(10_000)
+        Pioneer.writeArrow(path2, run2)
+
+        before1 = copy(DataFrame(Arrow.Table(path1)).abundance)
+        before2 = copy(DataFrame(Arrow.Table(path2)).abundance)
+        Pioneer.normalizeQuant([path1, path2], :abundance; N=50, spline_n_knots=5)
+
+        after1 = DataFrame(Arrow.Table(path1))
+        after2 = DataFrame(Arrow.Table(path2))
+        @test after1.abundance_normalized ≈ before1
+        @test after2.abundance_normalized ≈ before2
     end
 end
 

--- a/test/UnitTests/test_normalizeQuant.jl
+++ b/test/UnitTests/test_normalizeQuant.jl
@@ -87,7 +87,46 @@ function _write_rt_bias_quant_pair(dir::String; n::Int = 5_000)
     return path1, path2
 end
 
+# Four runs with two anchor populations interleaved throughout the gradient.
+# Stable anchors occur in every run and have residuals ±1 in runs 1 and 2.
+# Less-complete anchors occur only in runs 1 and 2 and have residuals ±4. They
+# are slightly more numerous, so an unweighted median chooses ±4, while their
+# 1/2 completeness weight lets the stable anchors determine the bin summary.
+function _write_completeness_weighted_runs(dir::String; n::Int = 2_000)
+    precursor_idx = UInt32.(1:n)
+    rts = Float32.(collect(LinRange(0.0, 100.0, n)))
+    complete = BitVector(mod(i - 1, 20) < 9 for i in 1:n)
+    observed = (trues(n), trues(n), complete, complete)
+
+    run_log2 = (
+        ifelse.(complete, 9.0f0, 12.0f0),
+        ifelse.(complete, 7.0f0, 4.0f0),
+        fill(8.0f0, n),
+        fill(8.0f0, n),
+    )
+    paths = String[]
+    for run in eachindex(run_log2)
+        keep = observed[run]
+        path = joinpath(dir, "run$(run).arrow")
+        Arrow.write(path, DataFrame(
+            precursor_idx = precursor_idx[keep],
+            irt_obs = rts[keep],
+            abundance = 2.0f0 .^ run_log2[run][keep],
+        ))
+        push!(paths, path)
+    end
+    return paths, complete
+end
+
 @testset "normalizeQuant" begin
+
+@testset "weighted median" begin
+    @test Pioneer._weighted_median([1.0, 2.0, 10.0], ones(3)) == 2.0
+    @test Pioneer._weighted_median([1.0, 2.0, 10.0, 20.0], ones(4)) == 6.0
+    @test Pioneer._weighted_median([1.0, 2.0, 10.0, 20.0], fill(2.0f0 / 3.0f0, 4)) == 6.0
+    @test Pioneer._weighted_median([1.0, 2.0, 10.0], [1.0, 1.0, 3.0]) == 10.0
+    @test Pioneer._weighted_median([10.0, 1.0, 2.0], [3.0, 1.0, 1.0]) == 10.0
+end
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # getQuantSplines — fit per-file splines
@@ -125,21 +164,32 @@ end
 end
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# getMatchedGlobalOffsets — estimate run-wide loading from shared precursors
+# Completeness weights — favor anchors seen consistently across runs
 # ═══════════════════════════════════════════════════════════════════════════════
 
-@testset "getMatchedGlobalOffsets" begin
+@testset "completeness-weighted matched residuals" begin
     mktempdir() do dir
-        path1 = joinpath(dir, "file1.arrow")
-        path2 = joinpath(dir, "file2.arrow")
-        _write_quant_arrow(path1, 1000, 0.0)
-        _write_quant_arrow(path2, 1000, 2.0)
+        paths, complete = _write_completeness_weighted_runs(dir)
+        _, weights = Pioneer.getPrecursorQuantReference(paths, :abundance)
 
-        offsets = Pioneer.getMatchedGlobalOffsets([path1, path2], :abundance)
-        @test length(offsets) == 2
-        @test offsets[path1] ≈ -1.0 atol=0.05
-        @test offsets[path2] ≈ 1.0 atol=0.05
-        @test offsets[path2] - offsets[path1] ≈ 2.0 atol=0.05
+        complete_pid = UInt32(findfirst(complete))
+        partial_pid = UInt32(findfirst(.!complete))
+        @test weights[complete_pid] == 1.0f0
+        @test weights[partial_pid] == 0.5f0
+
+        splines, _ = Pioneer.getQuantSplines(
+            paths,
+            :abundance;
+            N=8,
+            spline_n_knots=5,
+        )
+        @test length(splines) == 4
+        for rt in (10.0, 50.0, 90.0)
+            @test splines[paths[1]](rt) ≈ 1.0 atol=0.05
+            @test splines[paths[2]](rt) ≈ -1.0 atol=0.05
+            @test splines[paths[3]](rt) ≈ 0.0 atol=0.05
+            @test splines[paths[4]](rt) ≈ 0.0 atol=0.05
+        end
     end
 end
 
@@ -173,24 +223,6 @@ end
             @test c1 < 0.0 || c2 > 0.0
             # They should roughly cancel: c1 + c2 ≈ 0
             @test abs(c1 + c2) < 0.5
-        end
-    end
-end
-
-@testset "global offsets are excluded from RT shape" begin
-    mktempdir() do dir
-        path1 = joinpath(dir, "file1.arrow")
-        path2 = joinpath(dir, "file2.arrow")
-        _write_quant_arrow(path1, 1000, 0.0)
-        _write_quant_arrow(path2, 1000, 2.0)
-
-        splines, rt_range = Pioneer.getQuantSplines(
-            [path1, path2], :abundance; N=50, spline_n_knots=5)
-        shapes = Pioneer.getRTShapeCorrections(splines, rt_range; N=50)
-
-        for rt in range(0.0, 100.0, length=21)
-            @test abs(shapes[path1](rt)) < 0.05
-            @test abs(shapes[path2](rt)) < 0.05
         end
     end
 end
@@ -284,7 +316,7 @@ end
     end
 end
 
-@testset "decomposed estimator corrects RT-dependent bias" begin
+@testset "matched residual spline corrects RT-dependent bias" begin
     mktempdir() do dir
         path1, path2 = _write_rt_bias_quant_pair(dir)
         Pioneer.normalizeQuant(
@@ -327,13 +359,13 @@ end
 end
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Edge case: too few PSMs for RT shape — retain the global correction
+# Edge case: too few PSMs to fit any spline — fall back to identity
 # ═══════════════════════════════════════════════════════════════════════════════
 
-@testset "global correction does not require an RT spline" begin
+@testset "no file supports a spline" begin
     mktempdir() do dir
         # 200 PSMs fills only 2 bins at >= 100 each, short of the 8 a
-        # 7-coefficient spline needs, but supports a robust global median.
+        # 7-coefficient spline needs, so every file is skipped.
         paths = String[]
         for (i, offset) in enumerate([0.0, 2.0])
             path = joinpath(dir, "file$i.arrow")
@@ -345,41 +377,18 @@ end
             paths, :abundance; N=50, spline_n_knots=5)
         @test isempty(splines)
 
-        shapes = Pioneer.getRTShapeCorrections(splines, rt_range; N=50)
-        @test isempty(shapes)
-        offsets = Pioneer.getMatchedGlobalOffsets(paths, :abundance)
-        @test offsets[paths[2]] - offsets[paths[1]] ≈ 2.0 atol=0.05
+        # No cross-file median exists; corrections must be empty, not an error.
+        corrections = Pioneer.getQuantCorrections(splines, rt_range; N=50)
+        @test isempty(corrections)
 
         Pioneer.normalizeQuant(dir, :abundance; N=50, spline_n_knots=5)
 
-        run1 = DataFrame(Arrow.Table(paths[1]))
-        run2 = DataFrame(Arrow.Table(paths[2]))
-        @test hasproperty(run1, :abundance_normalized)
-        @test hasproperty(run2, :abundance_normalized)
-        @test median(
-            log2.(run2.abundance_normalized) .-
-            log2.(run1.abundance_normalized)
-        ) ≈ 0.0 atol=0.05
-    end
-end
-
-@testset "too few matched anchors falls back to identity" begin
-    mktempdir() do dir
-        path1 = joinpath(dir, "run1.arrow")
-        path2 = joinpath(dir, "run2.arrow")
-        _write_quant_arrow(path1, 50, 0.0)
-        _write_quant_arrow(path2, 50, 2.0)
-
-        before1 = copy(DataFrame(Arrow.Table(path1)).abundance)
-        before2 = copy(DataFrame(Arrow.Table(path2)).abundance)
-        offsets = Pioneer.getMatchedGlobalOffsets([path1, path2], :abundance)
-        @test isempty(offsets)
-
-        Pioneer.normalizeQuant([path1, path2], :abundance; N=50, spline_n_knots=5)
-        after1 = DataFrame(Arrow.Table(path1))
-        after2 = DataFrame(Arrow.Table(path2))
-        @test after1.abundance_normalized ≈ before1
-        @test after2.abundance_normalized ≈ before2
+        for path in paths
+            df = DataFrame(Arrow.Table(path))
+            @test hasproperty(df, :abundance_normalized)
+            # Correction factor 1.0: abundances pass through untouched.
+            @test all(df.abundance_normalized .≈ Float64.(df.abundance))
+        end
     end
 end
 

--- a/test/UnitTests/test_normalizeQuant.jl
+++ b/test/UnitTests/test_normalizeQuant.jl
@@ -87,46 +87,7 @@ function _write_rt_bias_quant_pair(dir::String; n::Int = 5_000)
     return path1, path2
 end
 
-# Four runs with two anchor populations interleaved throughout the gradient.
-# Stable anchors occur in every run and have residuals ±1 in runs 1 and 2.
-# Less-complete anchors occur only in runs 1 and 2 and have residuals ±4. They
-# are slightly more numerous, so an unweighted median chooses ±4, while their
-# 1/2 completeness weight lets the stable anchors determine the bin summary.
-function _write_completeness_weighted_runs(dir::String; n::Int = 2_000)
-    precursor_idx = UInt32.(1:n)
-    rts = Float32.(collect(LinRange(0.0, 100.0, n)))
-    complete = BitVector(mod(i - 1, 20) < 9 for i in 1:n)
-    observed = (trues(n), trues(n), complete, complete)
-
-    run_log2 = (
-        ifelse.(complete, 9.0f0, 12.0f0),
-        ifelse.(complete, 7.0f0, 4.0f0),
-        fill(8.0f0, n),
-        fill(8.0f0, n),
-    )
-    paths = String[]
-    for run in eachindex(run_log2)
-        keep = observed[run]
-        path = joinpath(dir, "run$(run).arrow")
-        Arrow.write(path, DataFrame(
-            precursor_idx = precursor_idx[keep],
-            irt_obs = rts[keep],
-            abundance = 2.0f0 .^ run_log2[run][keep],
-        ))
-        push!(paths, path)
-    end
-    return paths, complete
-end
-
 @testset "normalizeQuant" begin
-
-@testset "weighted median" begin
-    @test Pioneer._weighted_median([1.0, 2.0, 10.0], ones(3)) == 2.0
-    @test Pioneer._weighted_median([1.0, 2.0, 10.0, 20.0], ones(4)) == 6.0
-    @test Pioneer._weighted_median([1.0, 2.0, 10.0, 20.0], fill(2.0f0 / 3.0f0, 4)) == 6.0
-    @test Pioneer._weighted_median([1.0, 2.0, 10.0], [1.0, 1.0, 3.0]) == 10.0
-    @test Pioneer._weighted_median([10.0, 1.0, 2.0], [3.0, 1.0, 1.0]) == 10.0
-end
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # getQuantSplines — fit per-file splines
@@ -159,36 +120,6 @@ end
             v1 = splines[path1](50.0f0)
             v2 = splines[path2](50.0f0)
             @test v2 - v1 ≈ 2.0 atol=0.5
-        end
-    end
-end
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# Completeness weights — favor anchors seen consistently across runs
-# ═══════════════════════════════════════════════════════════════════════════════
-
-@testset "completeness-weighted matched residuals" begin
-    mktempdir() do dir
-        paths, complete = _write_completeness_weighted_runs(dir)
-        _, weights = Pioneer.getPrecursorQuantReference(paths, :abundance)
-
-        complete_pid = UInt32(findfirst(complete))
-        partial_pid = UInt32(findfirst(.!complete))
-        @test weights[complete_pid] == 1.0f0
-        @test weights[partial_pid] == 0.5f0
-
-        splines, _ = Pioneer.getQuantSplines(
-            paths,
-            :abundance;
-            N=8,
-            spline_n_knots=5,
-        )
-        @test length(splines) == 4
-        for rt in (10.0, 50.0, 90.0)
-            @test splines[paths[1]](rt) ≈ 1.0 atol=0.05
-            @test splines[paths[2]](rt) ≈ -1.0 atol=0.05
-            @test splines[paths[3]](rt) ≈ 0.0 atol=0.05
-            @test splines[paths[4]](rt) ≈ 0.0 atol=0.05
         end
     end
 end

--- a/test/UnitTests/test_normalizeQuant.jl
+++ b/test/UnitTests/test_normalizeQuant.jl
@@ -87,6 +87,75 @@ function _write_rt_bias_quant_pair(dir::String; n::Int = 5_000)
     return path1, path2
 end
 
+function _write_pairwise_chain_runs(
+    dir::String;
+    n_per_edge::Int = 1_000,
+    offsets::Vector{Float32} = Float32[0.0, 1.0, -2.0, 2.0, -1.0],
+)
+    n_runs = length(offsets)
+    paths = String[]
+    observed_ids_by_run = Dict{UInt32, Vector{UInt32}}()
+    for run in 1:n_runs
+        precursor_idx = UInt32[]
+        irt_obs = Float32[]
+        base_log2 = Float32[]
+        first_edge = max(1, run - 1)
+        last_edge = min(n_runs - 1, run)
+        for edge in first_edge:last_edge
+            append!(
+                precursor_idx,
+                UInt32.(((edge - 1) * n_per_edge + 1):(edge * n_per_edge)),
+            )
+            append!(irt_obs, Float32.(LinRange(0.0, 100.0, n_per_edge)))
+            append!(
+                base_log2,
+                Float32[8.0f0 + 0.25f0 * sin(Float32(i) / 17.0f0)
+                        for i in 1:n_per_edge],
+            )
+        end
+        path = joinpath(dir, "chain_run$(run).arrow")
+        Arrow.write(path, DataFrame(
+            precursor_idx = precursor_idx,
+            irt_obs = irt_obs,
+            abundance = 2.0f0 .^ (base_log2 .+ offsets[run]),
+            target = trues(length(precursor_idx)),
+            mbr_recovered = falses(length(precursor_idx)),
+        ))
+        push!(paths, path)
+        observed_ids_by_run[UInt32(run)] = precursor_idx
+    end
+    return paths, Pioneer.build_run_similarity(observed_ids_by_run), offsets
+end
+
+function _write_mbr_anchor_pair(
+    dir::String;
+    n_observed::Int = 1_000,
+    n_recovered::Int = 2_000,
+)
+    precursor_idx = UInt32.(1:(n_observed + n_recovered))
+    irt_obs = Float32.(LinRange(0.0, 100.0, n_observed + n_recovered))
+    recovered = BitVector(vcat(falses(n_observed), trues(n_recovered)))
+    run1_log2 = vcat(fill(8.0f0, n_observed), fill(14.0f0, n_recovered))
+    run2_log2 = vcat(fill(10.0f0, n_observed), fill(4.0f0, n_recovered))
+    paths = String[]
+    for (run, log2_quant) in enumerate((run1_log2, run2_log2))
+        path = joinpath(dir, "mbr_run$(run).arrow")
+        Arrow.write(path, DataFrame(
+            precursor_idx = precursor_idx,
+            irt_obs = irt_obs,
+            abundance = 2.0f0 .^ log2_quant,
+            target = trues(length(precursor_idx)),
+            mbr_recovered = recovered,
+        ))
+        push!(paths, path)
+    end
+    observed_ids_by_run = Dict(
+        UInt32(1) => copy(precursor_idx),
+        UInt32(2) => copy(precursor_idx),
+    )
+    return paths, Pioneer.build_run_similarity(observed_ids_by_run), n_observed
+end
+
 @testset "normalizeQuant" begin
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -121,6 +190,112 @@ end
             v2 = splines[path2](50.0f0)
             @test v2 - v1 ≈ 2.0 atol=0.5
         end
+    end
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Pairwise maximum spanning tree — local exact matches without global anchors
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@testset "pairwise maximum spanning tree" begin
+    mktempdir() do dir
+        paths, atlas, offsets = _write_pairwise_chain_runs(dir)
+        run_ids = UInt32.(eachindex(paths))
+
+        # Every precursor occurs in exactly two of five runs, below the current
+        # experiment-wide 50% anchor requirement. The original matched method
+        # therefore cannot fit any run, while adjacent pairwise edges can.
+        global_splines, _ = Pioneer.getQuantSplines(
+            paths,
+            :abundance;
+            N=20,
+            spline_n_knots=5,
+        )
+        @test isempty(global_splines)
+
+        tree = Pioneer.getPairwiseQuantTree(
+            paths,
+            :abundance,
+            run_ids,
+            atlas;
+            N=20,
+            spline_n_knots=5,
+        )
+        @test length(tree) == length(paths) - 1
+        @test Set(
+            (min(edge.left_position, edge.right_position),
+             max(edge.left_position, edge.right_position))
+            for edge in tree
+        ) == Set((run, run + 1) for run in 1:(length(paths) - 1))
+        @test all(edge -> edge.nanchors == 1_000, tree)
+
+        corrections, components = Pioneer.getPairwiseQuantCorrections(
+            paths,
+            tree;
+            N=20,
+        )
+        @test components == [collect(eachindex(paths))]
+        for edge in tree
+            left = edge.left_position
+            right = edge.right_position
+            @test (
+                corrections[paths[left]](50.0) -
+                corrections[paths[right]](50.0)
+            ) ≈ offsets[left] - offsets[right] atol=0.05
+        end
+
+        Pioneer.normalizeQuant(
+            paths,
+            :abundance;
+            N=20,
+            spline_n_knots=5,
+            run_ids=run_ids,
+            run_similarity_atlas=atlas,
+        )
+        normalized_medians = Float64[]
+        for path in paths
+            frame = DataFrame(Arrow.Table(path))
+            push!(normalized_medians, median(log2.(frame.abundance_normalized)))
+        end
+        @test maximum(normalized_medians) - minimum(normalized_medians) < 0.05
+    end
+end
+
+@testset "MBR-recovered rows are excluded from pairwise anchors" begin
+    mktempdir() do dir
+        paths, atlas, n_observed = _write_mbr_anchor_pair(dir)
+        run_ids = UInt32[1, 2]
+        consensus = Pioneer.getPrecursorQuantConsensus(paths, :abundance)
+        @test length(consensus) == n_observed
+
+        tree = Pioneer.getPairwiseQuantTree(
+            paths,
+            :abundance,
+            run_ids,
+            atlas;
+            N=20,
+            spline_n_knots=5,
+        )
+
+        @test length(tree) == 1
+        @test only(tree).nanchors == n_observed
+        @test only(tree).spline(50.0) ≈ -2.0 atol=0.05
+
+        Pioneer.normalizeQuant(
+            paths,
+            :abundance;
+            N=20,
+            spline_n_knots=5,
+            run_ids=run_ids,
+            run_similarity_atlas=atlas,
+        )
+        run1 = DataFrame(Arrow.Table(paths[1]))
+        run2 = DataFrame(Arrow.Table(paths[2]))
+        observed_difference = median(
+            log2.(run1.abundance_normalized[1:n_observed]) .-
+            log2.(run2.abundance_normalized[1:n_observed])
+        )
+        @test abs(observed_difference) < 0.05
     end
 end
 

--- a/test/UnitTests/test_normalizeQuant.jl
+++ b/test/UnitTests/test_normalizeQuant.jl
@@ -125,6 +125,25 @@ end
 end
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# getMatchedGlobalOffsets — estimate run-wide loading from shared precursors
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@testset "getMatchedGlobalOffsets" begin
+    mktempdir() do dir
+        path1 = joinpath(dir, "file1.arrow")
+        path2 = joinpath(dir, "file2.arrow")
+        _write_quant_arrow(path1, 1000, 0.0)
+        _write_quant_arrow(path2, 1000, 2.0)
+
+        offsets = Pioneer.getMatchedGlobalOffsets([path1, path2], :abundance)
+        @test length(offsets) == 2
+        @test offsets[path1] ≈ -1.0 atol=0.05
+        @test offsets[path2] ≈ 1.0 atol=0.05
+        @test offsets[path2] - offsets[path1] ≈ 2.0 atol=0.05
+    end
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # getQuantCorrections — compute offset corrections
 # ═══════════════════════════════════════════════════════════════════════════════
 
@@ -154,6 +173,24 @@ end
             @test c1 < 0.0 || c2 > 0.0
             # They should roughly cancel: c1 + c2 ≈ 0
             @test abs(c1 + c2) < 0.5
+        end
+    end
+end
+
+@testset "global offsets are excluded from RT shape" begin
+    mktempdir() do dir
+        path1 = joinpath(dir, "file1.arrow")
+        path2 = joinpath(dir, "file2.arrow")
+        _write_quant_arrow(path1, 1000, 0.0)
+        _write_quant_arrow(path2, 1000, 2.0)
+
+        splines, rt_range = Pioneer.getQuantSplines(
+            [path1, path2], :abundance; N=50, spline_n_knots=5)
+        shapes = Pioneer.getRTShapeCorrections(splines, rt_range; N=50)
+
+        for rt in range(0.0, 100.0, length=21)
+            @test abs(shapes[path1](rt)) < 0.05
+            @test abs(shapes[path2](rt)) < 0.05
         end
     end
 end
@@ -247,7 +284,7 @@ end
     end
 end
 
-@testset "matched residual spline corrects RT-dependent bias" begin
+@testset "decomposed estimator corrects RT-dependent bias" begin
     mktempdir() do dir
         path1, path2 = _write_rt_bias_quant_pair(dir)
         Pioneer.normalizeQuant(
@@ -290,13 +327,13 @@ end
 end
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Edge case: too few PSMs to fit any spline — fall back to identity
+# Edge case: too few PSMs for RT shape — retain the global correction
 # ═══════════════════════════════════════════════════════════════════════════════
 
-@testset "no file supports a spline" begin
+@testset "global correction does not require an RT spline" begin
     mktempdir() do dir
         # 200 PSMs fills only 2 bins at >= 100 each, short of the 8 a
-        # 7-coefficient spline needs, so every file is skipped.
+        # 7-coefficient spline needs, but supports a robust global median.
         paths = String[]
         for (i, offset) in enumerate([0.0, 2.0])
             path = joinpath(dir, "file$i.arrow")
@@ -308,18 +345,41 @@ end
             paths, :abundance; N=50, spline_n_knots=5)
         @test isempty(splines)
 
-        # No cross-file median exists; corrections must be empty, not an error.
-        corrections = Pioneer.getQuantCorrections(splines, rt_range; N=50)
-        @test isempty(corrections)
+        shapes = Pioneer.getRTShapeCorrections(splines, rt_range; N=50)
+        @test isempty(shapes)
+        offsets = Pioneer.getMatchedGlobalOffsets(paths, :abundance)
+        @test offsets[paths[2]] - offsets[paths[1]] ≈ 2.0 atol=0.05
 
         Pioneer.normalizeQuant(dir, :abundance; N=50, spline_n_knots=5)
 
-        for path in paths
-            df = DataFrame(Arrow.Table(path))
-            @test hasproperty(df, :abundance_normalized)
-            # Correction factor 1.0: abundances pass through untouched.
-            @test all(df.abundance_normalized .≈ Float64.(df.abundance))
-        end
+        run1 = DataFrame(Arrow.Table(paths[1]))
+        run2 = DataFrame(Arrow.Table(paths[2]))
+        @test hasproperty(run1, :abundance_normalized)
+        @test hasproperty(run2, :abundance_normalized)
+        @test median(
+            log2.(run2.abundance_normalized) .-
+            log2.(run1.abundance_normalized)
+        ) ≈ 0.0 atol=0.05
+    end
+end
+
+@testset "too few matched anchors falls back to identity" begin
+    mktempdir() do dir
+        path1 = joinpath(dir, "run1.arrow")
+        path2 = joinpath(dir, "run2.arrow")
+        _write_quant_arrow(path1, 50, 0.0)
+        _write_quant_arrow(path2, 50, 2.0)
+
+        before1 = copy(DataFrame(Arrow.Table(path1)).abundance)
+        before2 = copy(DataFrame(Arrow.Table(path2)).abundance)
+        offsets = Pioneer.getMatchedGlobalOffsets([path1, path2], :abundance)
+        @test isempty(offsets)
+
+        Pioneer.normalizeQuant([path1, path2], :abundance; N=50, spline_n_knots=5)
+        after1 = DataFrame(Arrow.Table(path1))
+        after2 = DataFrame(Arrow.Table(path2))
+        @test after1.abundance_normalized ≈ before1
+        @test after2.abundance_normalized ≈ before2
     end
 end
 

--- a/test/UnitTests/test_protein_mbr_features.jl
+++ b/test/UnitTests/test_protein_mbr_features.jl
@@ -1,5 +1,6 @@
 using DataFrames
 using Test
+import Pioneer
 
 using Pioneer: group_psms_by_protein, run_level_protein_feature_names
 
@@ -11,6 +12,58 @@ function _empty_precursor_consensus_for_mbr_feature_tests()
         cached_protein_total_vote = Dict{Tuple{String, Bool, UInt8}, Float64}(),
         shape_confidence_scale = 1.0f0
     )
+end
+
+@testset "Counterfactual protein training controls" begin
+    @testset "one hardest shadow PSM is selected only for target MBR-only proteins" begin
+        psms = DataFrame(
+            inferred_protein_group = ["P1", "P1", "P2", "P2", "D1"],
+            target = Bool[true, true, true, true, false],
+            entrap_id = zeros(UInt8, 5),
+            use_for_protein_quant = trues(5),
+            qval = fill(0.001f0, 5),
+            global_qval = fill(0.001f0, 5),
+            mbr_recovered = Bool[true, true, true, false, true],
+            precursor_idx = UInt32[1, 2, 3, 4, 5],
+            prec_prob = Float32[0.9, 0.8, 0.7, 0.6, 0.5],
+            mbr_counterfactual_decoy_prec_prob =
+                Float32[0.2, 0.7, 0.95, 0.9, 0.99],
+        )
+
+        shadows = Pioneer._mbr_counterfactual_shadow_psms(psms)
+        @test nrow(shadows) == 1
+        @test shadows.inferred_protein_group == ["P1"]
+        @test shadows.precursor_idx == UInt32[2]
+        @test shadows.prec_prob == Float32[0.7]
+    end
+
+    @testset "existing targets stay positive and shadows are negatives" begin
+        actual = DataFrame(
+            protein_name = ["P_SINGLE", "P_MULTI", "DECOY"],
+            target = Bool[true, true, false],
+            n_non_mbr_peptides = Int64[0, 0, 0],
+            mbr_only_protein = Bool[true, true, false],
+            mbr_recovered_peptides = Int64[1, 2, 0],
+        )
+        shadows = DataFrame(
+            protein_name = ["P_SINGLE"],
+            target = Bool[true],
+            n_non_mbr_peptides = Int64[0],
+            mbr_only_protein = Bool[true],
+            mbr_recovered_peptides = Int64[1],
+        )
+
+        prepared = Pioneer.prepare_run_level_protein_training_rows(
+            actual,
+            shadows,
+        )
+        @test prepared.n_shadows == 1
+        @test prepared.rows.training_label ==
+            Bool[true, true, false, false]
+        @test prepared.rows.protein_shadow_negative ==
+            Bool[false, false, false, true]
+        @test prepared.rows.target[end]
+    end
 end
 
 @testset "ProteinScoring MBR feature rollup" begin


### PR DESCRIPTION
## Summary

This combines the finalized MBR-aware protein-scoring changes with the new pairwise maximum-spanning-tree run normalization.

## Protein scoring changes relative to `develop`

- Preserve the strongest qualifying MBR counterfactual transfer score and its counterfactual block index through recovery sidecars and final MBR merging.
- Remap retained counterfactual scores onto the same frozen precursor-probability scale used for accepted MBR transfers.
- For each target protein/run whose quantitative support is entirely MBR-recovered, build one training-only counterfactual shadow from the hardest retained counterfactual PSM.
- Roll shadow PSMs through the normal protein feature pipeline while preserving the target protein identity, so the real and shadow examples remain in the same cross-validation fold.
- Add explicit `training_label` and `protein_shadow_negative` columns: real target rows remain positive, ordinary decoys remain negative, and counterfactual shadows are negative training controls.
- Use the explicit training labels for data-sufficiency checks, LightGBM fitting, and training QC plots. Shadow rows and temporary labels are not written to final protein-group outputs.

## Normalization changes relative to `develop`

- Build run-pair normalization estimates from exact precursor matches rather than matching each run to an experiment-wide marginal distribution.
- Restrict normalization anchors to target precursors and exclude `mbr_recovered` observations, preventing transferred values from defining the correction.
- Reuse the existing run-similarity atlas to rank candidate run pairs by their strongest directional containment score.
- Fit RT-dependent log2 abundance-difference splines only for pairs with enough exact shared anchors, then use Kruskal's algorithm to construct a maximum-similarity spanning tree or forest.
- Propagate pairwise offsets through the tree and median-center each connected component independently at every RT position. Pairwise splines are held flat beyond their observed RT support.
- Warn when the supported graph is disconnected. If no pair supports a spline, fall back to the experiment-wide matched-precursor estimator; runs that cannot support any estimator are passed through unchanged.
- Pass stable run IDs and the existing similarity atlas from precursor scoring into MaxLFQ normalization.

## Tests

- `julia --project=. test/UnitTests/test_normalizeQuant.jl`
- `julia --project=. test/UnitTests/test_protein_mbr_features.jl`
- `julia --project=. test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_file_aware_decoys.jl`
- `julia --project=. test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_postintegration_pipeline.jl`
