### PR TITLE
fix: preserve cumulative intensity in MaxLFQ

### DIFF
--- a/src/utils/maxLFQ.jl
+++ b/src/utils/maxLFQ.jl
@@ -261,6 +261,9 @@ end
     solve_maxlfq_component(X::AbstractMatrix{Union{Missing, T}}) where {T<:Real}
 
 Solve the MaxLFQ system for a single connected run component in log2 space.
+The relative profile is rescaled so that its cumulative linear intensity across
+runs matches the cumulative observed precursor intensity, as described in the
+original MaxLFQ algorithm.
 """
 function solve_maxlfq_component(X::AbstractMatrix{Union{Missing, T}}) where {T<:Real}
     n_runs = size(X, 2)
@@ -285,13 +288,25 @@ function solve_maxlfq_component(X::AbstractMatrix{Union{Missing, T}}) where {T<:
 
     rhs = Vector{Float64}(undef, n_runs + 1)
     rhs[1:n_runs] = 2.0 .* Atb
-    rhs[end] = mean(observed_values) * n_runs
+    rhs[end] = 0.0
 
     solution = system_matrix \ rhs
+    relative_profile = @view solution[1:n_runs]
+    max_observed = maximum(observed_values)
+    max_profile = maximum(relative_profile)
+    log2_cumulative_intensity = Float64(max_observed) + log2(sum(
+        exp2(Float64(value) - Float64(max_observed)) for value in observed_values
+    ))
+    log2_profile_intensity = max_profile + log2(sum(
+        exp2(value - max_profile) for value in relative_profile
+    ))
+    log2_scale = log2_cumulative_intensity - log2_profile_intensity
+
     estimates = Vector{Union{Missing, Float32}}(missing, n_runs)
     for run_idx in 1:n_runs
-        if isfinite(solution[run_idx])
-            estimates[run_idx] = solution[run_idx]
+        scaled_estimate = solution[run_idx] + log2_scale
+        if isfinite(scaled_estimate)
+            estimates[run_idx] = scaled_estimate
         end
     end
 

--- a/test/UnitTests/test_maxLFQ.jl
+++ b/test/UnitTests/test_maxLFQ.jl
@@ -143,6 +143,35 @@ end
 end
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# solve_maxlfq_component — relative ratios and cumulative-intensity scale
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@testset "solve_maxlfq_component" begin
+    X = Union{Float64, Missing}[
+        log2(10.0)  log2(20.0)  log2(40.0);
+        log2(5.0)   log2(10.0)  log2(20.0)
+    ]
+
+    estimates = Pioneer.solve_maxlfq_component(X)
+    linear_estimates = exp2.(Float64.(estimates))
+    observed_cumulative_intensity = sum(exp2, skipmissing(vec(X)))
+
+    @testset "preserves precursor ratios" begin
+        @test isapprox(estimates[2] - estimates[1], 1.0; atol = 1.0e-6)
+        @test isapprox(estimates[3] - estimates[2], 1.0; atol = 1.0e-6)
+    end
+
+    @testset "preserves cumulative precursor intensity" begin
+        @test isapprox(
+            sum(linear_estimates),
+            observed_cumulative_intensity;
+            rtol = 1.0e-6
+        )
+        @test all(isapprox.(linear_estimates, [15.0, 30.0, 60.0]; rtol = 1.0e-6))
+    end
+end
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # getProtAbundance — end-to-end protein quantification
 # ═══════════════════════════════════════════════════════════════════════════════
 
@@ -206,6 +235,11 @@ end
         vals = collect(skipmissing(log2_abund_out))
         diffs = diff(vals)
         @test all(d -> isapprox(d, 1.0, atol=0.1), diffs)
+    end
+
+    @testset "protein profile preserves cumulative precursor intensity" begin
+        protein_cumulative_intensity = sum(exp2, skipmissing(log2_abund_out))
+        @test isapprox(protein_cumulative_intensity, sum(abundance); rtol = 1.0e-6)
     end
 
     @testset "peptide lists populated" begin
@@ -310,6 +344,7 @@ end
         vals = collect(skipmissing(log2_abund_out))
         @test all(isfinite, vals)
         @test length(vals) == 3
+        @test isapprox(sum(exp2, vals), sum(abundance); rtol = 1.0e-6)
     end
 
     @testset "peptide list reflects missing data" begin


### PR DESCRIPTION
## Summary

- rescale the MaxLFQ relative profile so its summed linear abundance matches the cumulative observed precursor intensity
- calculate the scale in log2 space for numerical stability
- add regression coverage for peptide ratios and cumulative-intensity preservation

## Testing

- `julia --startup-file=no --project=. test/UnitTests/test_maxLFQ.jl` (59/59 passed)