### PR TITLE
GUI: mzML conversion, file lists, and a startup that doesn't scale with history

### DIFF
--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -148,6 +148,13 @@ async fn list_spec_libs(app: AppHandle, repo: Option<String>) -> Result<String, 
     .map_err(|e| format!("listing task failed: {e}"))?
 }
 
+/// Build the single-file `ms_data` directory for one fanned-out search.
+/// See `paths::stage_ms_file` for why a search of chosen files needs one.
+#[tauri::command]
+fn stage_ms_file(job_id: String, file: String) -> Result<String, String> {
+    paths::stage_ms_file(&job_id, &file)
+}
+
 #[tauri::command]
 fn read_config(path: String) -> Result<String, String> {
     paths::read_config(&path)
@@ -257,6 +264,7 @@ pub fn run() {
             uninstall_info,
             uninstall_this_version,
             inspect_path,
+            stage_ms_file,
             read_config,
             library_info,
             list_spec_libs,

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -148,11 +148,11 @@ async fn list_spec_libs(app: AppHandle, repo: Option<String>) -> Result<String, 
     .map_err(|e| format!("listing task failed: {e}"))?
 }
 
-/// Build the single-file `ms_data` directory for one fanned-out search.
-/// See `paths::stage_ms_file` for why a search of chosen files needs one.
+/// Build the input directory for one run over a chosen set of files.
+/// See `paths::stage_files` for why a chosen set needs one.
 #[tauri::command]
-fn stage_ms_file(job_id: String, file: String) -> Result<String, String> {
-    paths::stage_ms_file(&job_id, &file)
+fn stage_files(job_id: String, subdir: String, files: Vec<String>) -> Result<String, String> {
+    paths::stage_files(&job_id, &subdir, &files)
 }
 
 #[tauri::command]
@@ -264,7 +264,7 @@ pub fn run() {
             uninstall_info,
             uninstall_this_version,
             inspect_path,
-            stage_ms_file,
+            stage_files,
             read_config,
             library_info,
             list_spec_libs,

--- a/gui/src-tauri/src/paths.rs
+++ b/gui/src-tauri/src/paths.rs
@@ -40,6 +40,24 @@ const MS_EXTENSIONS: [&str; 3] = ["raw", "mzml", "arrow"];
 /// serialization difference between library versions does not matter.
 const PION_MARKERS: [&str; 2] = ["precursors_table", "detailed_fragments"];
 
+/// Which MS data format a file name names, or "" for anything else.
+///
+/// Deliberately NOT `extension_of`: that looks through a trailing `.gz`, which
+/// is right for FASTA (Pioneer reads a gzipped one) and wrong for every MS
+/// format here. None of the three converters or readers decompresses --
+/// `convertMzML` matches `endswith(lowercase(path), ".mzml")` and nothing else
+/// -- so counting `run.mzML.gz` as an mzML would promise a conversion that
+/// silently finds no files to do.
+fn ms_extension_of(name: &str) -> &'static str {
+    let lower = name.to_ascii_lowercase();
+    for ext in MS_EXTENSIONS {
+        if lower.ends_with(&format!(".{ext}")) {
+            return ext;
+        }
+    }
+    ""
+}
+
 /// Lowercased extension, looking through a trailing `.gz`.
 ///
 /// Pioneer reads gzipped FASTA directly, so `proteins.fasta.gz` must report
@@ -91,9 +109,10 @@ pub fn inspect(path: &str) -> PathInfo {
     info.extension = extension_of(&p);
 
     if info.is_file {
-        if MS_EXTENSIONS.contains(&info.extension.as_str()) {
+        let ms = ms_extension_of(&p.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_default());
+        if MS_EXTENSIONS.contains(&ms) {
             info.ms_file_count = 1;
-            match info.extension.as_str() {
+            match ms {
                 "raw" => info.raw_count = 1,
                 "mzml" => info.mzml_count = 1,
                 "arrow" => info.arrow_count = 1,
@@ -121,8 +140,7 @@ pub fn inspect(path: &str) -> PathInfo {
                     if PION_MARKERS.contains(&stem) {
                         markers_seen += 1;
                     }
-                    let ext = extension_of(Path::new(name.as_ref()));
-                    match ext.as_str() {
+                    match ms_extension_of(name.as_ref()) {
                         "raw" => {
                             info.raw_count += 1;
                             info.ms_file_count += 1;
@@ -277,6 +295,25 @@ mod staging_tests {
         assert_eq!(first, second);
         assert_eq!(std::fs::read_dir(&first).unwrap().count(), 1);
         let _ = std::fs::remove_dir_all(&first);
+    }
+
+    #[test]
+    fn a_gzipped_mzml_is_not_counted_as_ms_data() {
+        // extension_of looks through .gz because Pioneer reads a gzipped FASTA.
+        // No MS converter does, so the counts must not promise otherwise: the
+        // form would say "1 .mzML file to convert" and convertMzML would find
+        // none, having matched only on a literal .mzml suffix.
+        let d = scratch("gz");
+        std::fs::write(d.join("run.mzML.gz"), b"x").unwrap();
+        std::fs::write(d.join("real.mzML"), b"x").unwrap();
+        let info = super::inspect(d.to_str().unwrap());
+        assert_eq!(info.mzml_count, 1, "only the uncompressed file converts");
+        assert_eq!(info.ms_file_count, 1);
+
+        let one = super::inspect(d.join("run.mzML.gz").to_str().unwrap());
+        assert_eq!(one.mzml_count, 0, "a lone .gz is not MS data either");
+        // The FASTA-facing field keeps looking through the .gz, unchanged.
+        assert_eq!(one.extension, "mzml");
     }
 
     #[test]

--- a/gui/src-tauri/src/paths.rs
+++ b/gui/src-tauri/src/paths.rs
@@ -237,31 +237,56 @@ pub fn stage_files(job_id: &str, subdir: &str, files: &[String]) -> Result<Strin
         if dst.symlink_metadata().is_ok() {
             let _ = std::fs::remove_file(&dst);
         }
-        link_file(&src, &dst)?;
+        let hard = link_file(&src, &dst)?;
+        if !hard && name.to_ascii_lowercase().ends_with(".raw") {
+            // Only a symlink was possible, which for a .raw means the converter
+            // would read nothing and still report success. Say so now, with the
+            // reason, rather than after a batch has silently produced no output.
+            let _ = std::fs::remove_file(&dst);
+            return Err(format!(
+                "{name} is on a different volume from the temporary folder, so it can only be \
+                 linked in a way the Thermo reader cannot open. Convert that folder on its own \
+                 in Folder mode, or copy the file alongside the others first."
+            ));
+        }
         seen.push(name);
     }
     Ok(dir.display().to_string())
 }
 
+/// Link `src` into place at `dst`.
+///
+/// A hard link first, on every platform. It is not a portability nicety: the
+/// Thermo reader PioneerConverter uses memory-maps the file it is given, and
+/// through a symlink it maps the *link* — a few dozen bytes — then reads past
+/// the end of it and dies with `System.OverflowException` out of
+/// `MemMapReader.ReadBytes`. Worse, PioneerConverter still exits 0, so a whole
+/// batch converts to nothing while reporting success. A hard link is a second
+/// name for the same inode and is indistinguishable from the original to
+/// anything that opens it.
+///
+/// The symlink fallback covers the one case a hard link cannot express, a
+/// source on another volume. `stage_files` refuses to use it for `.raw`, since
+/// for those it is the broken path above rather than a fallback.
+fn link_file(src: &Path, dst: &Path) -> Result<bool, String> {
+    if std::fs::hard_link(src, dst).is_ok() {
+        return Ok(true);
+    }
+    symlink_file(src, dst).map(|()| false)
+}
+
 #[cfg(unix)]
-fn link_file(src: &Path, dst: &Path) -> Result<(), String> {
+fn symlink_file(src: &Path, dst: &Path) -> Result<(), String> {
     std::os::unix::fs::symlink(src, dst)
         .map_err(|e| format!("could not link {} into place: {e}", src.display()))
 }
 
 #[cfg(windows)]
-fn link_file(src: &Path, dst: &Path) -> Result<(), String> {
-    // Hard link first: unprivileged, and these are always plain files. Falls
-    // back to a symlink when the source is on another volume, which is the one
-    // case a hard link cannot express.
-    if std::fs::hard_link(src, dst).is_ok() {
-        return Ok(());
-    }
+fn symlink_file(src: &Path, dst: &Path) -> Result<(), String> {
     std::os::windows::fs::symlink_file(src, dst).map_err(|e| {
         format!(
             "could not link {} into place: {e}. A hard link failed too, which \
-             usually means the file is on another drive; enable Developer Mode \
-             or copy the file next to the others.",
+             usually means the file is on another drive.",
             src.display()
         )
     })

--- a/gui/src-tauri/src/paths.rs
+++ b/gui/src-tauri/src/paths.rs
@@ -163,6 +163,132 @@ pub fn read_config(path: &str) -> Result<String, String> {
     std::fs::read_to_string(&target).map_err(|e| format!("Could not read {}: {e}", target.display()))
 }
 
+/// Stage one MS data file as a directory that contains only that file.
+///
+/// SearchDIA takes a *directory* and searches every `.arrow` inside it. There is
+/// no way to hand it a chosen handful out of a folder of forty, which is exactly
+/// what searching a batch of method-development files one at a time needs. So
+/// each such run gets its own directory holding a single link to the real file,
+/// and points `ms_data` at that.
+///
+/// A link, not a copy: these files are gigabytes, and copying forty of them to
+/// search forty of them would be absurd. On Unix that is a symlink. On Windows a
+/// hard link is tried first — it needs no special privilege, where a symlink
+/// needs Developer Mode or an elevated process — and a symlink is the fallback
+/// for the case a hard link cannot serve, a source on another volume.
+///
+/// Lives beside the params file for the same job, under the same temp root, and
+/// is left behind for the same reason: it is part of the record of what ran.
+pub fn stage_ms_file(job_id: &str, file: &str) -> Result<String, String> {
+    let src = PathBuf::from(file);
+    if !src.is_file() {
+        return Err(format!("{file} is not a file"));
+    }
+    let name = src
+        .file_name()
+        .ok_or_else(|| format!("{file} has no file name"))?
+        .to_owned();
+
+    let dir = std::env::temp_dir().join("pioneer-console").join(job_id).join("ms_data");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("could not create {}: {e}", dir.display()))?;
+
+    let dst = dir.join(&name);
+    // A resumed or re-run job can find its own link already there. Remove rather
+    // than fail: the link is derived state, and the source it points at is the
+    // thing that matters.
+    if dst.symlink_metadata().is_ok() {
+        let _ = std::fs::remove_file(&dst);
+    }
+    link_file(&src, &dst)?;
+    Ok(dir.display().to_string())
+}
+
+#[cfg(unix)]
+fn link_file(src: &Path, dst: &Path) -> Result<(), String> {
+    std::os::unix::fs::symlink(src, dst)
+        .map_err(|e| format!("could not link {} into place: {e}", src.display()))
+}
+
+#[cfg(windows)]
+fn link_file(src: &Path, dst: &Path) -> Result<(), String> {
+    // Hard link first: unprivileged, and these are always plain files. Falls
+    // back to a symlink when the source is on another volume, which is the one
+    // case a hard link cannot express.
+    if std::fs::hard_link(src, dst).is_ok() {
+        return Ok(());
+    }
+    std::os::windows::fs::symlink_file(src, dst).map_err(|e| {
+        format!(
+            "could not link {} into place: {e}. A hard link failed too, which \
+             usually means the file is on another drive; enable Developer Mode \
+             or copy the file next to the others.",
+            src.display()
+        )
+    })
+}
+
+#[cfg(test)]
+mod staging_tests {
+    use super::stage_ms_file;
+
+    /// A unique job id per test, so the tests do not collide in the shared temp
+    /// root and so a rerun does not see the previous run's links.
+    fn job_id(tag: &str) -> String {
+        format!("test-{tag}-{}", std::process::id())
+    }
+
+    fn scratch(tag: &str) -> std::path::PathBuf {
+        let d = std::env::temp_dir().join(format!("pioneer-stage-src-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn stages_one_file_into_a_directory_of_its_own() {
+        let src = scratch("one");
+        // Two files side by side is the situation the whole feature exists for:
+        // the staged directory must contain the chosen one and *only* it, or
+        // SearchDIA would search both.
+        std::fs::write(src.join("a.arrow"), b"a").unwrap();
+        std::fs::write(src.join("b.arrow"), b"b").unwrap();
+
+        let id = job_id("one");
+        let dir = stage_ms_file(&id, src.join("a.arrow").to_str().unwrap()).unwrap();
+        let staged: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(staged, vec!["a.arrow"], "only the chosen file may be staged");
+        // Reachable through the link, which is what the search will do.
+        assert_eq!(std::fs::read(std::path::Path::new(&dir).join("a.arrow")).unwrap(), b"a");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn staging_the_same_file_twice_is_not_an_error() {
+        // A re-run of the same job finds its own link already in place.
+        let src = scratch("twice");
+        std::fs::write(src.join("a.arrow"), b"a").unwrap();
+        let id = job_id("twice");
+        let path = src.join("a.arrow");
+        let first = stage_ms_file(&id, path.to_str().unwrap()).unwrap();
+        let second = stage_ms_file(&id, path.to_str().unwrap()).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(std::fs::read_dir(&first).unwrap().count(), 1);
+        let _ = std::fs::remove_dir_all(&first);
+    }
+
+    #[test]
+    fn refuses_a_directory_or_a_missing_path() {
+        let src = scratch("bad");
+        let id = job_id("bad");
+        assert!(stage_ms_file(&id, src.to_str().unwrap()).is_err());
+        assert!(stage_ms_file(&id, src.join("nope.arrow").to_str().unwrap()).is_err());
+    }
+}
+
+
 #[cfg(test)]
 mod extension_tests {
     use super::extension_of;

--- a/gui/src-tauri/src/paths.rs
+++ b/gui/src-tauri/src/paths.rs
@@ -181,43 +181,65 @@ pub fn read_config(path: &str) -> Result<String, String> {
     std::fs::read_to_string(&target).map_err(|e| format!("Could not read {}: {e}", target.display()))
 }
 
-/// Stage one MS data file as a directory that contains only that file.
+/// Stage a chosen set of files as a directory containing only those files.
 ///
-/// SearchDIA takes a *directory* and searches every `.arrow` inside it. There is
-/// no way to hand it a chosen handful out of a folder of forty, which is exactly
-/// what searching a batch of method-development files one at a time needs. So
-/// each such run gets its own directory holding a single link to the real file,
-/// and points `ms_data` at that.
+/// Every Pioneer program the console drives takes a *directory* (or a single
+/// file) and works on everything in it. None of them takes a list. But choosing
+/// a handful out of a folder of forty is what both "search these files
+/// separately" and "convert this list" mean, so each such run gets a directory
+/// built for it, holding links to exactly the files chosen.
 ///
-/// A link, not a copy: these files are gigabytes, and copying forty of them to
-/// search forty of them would be absurd. On Unix that is a symlink. On Windows a
-/// hard link is tried first — it needs no special privilege, where a symlink
-/// needs Developer Mode or an elevated process — and a symlink is the fallback
-/// for the case a hard link cannot serve, a source on another volume.
+/// SearchDIA stages one file per run — that is what makes them separate runs.
+/// ConvertRAW stages a whole format's worth into one, because the converters
+/// batch internally and there is no reason to make them start N times.
+///
+/// Links, not copies: these files are gigabytes. On Unix that is a symlink. On
+/// Windows a hard link is tried first — it needs no special privilege, where a
+/// symlink needs Developer Mode or an elevated process — and a symlink is the
+/// fallback for the one case a hard link cannot serve, a source on another
+/// volume.
 ///
 /// Lives beside the params file for the same job, under the same temp root, and
 /// is left behind for the same reason: it is part of the record of what ran.
-pub fn stage_ms_file(job_id: &str, file: &str) -> Result<String, String> {
-    let src = PathBuf::from(file);
-    if !src.is_file() {
-        return Err(format!("{file} is not a file"));
+///
+/// Two files with the same name from different folders cannot both be staged —
+/// one directory, one name each — so that is refused here rather than silently
+/// converting one file twice under the other's name.
+pub fn stage_files(job_id: &str, subdir: &str, files: &[String]) -> Result<String, String> {
+    if files.is_empty() {
+        return Err("nothing to stage".to_string());
     }
-    let name = src
-        .file_name()
-        .ok_or_else(|| format!("{file} has no file name"))?
-        .to_owned();
-
-    let dir = std::env::temp_dir().join("pioneer-console").join(job_id).join("ms_data");
+    let dir = std::env::temp_dir().join("pioneer-console").join(job_id).join(subdir);
     std::fs::create_dir_all(&dir).map_err(|e| format!("could not create {}: {e}", dir.display()))?;
 
-    let dst = dir.join(&name);
-    // A resumed or re-run job can find its own link already there. Remove rather
-    // than fail: the link is derived state, and the source it points at is the
-    // thing that matters.
-    if dst.symlink_metadata().is_ok() {
-        let _ = std::fs::remove_file(&dst);
+    let mut seen: Vec<String> = Vec::with_capacity(files.len());
+    for file in files {
+        let src = PathBuf::from(file);
+        if !src.is_file() {
+            return Err(format!("{file} is not a file"));
+        }
+        let name = src
+            .file_name()
+            .ok_or_else(|| format!("{file} has no file name"))?
+            .to_string_lossy()
+            .into_owned();
+        if seen.contains(&name) {
+            return Err(format!(
+                "two of the chosen files are both named {name}. They would have to \
+                 share one name in the folder handed to the converter; rename one, \
+                 or convert them separately."
+            ));
+        }
+        let dst = dir.join(&name);
+        // A resumed or re-run job can find its own link already there. Remove
+        // rather than fail: the link is derived state, and the source it points
+        // at is the thing that matters.
+        if dst.symlink_metadata().is_ok() {
+            let _ = std::fs::remove_file(&dst);
+        }
+        link_file(&src, &dst)?;
+        seen.push(name);
     }
-    link_file(&src, &dst)?;
     Ok(dir.display().to_string())
 }
 
@@ -247,12 +269,16 @@ fn link_file(src: &Path, dst: &Path) -> Result<(), String> {
 
 #[cfg(test)]
 mod staging_tests {
-    use super::stage_ms_file;
+    use super::stage_files;
 
     /// A unique job id per test, so the tests do not collide in the shared temp
     /// root and so a rerun does not see the previous run's links.
     fn job_id(tag: &str) -> String {
         format!("test-{tag}-{}", std::process::id())
+    }
+
+    fn path_of(dir: &std::path::Path, name: &str) -> String {
+        dir.join(name).to_string_lossy().into_owned()
     }
 
     fn scratch(tag: &str) -> std::path::PathBuf {
@@ -272,7 +298,7 @@ mod staging_tests {
         std::fs::write(src.join("b.arrow"), b"b").unwrap();
 
         let id = job_id("one");
-        let dir = stage_ms_file(&id, src.join("a.arrow").to_str().unwrap()).unwrap();
+        let dir = stage_files(&id, "ms_data", &[path_of(&src, "a.arrow")]).unwrap();
         let staged: Vec<String> = std::fs::read_dir(&dir)
             .unwrap()
             .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
@@ -289,12 +315,56 @@ mod staging_tests {
         let src = scratch("twice");
         std::fs::write(src.join("a.arrow"), b"a").unwrap();
         let id = job_id("twice");
-        let path = src.join("a.arrow");
-        let first = stage_ms_file(&id, path.to_str().unwrap()).unwrap();
-        let second = stage_ms_file(&id, path.to_str().unwrap()).unwrap();
+        let path = path_of(&src, "a.arrow");
+        let first = stage_files(&id, "ms_data", &[path.clone()]).unwrap();
+        let second = stage_files(&id, "ms_data", &[path.clone()]).unwrap();
         assert_eq!(first, second);
         assert_eq!(std::fs::read_dir(&first).unwrap().count(), 1);
         let _ = std::fs::remove_dir_all(&first);
+    }
+
+    #[test]
+    fn stages_a_whole_group_into_one_directory() {
+        // The ConvertRAW list case: several files, one run, one input folder.
+        let a = scratch("group-a");
+        let b = scratch("group-b");
+        std::fs::write(a.join("one.raw"), b"1").unwrap();
+        std::fs::write(a.join("two.raw"), b"2").unwrap();
+        // Deliberately from a different folder: a list is often assembled from
+        // more than one place, and all of it has to land in the same directory.
+        std::fs::write(b.join("three.raw"), b"3").unwrap();
+
+        let dir = stage_files(
+            &job_id("group"),
+            "raw_in",
+            &[path_of(&a, "one.raw"), path_of(&a, "two.raw"), path_of(&b, "three.raw")],
+        )
+        .unwrap();
+        let mut staged: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        staged.sort();
+        assert_eq!(staged, vec!["one.raw", "three.raw", "two.raw"]);
+        assert_eq!(std::fs::read(std::path::Path::new(&dir).join("three.raw")).unwrap(), b"3");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn refuses_two_chosen_files_with_the_same_name() {
+        // One directory cannot hold both, so converting the list would silently
+        // do one file twice. Refused with the name, rather than guessed at.
+        let a = scratch("dup-a");
+        let b = scratch("dup-b");
+        std::fs::write(a.join("QC_01.raw"), b"1").unwrap();
+        std::fs::write(b.join("QC_01.raw"), b"2").unwrap();
+        let err = stage_files(
+            &job_id("dup"),
+            "raw_in",
+            &[path_of(&a, "QC_01.raw"), path_of(&b, "QC_01.raw")],
+        )
+        .unwrap_err();
+        assert!(err.contains("QC_01.raw"), "the message must name the file: {err}");
     }
 
     #[test]
@@ -320,8 +390,9 @@ mod staging_tests {
     fn refuses_a_directory_or_a_missing_path() {
         let src = scratch("bad");
         let id = job_id("bad");
-        assert!(stage_ms_file(&id, src.to_str().unwrap()).is_err());
-        assert!(stage_ms_file(&id, src.join("nope.arrow").to_str().unwrap()).is_err());
+        assert!(stage_files(&id, "ms_data", &[src.to_string_lossy().into_owned()]).is_err());
+        assert!(stage_files(&id, "ms_data", &[path_of(&src, "nope.arrow")]).is_err());
+        assert!(stage_files(&id, "ms_data", &[]).is_err());
     }
 }
 

--- a/gui/src-tauri/src/pioneer.rs
+++ b/gui/src-tauri/src/pioneer.rs
@@ -10,7 +10,7 @@
 //!     bin/BuildSpecLib
 //!     bin/GetSearchParams
 //!     bin/GetBuildLibParams
-//!     bin/convertMzML
+//!     bin/convertMzML         Julia, ships with the CLI tools
 //!     bin/PioneerConverter    separate .NET 8 repo
 //!     lib/
 //! ```
@@ -31,6 +31,12 @@ pub enum Command {
     BuildSpecLib,
     DownloadSpecLib,
     ConvertRaw,
+    /// The other half of the ConvertRAW page. Same destination as ConvertRaw --
+    /// an Arrow file SearchDIA can read -- but a different program: Thermo
+    /// `.raw` needs the .NET converter, `.mzML` is handled by Pioneer's own
+    /// Julia one. The page picks between them; they are separate here because
+    /// they are separate binaries with separate flags and separate environments.
+    ConvertMzml,
 }
 
 impl Command {
@@ -40,6 +46,7 @@ impl Command {
             Command::BuildSpecLib => "BuildSpecLib",
             Command::DownloadSpecLib => "DownloadSpecLib",
             Command::ConvertRaw => "PioneerConverter",
+            Command::ConvertMzml => "convertMzML",
         }
     }
 
@@ -50,10 +57,13 @@ impl Command {
             Command::BuildSpecLib => "predict",
             Command::DownloadSpecLib => "download",
             Command::ConvertRaw => "convert-raw",
+            Command::ConvertMzml => "convert-mzml",
         }
     }
 
-    /// Julia-based executables need JULIA_NUM_THREADS; the .NET converter does not.
+    /// Julia-based executables need JULIA_NUM_THREADS; the .NET converter does
+    /// not. `convertMzML` is Julia, so it does -- it is the one converter that
+    /// honours the sidebar thread count.
     pub fn is_julia(self) -> bool {
         !matches!(self, Command::ConvertRaw)
     }
@@ -166,7 +176,7 @@ fn inspect(home: &Path, source: &str) -> Option<PioneerInfo> {
     let bin = home.join("bin");
     let mut executables = Vec::new();
     for cmd in [Command::SearchDia, Command::BuildSpecLib, Command::DownloadSpecLib,
-                Command::ConvertRaw] {
+                Command::ConvertRaw, Command::ConvertMzml] {
         if exe_path(&bin, cmd.exe_name()).is_some() {
             executables.push(cmd.exe_name().to_string());
         }

--- a/gui/src-tauri/src/runner.rs
+++ b/gui/src-tauri/src/runner.rs
@@ -124,6 +124,13 @@ pub enum Invocation {
     ParamsFile { json: String },
     /// Pass these arguments through verbatim.
     Args { args: Vec<String> },
+    /// Run the same program once per argument set, in order, as one job.
+    ///
+    /// For PioneerConverter over a chosen list of `.raw` files: its Thermo
+    /// reader takes one path and cannot read a linked file, so the list can
+    /// only be one invocation each — but that is one thing the user asked for
+    /// and should be one row in the queue, one log, and one outcome.
+    Steps { steps: Vec<Vec<String>> },
 }
 
 /// Everything needed to start one run.
@@ -162,20 +169,21 @@ pub struct Started {
 }
 
 /// Spawn the job and stream its output as events.
+///
+/// A job is usually one child process, but not always: `Invocation::Steps` runs
+/// several in order under a single job id, streaming into one log and reporting
+/// one outcome. That exists because PioneerConverter's Thermo reader cannot be
+/// handed a list and cannot read a linked file, so converting a chosen set of
+/// `.raw` means one invocation per file — while the queue should still show the
+/// one thing the user asked for.
 pub fn start(app: AppHandle, jobs: Arc<Jobs>, spec: Spec) -> Result<Started, String> {
     let resolved = pioneer::resolve_command(&spec.home, spec.command)?;
-
-    let mut cmd = Command::new(&resolved.program);
-    hide_console(&mut cmd);
-    for arg in &resolved.leading_args {
-        cmd.arg(arg);
-    }
 
     // `params_path` doubles as the record of what was run: for a params-file
     // command it is the JSON; for an argv command there is no file, so the
     // reported path is empty and the log carries the command line instead.
     let mut params_display = String::new();
-    match &spec.invocation {
+    let steps: Vec<Vec<String>> = match &spec.invocation {
         Invocation::ParamsFile { json } => {
             let params = params_path(&spec.job_id, spec.command);
             if let Some(parent) = params.parent() {
@@ -184,22 +192,20 @@ pub fn start(app: AppHandle, jobs: Arc<Jobs>, spec: Spec) -> Result<Started, Str
             }
             std::fs::write(&params, json)
                 .map_err(|e| format!("could not write {}: {e}", params.display()))?;
-            cmd.arg(&params);
             params_display = params.display().to_string();
+            vec![vec![params.display().to_string()]]
         }
-        Invocation::Args { args } => {
-            for a in args {
-                cmd.arg(a);
-            }
-        }
+        Invocation::Args { args } => vec![args.clone()],
+        Invocation::Steps { steps } => steps.clone(),
+    };
+    if steps.is_empty() {
+        return Err("nothing to run".to_string());
     }
-    cmd.stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .stdin(Stdio::null());
 
     // Bypassing the `pioneer` wrapper means we own these. Without
     // JULIA_NUM_THREADS a direct bin/SearchDIA call defaults to a single thread.
     let mut env_summary = String::new();
+    let mut envs: Vec<(String, String)> = Vec::new();
     if spec.command.is_julia() && !resolved.via_wrapper {
         // `JULIA_NUM_GC_THREADS` is the variable Julia actually reads — it is
         // the env form of `--gcthreads=N,M` (N marking, M concurrent sweeper).
@@ -208,14 +214,142 @@ pub fn start(app: AppHandle, jobs: Arc<Jobs>, spec: Spec) -> Result<Started, Str
         // Matches the `pioneer` wrapper's own formula, `(threads + 1) / 2`,
         // i.e. ceil rather than floor — so the GUI and the shell script agree.
         let gc = format!("{},1", ((spec.threads + 1) / 2).max(1));
-        cmd.env("JULIA_NUM_THREADS", spec.threads.to_string());
-        cmd.env("JULIA_NUM_GC_THREADS", &gc);
+        envs.push(("JULIA_NUM_THREADS".into(), spec.threads.to_string()));
+        envs.push(("JULIA_NUM_GC_THREADS".into(), gc.clone()));
         env_summary = format!(
             "JULIA_NUM_THREADS={} JULIA_NUM_GC_THREADS={}",
             spec.threads, gc
         );
     }
 
+    // The first step is spawned here rather than in the driver thread so that a
+    // distribution that cannot be executed at all still fails out of `start`,
+    // where the frontend surfaces it as an error on the Run button.
+    let multi = steps.len() > 1;
+    if multi {
+        announce(&app, &spec.job_id, &resolved, &steps[0], 1, steps.len());
+    }
+    let first = spawn_step(&resolved, &steps[0], &envs)?;
+
+    let cancelled = Arc::new(AtomicBool::new(false));
+    jobs.insert(
+        spec.job_id.clone(),
+        JobHandle { pid: first.id(), cancelled: Arc::clone(&cancelled) },
+    );
+
+    // Driver thread: owns each Child in turn, and reports one terminal state for
+    // the whole sequence.
+    let job_id = spec.job_id.clone();
+    let jobs_for_wait = Arc::clone(&jobs);
+    std::thread::spawn(move || {
+        let mut child = first;
+        let mut index = 0usize;
+        let event = loop {
+            // Drain both pipes to completion before the next step starts, so a
+            // step's output cannot interleave with the tail of the one before.
+            let out = child.stdout.take().map(|r| pump(app.clone(), job_id.clone(), r, "stdout"));
+            let err = child.stderr.take().map(|r| pump(app.clone(), job_id.clone(), r, "stderr"));
+            let status = child.wait();
+            if let Some(h) = out {
+                let _ = h.join();
+            }
+            if let Some(h) = err {
+                let _ = h.join();
+            }
+            let was_cancelled = cancelled.load(Ordering::SeqCst);
+
+            let st = match status {
+                Ok(st) => st,
+                Err(e) => {
+                    break ExitEvent {
+                        job_id: job_id.clone(),
+                        code: None,
+                        success: false,
+                        cancelled: was_cancelled,
+                        message: format!("Could not wait for Pioneer: {e}"),
+                    }
+                }
+            };
+
+            index += 1;
+            let last = index >= steps.len();
+            // A failed step ends the job: the steps of a sequence are the same
+            // command over different files, and continuing after one has failed
+            // would bury the failure under whatever came next.
+            if was_cancelled || !st.success() || last {
+                let success = st.success() && !was_cancelled;
+                let code = st.code();
+                let message = if was_cancelled {
+                    "Cancelled by user.".to_string()
+                } else if success {
+                    String::new()
+                } else {
+                    let where_ = if multi {
+                        format!(" on step {index} of {}", steps.len())
+                    } else {
+                        String::new()
+                    };
+                    match code {
+                        Some(c) => format!("Pioneer exited with code {c}{where_}."),
+                        None => format!("Pioneer was terminated by a signal{where_}."),
+                    }
+                };
+                break ExitEvent {
+                    job_id: job_id.clone(),
+                    code,
+                    success,
+                    cancelled: was_cancelled,
+                    message,
+                };
+            }
+
+            announce(&app, &job_id, &resolved, &steps[index], index + 1, steps.len());
+            match spawn_step(&resolved, &steps[index], &envs) {
+                Ok(next) => {
+                    // Replaces the previous entry, so a cancel now kills the
+                    // step that is actually running.
+                    jobs_for_wait.insert(
+                        job_id.clone(),
+                        JobHandle { pid: next.id(), cancelled: Arc::clone(&cancelled) },
+                    );
+                    child = next;
+                }
+                Err(e) => {
+                    break ExitEvent {
+                        job_id: job_id.clone(),
+                        code: None,
+                        success: false,
+                        cancelled: false,
+                        message: e,
+                    }
+                }
+            }
+        };
+        jobs_for_wait.remove(&job_id);
+        let _ = app.emit("job-exit", event);
+    });
+
+    Ok(Started { params_path: params_display, env_summary })
+}
+
+/// Build and spawn one step of a job.
+fn spawn_step(
+    resolved: &pioneer::Resolved,
+    args: &[String],
+    envs: &[(String, String)],
+) -> Result<Child, String> {
+    let mut cmd = Command::new(&resolved.program);
+    hide_console(&mut cmd);
+    for arg in &resolved.leading_args {
+        cmd.arg(arg);
+    }
+    for a in args {
+        cmd.arg(a);
+    }
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).stdin(Stdio::null());
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
     // Put the child in its own process group so cancel can take down Julia's
     // worker processes too, not just the parent.
     #[cfg(unix)]
@@ -223,64 +357,41 @@ pub fn start(app: AppHandle, jobs: Arc<Jobs>, spec: Spec) -> Result<Started, Str
         use std::os::unix::process::CommandExt;
         cmd.process_group(0);
     }
+    cmd.spawn()
+        .map_err(|e| format!("could not start {}: {e}", resolved.program.display()))
+}
 
-    let mut child: Child = cmd
-        .spawn()
-        .map_err(|e| format!("could not start {}: {e}", resolved.program.display()))?;
-
-    let pid = child.id();
-    let cancelled = Arc::new(AtomicBool::new(false));
-    jobs.insert(
-        spec.job_id.clone(),
-        JobHandle { pid, cancelled: Arc::clone(&cancelled) },
+/// Write a header into the log naming the step about to run.
+///
+/// Only for multi-step jobs, where the log would otherwise be several files'
+/// output run together with nothing saying where one ends and the next begins.
+fn announce(
+    app: &AppHandle,
+    job_id: &str,
+    resolved: &pioneer::Resolved,
+    args: &[String],
+    n: usize,
+    total: usize,
+) {
+    let program = resolved
+        .program
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| resolved.program.display().to_string());
+    let quoted: Vec<String> = args
+        .iter()
+        .map(|a| if a.contains(' ') { format!("\"{a}\"") } else { a.clone() })
+        .collect();
+    let _ = app.emit(
+        "job-line",
+        LineEvent {
+            job_id: job_id.to_string(),
+            line: format!("[{n}/{total}] {program} {}", quoted.join(" ")),
+            stream: "stdout",
+            transient: false,
+            overwrite: 0,
+        },
     );
-
-    let stdout = child.stdout.take();
-    let stderr = child.stderr.take();
-
-    if let Some(out) = stdout {
-        pump(app.clone(), spec.job_id.clone(), out, "stdout");
-    }
-    if let Some(err) = stderr {
-        pump(app.clone(), spec.job_id.clone(), err, "stderr");
-    }
-
-    // Waiter thread: owns the Child, reports the terminal state.
-    let job_id = spec.job_id.clone();
-    let jobs_for_wait = Arc::clone(&jobs);
-    std::thread::spawn(move || {
-        let status = child.wait();
-        jobs_for_wait.remove(&job_id);
-        let was_cancelled = cancelled.load(Ordering::SeqCst);
-
-        let event = match status {
-            Ok(st) => {
-                let code = st.code();
-                let success = st.success() && !was_cancelled;
-                let message = if was_cancelled {
-                    "Cancelled by user.".to_string()
-                } else if success {
-                    String::new()
-                } else {
-                    match code {
-                        Some(c) => format!("Pioneer exited with code {c}."),
-                        None => "Pioneer was terminated by a signal.".to_string(),
-                    }
-                };
-                ExitEvent { job_id: job_id.clone(), code, success, cancelled: was_cancelled, message }
-            }
-            Err(e) => ExitEvent {
-                job_id: job_id.clone(),
-                code: None,
-                success: false,
-                cancelled: was_cancelled,
-                message: format!("Could not wait for Pioneer: {e}"),
-            },
-        };
-        let _ = app.emit("job-exit", event);
-    });
-
-    Ok(Started { params_path: params_display, env_summary })
 }
 
 /// Forward one pipe to the frontend, honouring terminal carriage-return
@@ -297,7 +408,7 @@ fn pump<R: std::io::Read + Send + 'static>(
     job_id: String,
     reader: R,
     stream: &'static str,
-) {
+) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         let mut buf = BufReader::new(reader);
         let mut splitter = LineSplitter::default();
@@ -334,7 +445,7 @@ fn pump<R: std::io::Read + Send + 'static>(
                 },
             );
         }
-    });
+    })
 }
 
 /// One line ready to show, with the terminal control that applied to it.

--- a/gui/src-tauri/src/runner.rs
+++ b/gui/src-tauri/src/runner.rs
@@ -147,6 +147,7 @@ fn params_path(job_id: &str, command: pioneer::Command) -> PathBuf {
         // Argv-driven, so it never writes one; named for completeness.
         pioneer::Command::DownloadSpecLib => "download.json",
         pioneer::Command::ConvertRaw => "convert.json",
+        pioneer::Command::ConvertMzml => "convertmzml.json",
     };
     dir.join(name)
 }

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -52,6 +52,7 @@ import {
   EMPTY_PATH_INFO,
   SEARCH_DEFAULTS,
   DOWNLOAD_DEFAULTS,
+  type BackendCommand,
   type BuildParams,
   type CommandId,
   type ConvertParams,
@@ -228,7 +229,7 @@ const SUBTITLES: Record<CommandId, string> = {
   searchdia: 'Find & quantify proteins',
   buildspeclib: 'Predict a spectral library',
   downloadspeclib: 'Download a prebuilt spectral library',
-  convertraw: 'Convert .raw files to Arrow',
+  convertraw: 'Convert .raw or .mzML files to Arrow',
 }
 
 /** Append one line of process output, emulating the bits of a terminal that
@@ -457,7 +458,10 @@ export default function App() {
       // full-specific build. The same applies to the cleavage rule.
       setBuild({ ...BUILD_DEFAULTS, ...job.snapshot.build })
     } else if (job.snapshot.cmd === 'downloadspeclib') setDownload(job.snapshot.download)
-    else setConvert(job.snapshot.convert)
+    // Same reason as the build merge above: runs stored before the mzML
+    // converter existed carry no `format`, and recalling one must still render
+    // a form with a format selected rather than neither segment lit.
+    else setConvert({ ...CONVERT_DEFAULTS, ...job.snapshot.convert })
     setRunError('')
   }, [command, search, build, convert])
 
@@ -818,8 +822,16 @@ export default function App() {
       ),
     )
 
+    // The ConvertRAW workflow drives two binaries. Which one is a property of
+    // the run, not of the tab, so it is read off the snapshot rather than the
+    // command id -- that way a restored mzML run re-runs as an mzML run.
+    const backendCmd: BackendCommand =
+      next.snapshot.cmd === 'convertraw' && next.snapshot.convert.format === 'mzml'
+        ? 'convertmzml'
+        : next.cmd
+
     backend
-      .startJob(next.id, next.cmd, next.invocation, next.threads)
+      .startJob(next.id, backendCmd, next.invocation, next.threads)
       .then(({ params_path, env_summary }) => {
         setJobs((prev) =>
           prev.map((j) =>
@@ -908,10 +920,18 @@ export default function App() {
   }
 
   const browseConvertInput = async () => {
+    // `gz` is offered alongside `mzML` because convertMzML reads `.mzML.gz`,
+    // and the dialog filters on the final extension only -- without it a
+    // compressed file the converter handles fine would be unpickable.
+    const mzml = convert.format === 'mzml'
     const picked =
       convert.inputMode === 'file'
-        ? await backend.pickFile('Choose a .raw file', 'Thermo RAW', ['raw'])
-        : await backend.pickFolder('Choose a folder of .raw files')
+        ? mzml
+          ? await backend.pickFile('Choose an .mzML file', 'mzML', ['mzML', 'gz'])
+          : await backend.pickFile('Choose a .raw file', 'Thermo RAW', ['raw'])
+        : await backend.pickFolder(
+            mzml ? 'Choose a folder of .mzML files' : 'Choose a folder of .raw files',
+          )
     if (picked) onParam('input', picked)
   }
 
@@ -1258,8 +1278,10 @@ export default function App() {
       setRunError(pioneerError)
       return
     }
-    // Not on ConvertRAW: the picker is hidden there and the value is unused,
-    // so blocking on it would be an error about an invisible control.
+    // Not on ConvertRAW: the picker is hidden there, so blocking on it would be
+    // an error about an invisible control. The value is still passed through --
+    // convertMzML spawns on Julia threads -- but it is never zero, because it is
+    // seeded from the core count and only this hidden control could clear it.
     if (!isConvert && threads < 1) {
       setRunError(`Enter a thread count between 1 and ${maxThreads}.`)
       const el = document.querySelector('[data-key="threads"]')
@@ -1523,9 +1545,12 @@ export default function App() {
             <div style={{ fontSize: 12.5, color: '#667085', marginTop: 1 }}>{SUBTITLES[command]}</div>
           </div>
           <TopBar
-            // ConvertRAW is a .NET program: it never reads JULIA_NUM_THREADS,
-            // and its own thread count lives in the form. A picker here would
-            // be a control that changes nothing.
+            // Neither converter wants a picker here. PioneerConverter is .NET
+            // and never reads JULIA_NUM_THREADS at all; convertMzML is Julia and
+            // does, but its own knob is files-at-a-time and a second control
+            // would just be the multiplying-knobs trap the RAW path already
+            // avoids. The backend sets JULIA_NUM_THREADS from this value
+            // regardless, so the mzML converter still gets threads to spawn on.
             showThreads={!isConvert}
             threads={threads}
             maxThreads={maxThreads}

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -16,6 +16,7 @@ import {
   buildConvertArgs,
   convertGroups,
   groupParams,
+  rawStepArgs,
   downloadCommandLine,
   buildDownloadArgs,
   buildLibJson,
@@ -778,6 +779,40 @@ export default function App() {
 
   // ---- job events --------------------------------------------------------
 
+  /** Downgrade a "successful" conversion that produced nothing.
+   *
+   *  See the call site: the converter's exit code does not mean what it looks
+   *  like it means. Runs after the exit event rather than instead of it, so the
+   *  log the user is already reading stays intact and only the verdict changes.
+   */
+  const verifyConversionProduced = useCallback(async (job: Job) => {
+    if (job.snapshot.cmd !== 'convertraw') return
+    const c = job.snapshot.convert
+    const dir = c.outputDir.trim() || `${c.input.trim().replace(/[\\/]$/, '')}/arrow_out`
+    if (!dir) return
+    const info = await backend.inspectPath(dir)
+    if (info.arrow_count > 0) return
+    setJobs((prev) =>
+      prev.map((j) =>
+        j.id === job.id
+          ? {
+              ...j,
+              status: 'failed' as JobStatus,
+              failMsg: 'The converter reported success but wrote no .arrow files.',
+              logLines: [
+                ...j.logLines,
+                {
+                  text: `ERROR: no .arrow files in ${dir}. The converter exited 0 but converted nothing — check the messages above for files it could not open.`,
+                  stream: 'app' as const,
+                  transient: false,
+                },
+              ],
+            }
+          : j,
+      ),
+    )
+  }, [])
+
   useEffect(() => {
     const unlisteners: Array<() => void> = []
     // The listeners are registered asynchronously. If this effect is torn down
@@ -801,6 +836,16 @@ export default function App() {
           prev.map((j) => {
             if (j.id !== job_id) return j
             const status: JobStatus = cancelled ? 'cancelled' : success ? 'done' : 'failed'
+            // A conversion that exits 0 is not necessarily a conversion that
+            // happened: PioneerConverter reports every file it could not open
+            // and still exits 0, so a whole batch can fail while the queue says
+            // "done" and the output folder stays empty. Checked rather than
+            // trusted -- but only when the folder holds no .arrow at all, so a
+            // run that legitimately skipped everything (--skip-existing) or
+            // added to an existing folder is never called a failure.
+            if (status === 'done' && j.cmd === 'convertraw') {
+              void verifyConversionProduced(j)
+            }
             return {
               ...j,
               status,
@@ -1284,9 +1329,27 @@ export default function App() {
           convert.inputMode === 'files'
             ? convertGroups(convert.inputFiles)
                 .map((g) =>
-                  convertCommandLine(
-                    groupParams(convert, g, `<${g.files.length} staged ${g.format === 'raw' ? '.raw' : '.mzML'} file${g.files.length > 1 ? 's' : ''}>`),
-                  ),
+                  g.format === 'raw'
+                    ? // Exactly what will run: one line per file, real paths.
+                      g.files
+                        .map((f) =>
+                          convertCommandLine({
+                            ...convert,
+                            format: 'raw',
+                            inputMode: 'folder',
+                            input: f,
+                          }),
+                        )
+                        .join('\n')
+                    : // One invocation over a staging folder named after a job
+                      // id that does not exist yet, so the path stands in.
+                      convertCommandLine(
+                        groupParams(
+                          convert,
+                          g,
+                          `<${g.files.length} staged .mzML file${g.files.length > 1 ? 's' : ''}>`,
+                        ),
+                      ),
                 )
                 .join('\n\n') || 'Add files to convert.'
             : convertCommandLine(convert)
@@ -1347,6 +1410,7 @@ export default function App() {
     title: string,
     over?: SearchParams,
     overConvert?: ConvertParams,
+    convertSteps?: string[][],
   ): Job => {
     const s = over ?? search
     const c = overConvert ?? convert
@@ -1378,7 +1442,9 @@ export default function App() {
       failMsg: '',
       paramsJson: json,
       invocation: isConvert
-        ? { kind: 'args' as const, args: buildConvertArgs(c) }
+        ? convertSteps
+          ? { kind: 'steps' as const, steps: convertSteps }
+          : { kind: 'args' as const, args: buildConvertArgs(c) }
         : isDownload
           ? { kind: 'args' as const, args: buildDownloadArgs(download) }
           : { kind: 'paramsFile' as const, json },
@@ -1432,6 +1498,31 @@ export default function App() {
       const base = resolveRunName(jobName, taken)
       for (const group of groups) {
         const { id, runNo } = await allocate()
+        // Suffixed only when there are two, so a list of one format keeps the
+        // plain name rather than gaining a label that distinguishes nothing.
+        const title =
+          groups.length > 1 ? resolveRunName(`${base}-${group.format}`, taken) : base
+        taken.add(title)
+
+        if (group.format === 'raw') {
+          // One invocation per file on its real path -- PioneerConverter's
+          // Thermo reader cannot open a linked .raw (see convertGroups) -- but
+          // one job, because one list is one thing the user asked for. `input`
+          // on the snapshot is the first file, so recalling the run and the
+          // "point SearchDIA at the output" step both still have a path.
+          added.push(
+            makeJob(
+              id,
+              runNo,
+              title,
+              undefined,
+              { ...convert, format: 'raw', inputMode: 'folder', input: group.files[0] },
+              rawStepArgs(convert, group),
+            ),
+          )
+          continue
+        }
+
         let dir: string
         try {
           dir = await backend.stageFiles(id, `${group.format}_in`, group.files)
@@ -1439,11 +1530,6 @@ export default function App() {
           failure = String(e)
           break
         }
-        // Suffixed only when there are two, so a list of one format keeps the
-        // plain name rather than gaining a label that distinguishes nothing.
-        const title =
-          groups.length > 1 ? resolveRunName(`${base}-${group.format}`, taken) : base
-        taken.add(title)
         added.push(makeJob(id, runNo, title, undefined, groupParams(convert, group, dir)))
       }
     } else {

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -737,18 +737,20 @@ export default function App() {
     [build.calibrationFile, pathInfos],
   )
 
+  // Depends on the whole `convert` object, not a list of its fields. The list
+  // was a trap: convertInputNote takes the object, so every field it reads has
+  // to be named here, and adding `format` to the validator without adding it
+  // here left the note reading "switch the format to .mzML" after the format
+  // had been switched. The deps lint that would have caught it is off (see
+  // `info`, which is rebuilt every render), so nothing did. Recomputing when an
+  // unrelated field like batchSize changes costs two pure string comparisons.
   const convertNotes = useMemo(
     () => ({
       input: convertInputNote(convert, info('convertInput')),
       output: convertOutputNote(convert.outputDir, info('convertOutput')),
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      convert.input,
-      convert.inputMode,
-      convert.outputDir,
-      pathInfos,
-    ],
+    [convert, pathInfos],
   )
 
   const libNote = useMemo(

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -72,6 +72,8 @@ import {
 import {
   calibrationNote,
   convertInputNote,
+  fileStem,
+  joinPath,
   convertOutputNote,
   fastaNote,
   libPathNote,
@@ -919,6 +921,24 @@ export default function App() {
     else setBuild((p) => ({ ...p, [key]: !p[key as keyof BuildParams] }))
   }
 
+  /** Add to the file list rather than replacing it: a batch is often assembled
+   *  from more than one folder, and a picker that discarded the previous
+   *  selection would make that impossible. Duplicates are dropped -- the same
+   *  file twice would be the same search twice. */
+  const addMsFiles = async () => {
+    const picked = await backend.pickFiles('Choose the files to search', 'MS data', ['arrow'])
+    if (picked.length === 0) return
+    setSearch((p) => {
+      const have = new Set(p.msDataFiles)
+      return { ...p, msDataFiles: [...p.msDataFiles, ...picked.filter((f) => !have.has(f))] }
+    })
+    setRunError('')
+  }
+
+  const removeMsFile = (index: number) => {
+    setSearch((p) => ({ ...p, msDataFiles: p.msDataFiles.filter((_, i) => i !== index) }))
+  }
+
   const browseConvertInput = async () => {
     // `gz` is offered alongside `mzML` because convertMzML reads `.mzML.gz`,
     // and the dialog filters on the final extension only -- without it a
@@ -1180,6 +1200,24 @@ export default function App() {
 
   const currentExtras = extras[command] ?? null
 
+  /** What the JSON preview describes.
+   *
+   *  In folder mode that is the form itself. In file-list mode one click makes
+   *  several runs and there is no single config to show, so the preview stands
+   *  for the first of them -- the settings below the paths are shared by all of
+   *  them, and those are what the preview is read for.
+   *
+   *  `ms_data` shows the chosen file rather than the directory the run is
+   *  actually handed. That directory is created when the run starts, is named
+   *  after a job id that does not exist yet, and holds nothing but a link to
+   *  this file -- so the file is both the honest answer and the useful one. The
+   *  params file written for each run does carry the real path. */
+  const previewSearch = useMemo(() => {
+    if (!isSearch || search.msDataMode !== 'files' || search.msDataFiles.length === 0) return search
+    const first = search.msDataFiles[0]
+    return { ...search, msData: first, results: joinPath(search.results, fileStem(first)) }
+  }, [isSearch, search])
+
   const jsonText = useMemo(
     () =>
       isDownload
@@ -1190,13 +1228,13 @@ export default function App() {
           // the command we would run. Run refuses in that state anyway.
           convertCommandLine(convert)
         : JSON.stringify(
-            isSearch ? buildSearchJson(search, currentExtras) : buildLibJson(build, currentExtras),
+            isSearch ? buildSearchJson(previewSearch, currentExtras) : buildLibJson(build, currentExtras),
             null,
             2,
           ),
     // `threads` belongs here: the ConvertRAW preview renders --threads-per-file
     // from it, so without it the command line goes stale when the stepper moves.
-    [isConvert, isDownload, isSearch, search, build, convert, download, currentExtras, threads],
+    [isConvert, isDownload, isSearch, previewSearch, build, convert, download, currentExtras, threads],
   )
 
   const overwriteNote = isConvert
@@ -1220,25 +1258,40 @@ export default function App() {
    *  a preview that reshuffles on every keystroke is noise. */
   const resolvedJobName = trimmedJobName ? resolveRunName(trimmedJobName, takenTitles) : ''
 
-  const enqueue = async () => {
+  /** Claim the identity for one run: a session-unique id, and the next history
+   *  number from the store. Separate from building the job because a fanned-out
+   *  search needs the id first — the staging directory is named after it — and
+   *  the parameters only afterwards. */
+  const allocate = async (): Promise<{ id: string; runNo: number }> => {
     jobSeq.current += 1
     const id = `${sessionId.current}-job${jobSeq.current}`
     // From the store, so it keeps climbing across restarts and cannot
     // diverge from the rows it numbers. Falls back to the local counter if
     // the store is unavailable.
     const runNo = await backend.historyNextRunNo().catch(() => nextRunNo())
-    const job: Job = {
+    return { id, runNo }
+  }
+
+  /** One queued job, ready to be appended.
+   *
+   *  `over` replaces the search parameters for a fanned-out run, which differs
+   *  from the form only in its `ms_data` and `results` paths. The JSON is built
+   *  by the same function either way, so the two cannot drift apart. */
+  const makeJob = (id: string, runNo: number, title: string, over?: SearchParams): Job => {
+    const s = over ?? search
+    const json = over ? JSON.stringify(buildSearchJson(over, currentExtras), null, 2) : jsonText
+    return {
       id,
       runNo,
       finishedAt: 0,
       cmd: command,
-      title: resolveRunName(jobName, jobs.map((j) => j.title)),
+      title,
       snapshot: isConvert
         ? { cmd: 'convertraw' as const, convert }
         : isDownload
           ? { cmd: 'downloadspeclib' as const, download }
           : isSearch
-            ? { cmd: 'searchdia' as const, search }
+            ? { cmd: 'searchdia' as const, search: s }
             : { cmd: 'buildspeclib' as const, build },
       target:
         (isConvert
@@ -1246,31 +1299,75 @@ export default function App() {
           : isDownload
             ? download.dest
             : isSearch
-              ? search.results
-              : libraryTargetPath(build.libPath)) || '—',
+              ? s.results
+              : libraryTargetPath(build.libPath)) || '\u2014',
       threads: Math.max(1, threads),
       status: 'queued',
       logLines: [],
       failMsg: '',
-      paramsJson: jsonText,
+      paramsJson: json,
       invocation: isConvert
         ? { kind: 'args' as const, args: buildConvertArgs(convert) }
         : isDownload
           ? { kind: 'args' as const, args: buildDownloadArgs(download) }
-          : { kind: 'paramsFile' as const, json: jsonText },
-      viewerPaths: isSearch
-        ? { results: search.results, msData: search.msData, library: search.library }
-        : null,
+          : { kind: 'paramsFile' as const, json },
+      viewerPaths: isSearch ? { results: s.results, msData: s.msData, library: s.library } : null,
       paramsPath: '',
     }
-    setJobs((prev) => [...prev, job])
-    // If this run came from tweaking a past one, follow the new job rather than
-    // staying pointed at the old one. The stashed draft is deliberately kept, so
-    // a workflow tab still gives back the work in progress.
-    setInspectingJobId((current) => (current ? id : null))
-    setViewJobId(id)
-    setDrawerOpen(true)
-    setRunError('')
+  }
+
+  const enqueue = async () => {
+    const taken = new Set(jobs.map((j) => j.title))
+    const added: Job[] = []
+    let failure = ''
+
+    if (isSearch && search.msDataMode === 'files') {
+      // One run per file. Pioneer has no way to be handed a list -- it takes a
+      // directory and searches everything in it -- so each run gets a directory
+      // of its own holding a single link to its file, plus a results folder
+      // named after that file. Together those are what "search these
+      // separately" means: no shared FDR, no match-between-runs across files
+      // that are meant to be compared, and one output tree per file.
+      const base = resolveRunName(jobName, taken)
+      for (const file of search.msDataFiles) {
+        const stem = fileStem(file)
+        const { id, runNo } = await allocate()
+        let msData: string
+        try {
+          msData = await backend.stageMsFile(id, file)
+        } catch (e) {
+          // Stop rather than queue a run pointed at nothing. Whatever was
+          // already built stays queued -- those files are fine, and dropping
+          // them too would turn one bad path into a wasted batch.
+          failure = `Could not prepare ${stem}: ${String(e)}`
+          break
+        }
+        const title = resolveRunName(`${base}-${stem}`, taken)
+        taken.add(title)
+        added.push(
+          makeJob(id, runNo, title, {
+            ...search,
+            msData,
+            results: joinPath(search.results, stem),
+          }),
+        )
+      }
+    } else {
+      const { id, runNo } = await allocate()
+      added.push(makeJob(id, runNo, resolveRunName(jobName, taken)))
+    }
+
+    if (added.length > 0) {
+      setJobs((prev) => [...prev, ...added])
+      // If this run came from tweaking a past one, follow the new job rather
+      // than staying pointed at the old one. The stashed draft is deliberately
+      // kept, so a workflow tab still gives back the work in progress.
+      const first = added[0].id
+      setInspectingJobId((current) => (current ? first : null))
+      setViewJobId(first)
+      setDrawerOpen(true)
+    }
+    setRunError(failure)
   }
 
   const run = (skipOverwriteCheck = false) => {
@@ -1653,6 +1750,8 @@ export default function App() {
                 onParam={onParam}
                 onToggle={onToggle}
                 onBrowse={onBrowseSearch}
+                onAddMsFiles={addMsFiles}
+                onRemoveMsFile={removeMsFile}
                 onJobName={setJobName}
                 onOpenLoad={() => setLoadOpen(true)}
                 onGoToBuild={() => setCommand('buildspeclib')}

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -497,9 +497,22 @@ export default function App() {
     setInspectingJobId(null)
   }, [])
 
-  /** `${id}:${status}` pairs already written, so a re-render does not rewrite
-   *  the history — but a status *change* does write, which is what lets an
-   *  interrupted run be recognised later. */
+  /** What a row has to match to count as already written.
+   *
+   *  Status, because a change of it is exactly what has to be persisted — that
+   *  is how an interrupted run is recognised next launch. And runNo, because
+   *  reordering the queue reassigns it and a status that has not changed would
+   *  otherwise suppress the write.
+   *
+   *  One function rather than the same template written twice: it was written
+   *  twice, the two drifted (the seed omitted runNo), and the mismatch meant
+   *  every row read from the store was immediately written back to it — a
+   *  full rewrite of the entire history on every launch, which at a few
+   *  thousand runs is a few thousand IPC round trips and SQLite upserts before
+   *  the app is any use. */
+  const runKey = (j: Job) => `${j.id}:${j.status}:${j.runNo}`
+
+  /** Rows already written, so a re-render does not rewrite the history. */
   const savedRuns = useRef(new Set<string>())
 
   useEffect(() => {
@@ -508,9 +521,7 @@ export default function App() {
       // is how interruption is detected: if the app goes away, the row stays
       // pending on disk and startup can see it never finished. Waiting for a
       // close event would miss a crash or a force quit.
-      // runNo is part of the key because reordering the queue reassigns it,
-      // and a status that has not changed would otherwise suppress the write.
-      const key = `${j.id}:${j.status}:${j.runNo}`
+      const key = runKey(j)
       if (savedRuns.current.has(key)) continue
       savedRuns.current.add(key)
       backend.historySave(jobToRun(j)).catch(() => {
@@ -553,7 +564,7 @@ export default function App() {
               ? { ...j, status: 'interrupted' as JobStatus }
               : j
           })
-        merged.forEach((j) => savedRuns.current.add(`${j.id}:${j.status}`))
+        merged.forEach((j) => savedRuns.current.add(runKey(j)))
         // Persist only the reinterpretations, so they are not redone next launch.
         const onDisk = new Map(rows.map((r) => [r.id, r.status]))
         merged

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -873,7 +873,23 @@ export default function App() {
 
   const onParam = (key: string, value: string) => {
     if (isSearch) setSearch((p) => ({ ...p, [key]: value }))
-    else if (isConvert) setConvert((p) => ({ ...p, [key]: value }))
+    else if (isConvert)
+      setConvert((p) => {
+        const next = { ...p, [key]: value }
+        // Switching between a file and a folder invalidates whatever is in the
+        // box: a path to a .raw file is never a folder of them, and the other
+        // way round. Leaving it there means the field reads as filled in while
+        // showing an error, and the Browse dialog opens on a path that cannot
+        // be what is wanted. Cleared only on a real change, so re-clicking the
+        // mode you are already in does not wipe the path.
+        //
+        // Deliberately not done for the format toggle beside it: there the
+        // stale path is what makes "No .raw files in this folder, but 3 .mzML
+        // files -- switch the format" possible, and that message is more use
+        // than an empty box.
+        if (key === 'inputMode' && value !== p.inputMode) next.input = ''
+        return next
+      })
     else if (key === 'predictionModel') switchModel(value)
     else setBuild((p) => ({ ...p, [key]: value }))
     setRunError('')

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -940,14 +940,14 @@ export default function App() {
   }
 
   const browseConvertInput = async () => {
-    // `gz` is offered alongside `mzML` because convertMzML reads `.mzML.gz`,
-    // and the dialog filters on the final extension only -- without it a
-    // compressed file the converter handles fine would be unpickable.
+    // No `gz`: convertMzML matches `endswith(lowercase(path), ".mzml")` and has
+    // no decompression step, so offering a compressed file here would let one
+    // be picked and then converted into nothing.
     const mzml = convert.format === 'mzml'
     const picked =
       convert.inputMode === 'file'
         ? mzml
-          ? await backend.pickFile('Choose an .mzML file', 'mzML', ['mzML', 'gz'])
+          ? await backend.pickFile('Choose an .mzML file', 'mzML', ['mzML'])
           : await backend.pickFile('Choose a .raw file', 'Thermo RAW', ['raw'])
         : await backend.pickFolder(
             mzml ? 'Choose a folder of .mzML files' : 'Choose a folder of .raw files',

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -14,6 +14,8 @@ import { Sidebar } from './components/Sidebar'
 import * as backend from './lib/backend'
 import {
   buildConvertArgs,
+  convertGroups,
+  groupParams,
   downloadCommandLine,
   buildDownloadArgs,
   buildLibJson,
@@ -609,7 +611,7 @@ export default function App() {
           return
         }
         if (kind === 'file' && isDir) {
-          setRunError('That is a folder — this field takes a single file.')
+          setRunError('That is a folder — this field takes a file.')
           return
         }
         setRunError('')
@@ -620,7 +622,22 @@ export default function App() {
           return
         }
         if (key === 'convertInput') {
-          setConvert((c) => ({ ...c, input: path, inputMode: isDir ? 'folder' : 'file' }))
+          // Dropping a folder means folder mode; dropping files means the list,
+          // and every dropped path joins it rather than only the first -- the
+          // whole point of the list is that a batch arrives at once. The mode
+          // follows what was dropped, so neither has to be chosen first.
+          if (isDir) {
+            setConvert((c) => ({ ...c, input: path, inputMode: 'folder' }))
+          } else {
+            setConvert((c) => {
+              const have = new Set(c.inputFiles)
+              return {
+                ...c,
+                inputMode: 'files',
+                inputFiles: [...c.inputFiles, ...paths.filter((f) => !have.has(f))],
+              }
+            })
+          }
           return
         }
         // `data-key` doubles as the scroll target for validation errors, and
@@ -958,19 +975,33 @@ export default function App() {
   }
 
   const browseConvertInput = async () => {
-    // No `gz`: convertMzML matches `endswith(lowercase(path), ".mzml")` and has
-    // no decompression step, so offering a compressed file here would let one
-    // be picked and then converted into nothing.
-    const mzml = convert.format === 'mzml'
-    const picked =
-      convert.inputMode === 'file'
-        ? mzml
-          ? await backend.pickFile('Choose an .mzML file', 'mzML', ['mzML'])
-          : await backend.pickFile('Choose a .raw file', 'Thermo RAW', ['raw'])
-        : await backend.pickFolder(
-            mzml ? 'Choose a folder of .mzML files' : 'Choose a folder of .raw files',
-          )
+    const picked = await backend.pickFolder(
+      convert.format === 'mzml' ? 'Choose a folder of .mzML files' : 'Choose a folder of .raw files',
+    )
     if (picked) onParam('input', picked)
+  }
+
+  /** Add to the convert list rather than replacing it, for the same reason the
+   *  search list does: a batch is usually assembled from more than one folder.
+   *
+   *  One picker for both formats -- the list is allowed to mix them, and which
+   *  converter each file goes to is decided from its name at run time. No `gz`:
+   *  neither converter decompresses. */
+  const addConvertFiles = async () => {
+    const picked = await backend.pickFiles('Choose the files to convert', 'MS data', [
+      'raw',
+      'mzML',
+    ])
+    if (picked.length === 0) return
+    setConvert((p) => {
+      const have = new Set(p.inputFiles)
+      return { ...p, inputFiles: [...p.inputFiles, ...picked.filter((f) => !have.has(f))] }
+    })
+    setRunError('')
+  }
+
+  const removeConvertFile = (index: number) => {
+    setConvert((p) => ({ ...p, inputFiles: p.inputFiles.filter((_, i) => i !== index) }))
   }
 
   const browseConvertOutput = async () => {
@@ -1244,7 +1275,21 @@ export default function App() {
         ? // Clamped: while the threads field is being cleared it holds 0, and
           // the preview should not show `--threads-per-file 0` as if that were
           // the command we would run. Run refuses in that state anyway.
-          convertCommandLine(convert)
+          //
+          // A file list is more than one command, so the preview is all of
+          // them, one per line. The input path each will really be given is a
+          // staging folder named after a job id that does not exist yet, so it
+          // stands in as `<staged .raw files>`; every other argument is exact,
+          // and each run's own log opens with the command line as executed.
+          convert.inputMode === 'files'
+            ? convertGroups(convert.inputFiles)
+                .map((g) =>
+                  convertCommandLine(
+                    groupParams(convert, g, `<${g.files.length} staged ${g.format === 'raw' ? '.raw' : '.mzML'} file${g.files.length > 1 ? 's' : ''}>`),
+                  ),
+                )
+                .join('\n\n') || 'Add files to convert.'
+            : convertCommandLine(convert)
         : JSON.stringify(
             isSearch ? buildSearchJson(previewSearch, currentExtras) : buildLibJson(build, currentExtras),
             null,
@@ -1292,11 +1337,19 @@ export default function App() {
 
   /** One queued job, ready to be appended.
    *
-   *  `over` replaces the search parameters for a fanned-out run, which differs
-   *  from the form only in its `ms_data` and `results` paths. The JSON is built
-   *  by the same function either way, so the two cannot drift apart. */
-  const makeJob = (id: string, runNo: number, title: string, over?: SearchParams): Job => {
+   *  `over` replaces the parameters for a fanned-out run -- a search over one
+   *  staged file, or one format's group of a convert list. Either way the JSON
+   *  and the argv are built by the same functions as the un-fanned case, so the
+   *  two cannot drift apart. */
+  const makeJob = (
+    id: string,
+    runNo: number,
+    title: string,
+    over?: SearchParams,
+    overConvert?: ConvertParams,
+  ): Job => {
     const s = over ?? search
+    const c = overConvert ?? convert
     const json = over ? JSON.stringify(buildSearchJson(over, currentExtras), null, 2) : jsonText
     return {
       id,
@@ -1305,7 +1358,7 @@ export default function App() {
       cmd: command,
       title,
       snapshot: isConvert
-        ? { cmd: 'convertraw' as const, convert }
+        ? { cmd: 'convertraw' as const, convert: c }
         : isDownload
           ? { cmd: 'downloadspeclib' as const, download }
           : isSearch
@@ -1313,7 +1366,7 @@ export default function App() {
             : { cmd: 'buildspeclib' as const, build },
       target:
         (isConvert
-          ? convert.outputDir || convert.input
+          ? c.outputDir || c.input
           : isDownload
             ? download.dest
             : isSearch
@@ -1325,7 +1378,7 @@ export default function App() {
       failMsg: '',
       paramsJson: json,
       invocation: isConvert
-        ? { kind: 'args' as const, args: buildConvertArgs(convert) }
+        ? { kind: 'args' as const, args: buildConvertArgs(c) }
         : isDownload
           ? { kind: 'args' as const, args: buildDownloadArgs(download) }
           : { kind: 'paramsFile' as const, json },
@@ -1352,7 +1405,7 @@ export default function App() {
         const { id, runNo } = await allocate()
         let msData: string
         try {
-          msData = await backend.stageMsFile(id, file)
+          msData = await backend.stageFiles(id, 'ms_data', [file])
         } catch (e) {
           // Stop rather than queue a run pointed at nothing. Whatever was
           // already built stays queued -- those files are fine, and dropping
@@ -1369,6 +1422,29 @@ export default function App() {
             results: joinPath(search.results, stem),
           }),
         )
+      }
+    } else if (isConvert && convert.inputMode === 'files') {
+      // One run per format present, never per file: both converters batch
+      // internally, so starting each once beats starting it N times. Each group
+      // becomes an ordinary folder-mode conversion whose folder is the staging
+      // directory built for it.
+      const groups = convertGroups(convert.inputFiles)
+      const base = resolveRunName(jobName, taken)
+      for (const group of groups) {
+        const { id, runNo } = await allocate()
+        let dir: string
+        try {
+          dir = await backend.stageFiles(id, `${group.format}_in`, group.files)
+        } catch (e) {
+          failure = String(e)
+          break
+        }
+        // Suffixed only when there are two, so a list of one format keeps the
+        // plain name rather than gaining a label that distinguishes nothing.
+        const title =
+          groups.length > 1 ? resolveRunName(`${base}-${group.format}`, taken) : base
+        taken.add(title)
+        added.push(makeJob(id, runNo, title, undefined, groupParams(convert, group, dir)))
       }
     } else {
       const { id, runNo } = await allocate()
@@ -1741,6 +1817,8 @@ export default function App() {
                 onParam={onParam}
                 onToggle={onToggle}
                 onBrowseInput={browseConvertInput}
+                onAddFiles={addConvertFiles}
+                onRemoveFile={removeConvertFile}
                 onBrowseOutput={browseConvertOutput}
                 onToggleAdvanced={() => setAdvancedOpen((o) => !o)}
               />

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -230,6 +230,22 @@ const TITLES: Record<CommandId, string> = {
   convertraw: 'ConvertRAW',
 }
 
+/** What the overwrite confirmation says, per workflow.
+ *
+ *  Was a two-way `isSearch ? ... : ...`, so ConvertRAW and DownloadSpecLib both
+ *  fell into the BuildSpecLib branch and a conversion was asked to confirm
+ *  "A library already exists here / Overwrite & build" over a path taken from
+ *  the BuildSpecLib form, which it had nothing to do with. */
+const OVERWRITE_COPY: Record<CommandId, { title: string; confirm: string }> = {
+  searchdia: { title: 'Results folder already exists', confirm: 'Overwrite & run' },
+  buildspeclib: { title: 'A library already exists here', confirm: 'Overwrite & build' },
+  downloadspeclib: { title: 'A library already exists here', confirm: 'Overwrite & download' },
+  convertraw: {
+    title: 'This folder already holds converted files',
+    confirm: 'Overwrite & convert',
+  },
+}
+
 const SUBTITLES: Record<CommandId, string> = {
   searchdia: 'Find & quantify proteins',
   buildspeclib: 'Predict a spectral library',
@@ -765,7 +781,7 @@ export default function App() {
   const convertNotes = useMemo(
     () => ({
       input: convertInputNote(convert, info('convertInput')),
-      output: convertOutputNote(convert.outputDir, info('convertOutput')),
+      output: convertOutputNote(convert, info('convertOutput')),
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [convert, pathInfos],
@@ -1373,6 +1389,16 @@ export default function App() {
       : isSearch
         ? searchNotes.results
         : libNote
+
+  /** The path the overwrite confirmation is about. */
+  const overwriteDetail = isConvert
+    ? convert.outputDir.trim() ||
+      `${convert.input.trim().replace(/[\\/]$/, '')}/arrow_out`
+    : isDownload
+      ? downloadTargetPath(download.dest, download.selected)
+      : isSearch
+        ? search.results
+        : libraryTargetPath(build.libPath)
 
   /** Names already spoken for, across this session and persisted history. */
   const takenTitles = useMemo(() => new Set(jobs.map((j) => j.title)), [jobs])
@@ -2071,11 +2097,11 @@ export default function App() {
         {overwriteOpen && (
           <ConfirmDialog
             tone="warning"
-            title={isSearch ? 'Results folder already exists' : 'A library already exists here'}
+            title={OVERWRITE_COPY[command].title}
             body={overwriteNote.msg}
-            detail={isSearch ? search.results : libraryTargetPath(build.libPath)}
+            detail={overwriteDetail}
             dismissLabel="Cancel"
-            confirmLabel={isSearch ? 'Overwrite & run' : 'Overwrite & build'}
+            confirmLabel={OVERWRITE_COPY[command].confirm}
             onDismiss={() => setOverwriteOpen(false)}
             onConfirm={() => {
               setOverwriteOpen(false)

--- a/gui/src/components/BuildSpecLibForm.tsx
+++ b/gui/src/components/BuildSpecLibForm.tsx
@@ -26,7 +26,12 @@ import {
   previewDigest,
 } from '../lib/enzymes'
 import { BROWSE, HINT, LABEL } from '../lib/styles'
-import { PREDICTION_MODELS, isPrositModel, predictionModelById } from '../lib/types'
+import {
+  PREDICTION_MODELS,
+  isPrositModel,
+  predictionModelById,
+  unlocalizedMods,
+} from '../lib/types'
 import type { BuildParams, FastaEntry, HeaderPresetId, ModEntry } from '../lib/types'
 import { conflictingResidues, modPatternResidues } from '../lib/validate'
 import type { Note } from '../lib/validate'
@@ -1258,7 +1263,8 @@ export function BuildSpecLibForm({
           onAdd={onAddMod}
         />
         <div style={{ height: 18 }} />
-        {isPrositModel(params.predictionModel) && params.variableMods.length > 0 && (
+        {isPrositModel(params.predictionModel) &&
+          unlocalizedMods(params.variableMods).length > 0 && (
           <div
             style={{
               marginTop: 12,

--- a/gui/src/components/ConvertRawForm.tsx
+++ b/gui/src/components/ConvertRawForm.tsx
@@ -83,8 +83,8 @@ export function ConvertRawForm({
             <>
               Convert <code style={{ fontFamily: "'IBM Plex Mono'", fontSize: 12 }}>.mzML</code>{' '}
               files to Arrow, which is what SearchDIA reads. Runs Pioneer&rsquo;s own converter, so
-              it works on any platform and reads{' '}
-              <code style={{ fontFamily: "'IBM Plex Mono'", fontSize: 12 }}>.mzML.gz</code> too.
+              it works on any platform. The data must be centroided — profile-mode spectra are
+              skipped.
             </>
           ) : (
             <>

--- a/gui/src/components/ConvertRawForm.tsx
+++ b/gui/src/components/ConvertRawForm.tsx
@@ -15,7 +15,8 @@
 import { NumField } from './NumField'
 import { Toggle } from './Toggle'
 import { BROWSE, LABEL, SEG_TRACK, seg } from '../lib/styles'
-import type { ConvertParams } from '../lib/types'
+import { convertGroups, formatOfFile, type ConvertGroup } from '../lib/config'
+import type { ConvertFormat, ConvertParams } from '../lib/types'
 import { type Note } from '../lib/validate'
 
 const CARD: React.CSSProperties = {
@@ -50,8 +51,155 @@ interface Props {
   onParam: (key: string, value: string) => void
   onToggle: (key: string) => void
   onBrowseInput: () => void
+  /** Add files to the list, via the multi-select picker. */
+  onAddFiles: () => void
+  /** Drop one file from the list, by index. */
+  onRemoveFile: (index: number) => void
   onBrowseOutput: () => void
   onToggleAdvanced: () => void
+}
+
+/** A pill naming which converter a file goes to. */
+function FormatTag({ format }: { format: ConvertFormat | null }) {
+  const [text, fg, bg] =
+    format === 'raw'
+      ? ['RAW', '#1B4B7A', '#E6F0F9']
+      : format === 'mzml'
+        ? ['mzML', '#3B5A1B', '#EDF5E3']
+        : ['?', '#8A2B22', '#FBE9E7']
+  return (
+    <span
+      style={{
+        flex: 'none',
+        padding: '2px 7px',
+        borderRadius: 5,
+        font: "600 10.5px 'IBM Plex Sans'",
+        letterSpacing: '0.03em',
+        color: fg,
+        background: bg,
+      }}
+    >
+      {text}
+    </span>
+  )
+}
+
+/** The chosen-files list.
+ *
+ *  Each row carries the format it was matched as, because that is what decides
+ *  which converter it goes to and it is read off the name alone -- a file that
+ *  neither converter can read is a `?` in the list rather than a surprise at
+ *  run time.
+ */
+function ConvertFileList({
+  files,
+  groups,
+  unreadable,
+  onAdd,
+  onRemove,
+}: {
+  files: string[]
+  groups: ConvertGroup[]
+  unreadable: string[]
+  onAdd: () => void
+  onRemove: (index: number) => void
+}) {
+  const summary = groups
+    .map((g) => `${g.files.length} ${g.format === 'raw' ? '.raw' : '.mzML'}`)
+    .join(' and ')
+  return (
+    <div data-key="convertInput">
+      {files.length > 0 && (
+        <div
+          style={{
+            border: '1px solid #E3E8EC',
+            borderRadius: 9,
+            overflow: 'hidden',
+            marginBottom: 9,
+          }}
+        >
+          {files.map((f, i) => (
+            <div
+              key={`${f}:${i}`}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 9,
+                padding: '7px 10px',
+                borderTop: i ? '1px solid #EEF1F4' : undefined,
+              }}
+            >
+              <FormatTag format={formatOfFile(f)} />
+              <div
+                title={f}
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  font: "12.5px 'IBM Plex Mono'",
+                  color: '#1A2230',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  direction: 'rtl',
+                  textAlign: 'left',
+                }}
+              >
+                {f}
+              </div>
+              <button
+                type="button"
+                onClick={() => onRemove(i)}
+                title="Remove from the list"
+                style={{
+                  flex: 'none',
+                  border: 'none',
+                  background: 'none',
+                  cursor: 'pointer',
+                  padding: 4,
+                  lineHeight: 0,
+                  color: '#98A2B3',
+                }}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                  <path
+                    d="M6 6l12 12M18 6L6 18"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <button
+          type="button"
+          className="pio-browse"
+          onClick={onAdd}
+          style={{ ...BROWSE, padding: '7px 13px', display: 'inline-flex', alignItems: 'center', gap: 6 }}
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none">
+            <path
+              d="M12 5v14M5 12h14"
+              stroke="currentColor"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+            />
+          </svg>
+          {files.length ? 'Add more files' : 'Choose files'}
+        </button>
+        <span style={{ fontSize: 11.5, color: '#98A2B3' }}>
+          {unreadable.length
+            ? `${unreadable.length} file${unreadable.length > 1 ? 's' : ''} neither converter reads.`
+            : files.length
+              ? `${summary} \u2014 ${groups.length} run${groups.length > 1 ? 's' : ''}.`
+              : 'Pick .raw or .mzML files. Mixing them is fine.'}
+        </span>
+      </div>
+    </div>
+  )
 }
 
 export function ConvertRawForm({
@@ -62,24 +210,45 @@ export function ConvertRawForm({
   onParam,
   onToggle,
   onBrowseInput,
+  onAddFiles,
+  onRemoveFile,
   onBrowseOutput,
   onToggleAdvanced,
 }: Props) {
-  const isMzml = params.format === 'mzml'
+  const byFiles = params.inputMode === 'files'
+  // In list mode each file names its own converter, so the format toggle has
+  // nothing to decide and is hidden. `format` still drives the folder-mode copy.
+  const isMzml = !byFiles && params.format === 'mzml'
+  const groups = convertGroups(params.inputFiles)
+  const unreadable = params.inputFiles.filter((f) => formatOfFile(f) === null)
 
-
-  const defaultOut = params.input.trim()
-    ? `${params.inputMode === 'file' ? params.input.trim().replace(/[^\\/]+$/, '').replace(/[\\/]$/, '') : params.input.trim()}/arrow_out`
-    : '<input folder>/arrow_out'
+  // In list mode the converters are handed a staging folder under the system
+  // temp directory, so their own <input_dir>/arrow_out default would write
+  // there. validateConvertRun requires the field instead of quietly defaulting
+  // somewhere nobody would look.
+  const defaultOut = byFiles
+    ? 'required for a list of files'
+    : params.input.trim()
+      ? `${params.input.trim()}/arrow_out`
+      : '<input folder>/arrow_out'
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
       <section style={CARD}>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 12, marginBottom: 14 }}>
-          <h2 style={H2}>{isMzml ? 'Convert mzML files' : 'Convert raw files'}</h2>
+          <h2 style={H2}>
+            {byFiles ? 'Convert files' : isMzml ? 'Convert mzML files' : 'Convert raw files'}
+          </h2>
         </div>
         <p style={{ margin: '-4px 0 14px', fontSize: 12.5, color: '#667085', lineHeight: 1.5 }}>
-          {isMzml ? (
+          {byFiles ? (
+            <>
+              Convert <code style={{ fontFamily: "'IBM Plex Mono'", fontSize: 12 }}>.raw</code> and{' '}
+              <code style={{ fontFamily: "'IBM Plex Mono'", fontSize: 12 }}>.mzML</code> files to
+              Arrow, which is what SearchDIA reads. The list can mix the two — each format goes to
+              its own converter, as its own run.
+            </>
+          ) : isMzml ? (
             <>
               Convert <code style={{ fontFamily: "'IBM Plex Mono'", fontSize: 12 }}>.mzML</code>{' '}
               files to Arrow, which is what SearchDIA reads. Runs Pioneer&rsquo;s own converter, so
@@ -95,8 +264,8 @@ export function ConvertRawForm({
           )}
         </p>
 
-        <label style={LABEL}>Format</label>
-        <div style={{ ...SEG_TRACK, marginBottom: 14 }}>
+        {!byFiles && <label style={LABEL}>Format</label>}
+        <div style={{ ...SEG_TRACK, marginBottom: 14, display: byFiles ? 'none' : undefined }}>
           <button
             type="button"
             onClick={() => onParam('format', 'raw')}
@@ -117,52 +286,56 @@ export function ConvertRawForm({
         <div style={{ ...SEG_TRACK, marginBottom: 12 }}>
           <button
             type="button"
-            onClick={() => onParam('inputMode', 'file')}
-            style={seg(params.inputMode === 'file')}
+            onClick={() => onParam('inputMode', 'files')}
+            style={seg(byFiles)}
           >
-            Single file
+            Files
           </button>
           <button
             type="button"
             onClick={() => onParam('inputMode', 'folder')}
-            style={seg(params.inputMode === 'folder')}
+            style={seg(!byFiles)}
           >
             Folder
           </button>
         </div>
 
-        <div data-drop="convertInput" style={{ display: 'flex', gap: 8 }}>
-          <input
-            className="pio-input"
-            data-key="convertInput"
-            value={params.input}
-            onChange={(e) => onParam('input', e.target.value)}
-            placeholder={
-              params.inputMode === 'file'
-                ? isMzml
-                  ? '/path/to/file.mzML'
-                  : '/path/to/file.raw'
-                : isMzml
-                  ? '/path/to/mzml/folder'
-                  : '/path/to/raw/folder'
-            }
-            style={{
-              flex: 1,
-              padding: '9px 12px',
-              borderRadius: 9,
-              font: "13px 'IBM Plex Mono'",
-              outline: 'none',
-              minWidth: 0,
-              border: `1px solid ${inputNote.level === 'error' ? '#E5484D' : '#D7DBE0'}`,
-            }}
-          />
-          <button type="button" className="pio-browse" onClick={onBrowseInput} style={BROWSE}>
-            Browse
-          </button>
+        <div data-drop="convertInput">
+          {byFiles ? (
+            <ConvertFileList
+              files={params.inputFiles}
+              groups={groups}
+              unreadable={unreadable}
+              onAdd={onAddFiles}
+              onRemove={onRemoveFile}
+            />
+          ) : (
+            <div style={{ display: 'flex', gap: 8 }}>
+              <input
+                className="pio-input"
+                data-key="convertInput"
+                value={params.input}
+                onChange={(e) => onParam('input', e.target.value)}
+                placeholder={isMzml ? '/path/to/mzml/folder' : '/path/to/raw/folder'}
+                style={{
+                  flex: 1,
+                  padding: '9px 12px',
+                  borderRadius: 9,
+                  font: "13px 'IBM Plex Mono'",
+                  outline: 'none',
+                  minWidth: 0,
+                  border: `1px solid ${inputNote.level === 'error' ? '#E5484D' : '#D7DBE0'}`,
+                }}
+              />
+              <button type="button" className="pio-browse" onClick={onBrowseInput} style={BROWSE}>
+                Browse
+              </button>
+            </div>
+          )}
         </div>
         {inputNote.msg && (
           <div style={noteStyle(inputNote)}>
-            {inputNote.level ? '⚠  ' : ''}
+            {inputNote.level ? '\u26a0  ' : ''}
             {inputNote.msg}
           </div>
         )}
@@ -174,7 +347,9 @@ export function ConvertRawForm({
         </div>
         <label style={LABEL}>
           Output folder{' '}
-          <span style={{ fontWeight: 400, color: '#98A2B3' }}>— defaults to the input folder</span>
+          <span style={{ fontWeight: 400, color: '#98A2B3' }}>
+            {byFiles ? '— required for a list of files' : '— defaults to the input folder'}
+          </span>
         </label>
         <div data-drop="convertOutput" style={{ display: 'flex', gap: 8 }}>
           <input

--- a/gui/src/components/ConvertRawForm.tsx
+++ b/gui/src/components/ConvertRawForm.tsx
@@ -14,7 +14,7 @@
  */
 import { NumField } from './NumField'
 import { Toggle } from './Toggle'
-import { BROWSE, LABEL } from '../lib/styles'
+import { BROWSE, LABEL, SEG_TRACK, seg } from '../lib/styles'
 import type { ConvertParams } from '../lib/types'
 import { type Note } from '../lib/validate'
 
@@ -65,18 +65,6 @@ export function ConvertRawForm({
   onBrowseOutput,
   onToggleAdvanced,
 }: Props) {
-  const seg = (active: boolean): React.CSSProperties => ({
-    padding: '7px 14px',
-    border: 'none',
-    borderRadius: 8,
-    font: "600 12.5px 'IBM Plex Sans'",
-    cursor: 'pointer',
-    transition: 'all .12s',
-    ...(active
-      ? { background: '#fff', color: '#1B2A4A', boxShadow: '0 1px 3px rgba(15,20,27,0.12)' }
-      : { background: 'none', color: '#667085' }),
-  })
-
   const isMzml = params.format === 'mzml'
 
 
@@ -108,15 +96,7 @@ export function ConvertRawForm({
         </p>
 
         <label style={LABEL}>Format</label>
-        <div
-          style={{
-            display: 'inline-flex',
-            padding: 3,
-            background: '#EEF1F4',
-            borderRadius: 10,
-            marginBottom: 14,
-          }}
-        >
+        <div style={{ ...SEG_TRACK, marginBottom: 14 }}>
           <button
             type="button"
             onClick={() => onParam('format', 'raw')}
@@ -134,15 +114,7 @@ export function ConvertRawForm({
         </div>
 
         <label style={LABEL}>Input</label>
-        <div
-          style={{
-            display: 'inline-flex',
-            padding: 3,
-            background: '#EEF1F4',
-            borderRadius: 10,
-            marginBottom: 12,
-          }}
-        >
+        <div style={{ ...SEG_TRACK, marginBottom: 12 }}>
           <button
             type="button"
             onClick={() => onParam('inputMode', 'file')}

--- a/gui/src/components/ConvertRawForm.tsx
+++ b/gui/src/components/ConvertRawForm.tsx
@@ -1,10 +1,16 @@
 /** The ConvertRAW page.
  *
  *  Adapted rather than ported: the design shows a file / file-list / folder
- *  toggle and a JSON config, but PioneerConverter is a .NET program that takes
- *  ONE positional RAW path plus flags and has no params file at all. So the
- *  file-list mode is dropped (the binary cannot express it) and the panel shows
- *  the real command line instead of an invented JSON document.
+ *  toggle and a JSON config, but neither converter takes a params file -- both
+ *  take ONE positional path plus flags. So the file-list mode is dropped (the
+ *  binaries cannot express it) and the panel shows the real command line
+ *  instead of an invented JSON document.
+ *
+ *  The page drives two programs, not one: Thermo `.raw` goes through
+ *  PioneerConverter (.NET), `.mzML` through Pioneer's own `convertMzML`
+ *  (Julia). They are one page because they are one task -- get instrument data
+ *  into the Arrow files SearchDIA reads -- but their tuning knobs are disjoint,
+ *  so the advanced section swaps rather than greying fields out.
  */
 import { NumField } from './NumField'
 import { Toggle } from './Toggle'
@@ -71,8 +77,8 @@ export function ConvertRawForm({
       : { background: 'none', color: '#667085' }),
   })
 
-  // The two knobs multiply: N files in flight, each with M scan-reader threads.
-  // Shared with the validator so the readout and the block can never disagree.
+  const isMzml = params.format === 'mzml'
+
 
   const defaultOut = params.input.trim()
     ? `${params.inputMode === 'file' ? params.input.trim().replace(/[^\\/]+$/, '').replace(/[\\/]$/, '') : params.input.trim()}/arrow_out`
@@ -82,13 +88,50 @@ export function ConvertRawForm({
     <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
       <section style={CARD}>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 12, marginBottom: 14 }}>
-          <h2 style={H2}>Convert raw files</h2>
+          <h2 style={H2}>{isMzml ? 'Convert mzML files' : 'Convert raw files'}</h2>
         </div>
         <p style={{ margin: '-4px 0 14px', fontSize: 12.5, color: '#667085', lineHeight: 1.5 }}>
-          Convert Thermo{' '}
-          <code style={{ fontFamily: "'IBM Plex Mono'", fontSize: 12 }}>.raw</code> files to Arrow,
-          which is what SearchDIA reads.
+          {isMzml ? (
+            <>
+              Convert <code style={{ fontFamily: "'IBM Plex Mono'", fontSize: 12 }}>.mzML</code>{' '}
+              files to Arrow, which is what SearchDIA reads. Runs Pioneer&rsquo;s own converter, so
+              it works on any platform and reads{' '}
+              <code style={{ fontFamily: "'IBM Plex Mono'", fontSize: 12 }}>.mzML.gz</code> too.
+            </>
+          ) : (
+            <>
+              Convert Thermo{' '}
+              <code style={{ fontFamily: "'IBM Plex Mono'", fontSize: 12 }}>.raw</code> files to
+              Arrow, which is what SearchDIA reads.
+            </>
+          )}
         </p>
+
+        <label style={LABEL}>Format</label>
+        <div
+          style={{
+            display: 'inline-flex',
+            padding: 3,
+            background: '#EEF1F4',
+            borderRadius: 10,
+            marginBottom: 14,
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => onParam('format', 'raw')}
+            style={seg(!isMzml)}
+          >
+            Thermo .raw
+          </button>
+          <button
+            type="button"
+            onClick={() => onParam('format', 'mzml')}
+            style={seg(isMzml)}
+          >
+            .mzML
+          </button>
+        </div>
 
         <label style={LABEL}>Input</label>
         <div
@@ -123,7 +166,13 @@ export function ConvertRawForm({
             value={params.input}
             onChange={(e) => onParam('input', e.target.value)}
             placeholder={
-              params.inputMode === 'file' ? '/path/to/file.raw' : '/path/to/raw/folder'
+              params.inputMode === 'file'
+                ? isMzml
+                  ? '/path/to/file.mzML'
+                  : '/path/to/file.raw'
+                : isMzml
+                  ? '/path/to/mzml/folder'
+                  : '/path/to/raw/folder'
             }
             style={{
               flex: 1,
@@ -262,19 +311,75 @@ export function ConvertRawForm({
         </button>
         {advancedOpen && (
           <div style={{ padding: '4px 20px 20px', borderTop: '1px solid #EEF1F4' }}>
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: '1fr 1fr',
-                gap: 14,
-                alignItems: 'start',
-                marginTop: 16,
-              }}
-            >
-              <NumField fieldKey="threadsPerFile" value={params.threadsPerFile} onChange={onParam} />
-              <NumField fieldKey="batchSize" value={params.batchSize} onChange={onParam} />
-              <NumField fieldKey="scanChunkSize" value={params.scanChunkSize} onChange={onParam} />
-            </div>
+            {/* Disjoint sets, not a shared set with some fields disabled: none
+                of PioneerConverter's knobs has a counterpart in convertMzML,
+                so showing them greyed out would only suggest otherwise. */}
+            {isMzml ? (
+              <>
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1fr 1fr',
+                    gap: 14,
+                    alignItems: 'start',
+                    marginTop: 16,
+                  }}
+                >
+                  <NumField
+                    fieldKey="concurrentFiles"
+                    value={params.concurrentFiles}
+                    onChange={onParam}
+                  />
+                </div>
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: 14,
+                    marginTop: 18,
+                  }}
+                >
+                  <div>
+                    <div style={{ fontSize: 13, fontWeight: 600, color: '#344054' }}>
+                      Include scan headers
+                    </div>
+                    <div style={{ fontSize: 11.5, color: '#98A2B3' }}>
+                      Carry each scan&rsquo;s header into the Arrow file. SearchDIA does not read
+                      them and they roughly double the output — leave off unless something else
+                      needs them.
+                    </div>
+                  </div>
+                  <Toggle
+                    on={params.includeScanHeader}
+                    fieldKey="includeScanHeader"
+                    onClick={() => onToggle('includeScanHeader')}
+                  />
+                </div>
+              </>
+            ) : (
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: '1fr 1fr',
+                  gap: 14,
+                  alignItems: 'start',
+                  marginTop: 16,
+                }}
+              >
+                <NumField
+                  fieldKey="threadsPerFile"
+                  value={params.threadsPerFile}
+                  onChange={onParam}
+                />
+                <NumField fieldKey="batchSize" value={params.batchSize} onChange={onParam} />
+                <NumField
+                  fieldKey="scanChunkSize"
+                  value={params.scanChunkSize}
+                  onChange={onParam}
+                />
+              </div>
+            )}
           </div>
         )}
       </section>

--- a/gui/src/components/SearchDiaForm.tsx
+++ b/gui/src/components/SearchDiaForm.tsx
@@ -14,10 +14,10 @@ import { LibrarySummary } from './LibrarySummary'
 import { NumField } from './NumField'
 import { RecentLibraries } from './RecentLibraries'
 import { Toggle } from './Toggle'
-import { unimodDisplay } from '../lib/fasta'
+import { parseModEntry, unimodDisplay } from '../lib/fasta'
 import { BROWSE, HINT, LABEL, LABEL_TIGHT, SEG_TRACK, seg } from '../lib/styles'
 import type { LibraryInfo } from '../lib/backend'
-import { isPrositModel } from '../lib/types'
+import { isPrositModel, unlocalizedMods } from '../lib/types'
 import type { SearchParams } from '../lib/types'
 import { fileStem } from '../lib/validate'
 import type { Note } from '../lib/validate'
@@ -303,6 +303,11 @@ export function SearchDiaForm({
   onGoToBuild,
 }: Props) {
   const byFiles = params.msDataMode === 'files'
+  // Only the modifications the caveat is about -- oxidation on M is standard
+  // and is excluded, so an ordinary Prosit library raises nothing.
+  const caveatMods = (libInfo?.variable_mods ?? []).filter(
+    (e) => unlocalizedMods([parseModEntry(e)]).length > 0,
+  )
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
       <section style={CARD}>
@@ -382,7 +387,7 @@ export function SearchDiaForm({
             {libInfo &&
               libInfo.is_library &&
               isPrositModel(libInfo.prediction_model) &&
-              libInfo.variable_mods.length > 0 && (
+              caveatMods.length > 0 && (
                 <div
                   style={{
                     marginTop: 10,
@@ -397,7 +402,7 @@ export function SearchDiaForm({
                 >
                   <strong style={{ fontWeight: 600 }}>Experimental.</strong> This library
                   is Prosit-predicted and carries variable modifications
-                  ({libInfo.variable_mods.map(unimodDisplay).join(', ')}). Pioneer does not report
+                  ({caveatMods.map(unimodDisplay).join(', ')}). Pioneer does not report
                   site-localization confidence, so a modified residue is placed but the
                   placement is not scored.
                 </div>

--- a/gui/src/components/SearchDiaForm.tsx
+++ b/gui/src/components/SearchDiaForm.tsx
@@ -15,10 +15,11 @@ import { NumField } from './NumField'
 import { RecentLibraries } from './RecentLibraries'
 import { Toggle } from './Toggle'
 import { unimodDisplay } from '../lib/fasta'
-import { BROWSE, HINT, LABEL, LABEL_TIGHT } from '../lib/styles'
+import { BROWSE, HINT, LABEL, LABEL_TIGHT, SEG_TRACK, seg } from '../lib/styles'
 import type { LibraryInfo } from '../lib/backend'
 import { isPrositModel } from '../lib/types'
 import type { SearchParams } from '../lib/types'
+import { fileStem } from '../lib/validate'
 import type { Note } from '../lib/validate'
 
 const CARD: React.CSSProperties = {
@@ -76,7 +77,7 @@ function PathRow({
     // data field" can plausibly land on the label, the Browse button or the
     // padding between them.
     <div data-drop={fieldKey}>
-      <label style={LABEL}>{label}</label>
+      {label ? <label style={LABEL}>{label}</label> : null}
       <div style={{ display: 'flex', gap: 8 }}>
         <input
           className="pio-input"
@@ -104,6 +105,107 @@ function PathRow({
         </div>
       )}
       {children}
+    </div>
+  )
+}
+
+/** The chosen-files list.
+ *
+ *  Each row is one search: the file on the left, the results folder it will
+ *  write to on the right. Showing the destination per row rather than once
+ *  above the list is the point of the mode -- what makes these separate runs is
+ *  that they do not share an output tree, and a list that only showed file
+ *  names would look like the folder mode with extra steps.
+ */
+function MsFileList({
+  params,
+  onAdd,
+  onRemove,
+}: {
+  params: SearchParams
+  onAdd: () => void
+  onRemove: (index: number) => void
+}) {
+  const files = params.msDataFiles
+  const root = params.results.trim()
+  return (
+    <div>
+      {files.length > 0 && (
+        <div
+          style={{
+            border: '1px solid #E3E8EC',
+            borderRadius: 9,
+            overflow: 'hidden',
+            marginBottom: 9,
+          }}
+        >
+          {files.map((f, i) => (
+            <div
+              key={`${f}:${i}`}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                padding: '8px 10px',
+                borderTop: i ? '1px solid #EEF1F4' : undefined,
+              }}
+            >
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  title={f}
+                  style={{
+                    font: "12.5px 'IBM Plex Mono'",
+                    color: '#1A2230',
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    direction: 'rtl',
+                    textAlign: 'left',
+                  }}
+                >
+                  {f}
+                </div>
+                <div style={{ ...HINT, marginTop: 2 }}>
+                  {root ? `\u2192 ${root}/${fileStem(f)}` : '\u2192 set a results folder below'}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => onRemove(i)}
+                title="Remove from the list"
+                style={{
+                  flex: 'none',
+                  border: 'none',
+                  background: 'none',
+                  cursor: 'pointer',
+                  padding: 4,
+                  lineHeight: 0,
+                  color: '#98A2B3',
+                }}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                  <path
+                    d="M6 6l12 12M18 6L6 18"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <button type="button" className="pio-browse" onClick={onAdd} style={BROWSE}>
+          {files.length ? 'Add more files' : 'Choose files'}
+        </button>
+        <span style={HINT}>
+          {files.length
+            ? `${files.length} file${files.length > 1 ? 's' : ''}, searched separately \u2014 ${files.length} run${files.length > 1 ? 's' : ''} queued.`
+            : 'Each file is searched on its own, into its own results folder.'}
+        </span>
+      </div>
     </div>
   )
 }
@@ -175,6 +277,10 @@ interface Props {
   onParam: (key: string, value: string) => void
   onToggle: (key: string) => void
   onBrowse: (key: 'msData' | 'library' | 'results') => void
+  /** Add files to the list, via the multi-select picker. */
+  onAddMsFiles: () => void
+  /** Drop one file from the list, by index. */
+  onRemoveMsFile: (index: number) => void
   onJobName: (value: string) => void
   onOpenLoad: () => void
   onGoToBuild: () => void
@@ -190,10 +296,13 @@ export function SearchDiaForm({
   onParam,
   onToggle,
   onBrowse,
+  onAddMsFiles,
+  onRemoveMsFile,
   onJobName,
   onOpenLoad,
   onGoToBuild,
 }: Props) {
+  const byFiles = params.msDataMode === 'files'
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
       <section style={CARD}>
@@ -210,15 +319,28 @@ export function SearchDiaForm({
           <LoadPreviousButton onClick={onOpenLoad} />
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-          <PathRow
-            label="MS data folder"
-            fieldKey="msData"
-            value={params.msData}
-            placeholder="/path/to/ms/data"
-            note={notes.msData}
-            onChange={onParam}
-            onBrowse={() => onBrowse('msData')}
-          />
+          <div data-key="msData">
+            <label style={LABEL}>MS data</label>
+            <div style={{ ...SEG_TRACK, marginBottom: 10 }}>
+              <button type="button" onClick={() => onParam('msDataMode', 'folder')} style={seg(!byFiles)}>
+                One folder
+              </button>
+              <button type="button" onClick={() => onParam('msDataMode', 'files')} style={seg(byFiles)}>
+                Chosen files
+              </button>
+            </div>
+            {byFiles ? <MsFileList params={params} onAdd={onAddMsFiles} onRemove={onRemoveMsFile} /> : (
+              <PathRow
+                label=""
+                fieldKey="msData"
+                value={params.msData}
+                placeholder="/path/to/ms/data"
+                note={notes.msData}
+                onChange={onParam}
+                onBrowse={() => onBrowse('msData')}
+              />
+            )}
+          </div>
           <PathRow
             label="Spectral library"
             fieldKey="library"

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -51,6 +51,23 @@ const DOT_COLORS: Record<Job['status'], string> = {
  *  used the phospho library". Every path in the snapshot is included, so a
  *  match on any part of any of them finds the run.
  */
+const searchCache = new WeakMap<Job, string>()
+
+/** `searchableText`, computed once per job object.
+ *
+ *  Keyed on the job itself, so an edited job (a new object) is recomputed and a
+ *  deleted one is collected with it. Worth caching because the sidebar
+ *  re-renders on every line of output a running job produces, and this walks
+ *  every FASTA path and modification label of every run each time. */
+function searchable(j: Job): string {
+  let t = searchCache.get(j)
+  if (t === undefined) {
+    t = searchableText(j)
+    searchCache.set(j, t)
+  }
+  return t
+}
+
 function searchableText(j: Job): string {
   const parts: string[] = [j.title, CMD_TEXT[j.cmd], j.target, String(j.runNo), j.status]
   const s = j.snapshot
@@ -102,6 +119,11 @@ function rowTitle(j: Job): string {
     .filter(Boolean)
     .join('\n')
 }
+
+/** History rows rendered initially, and added each time the list is scrolled to
+ *  the end. Comfortably more than a sidebar can show at once, so the growth is
+ *  never visible. */
+const HISTORY_WINDOW = 60
 
 const CMD_TEXT: Record<CommandId, string> = {
   searchdia: 'SearchDIA',
@@ -429,6 +451,15 @@ export function Sidebar({
 }: Props) {
   const [themeOpen, setThemeOpen] = useState(false)
   const [query, setQuery] = useState('')
+  /** How many finished runs are on screen.
+   *
+   *  Not a limit on how many are *loaded* — reading the whole store costs about
+   *  4 ms per thousand runs, which is nothing. Rendering them is what costs:
+   *  10,000 rows took 2.3 s to paint, and paid it again on every re-render,
+   *  which for a running job means every line of output. A window keeps both
+   *  the first paint and every re-render flat no matter how long the history
+   *  gets. It grows as you scroll, so there is nothing to click. */
+  const [windowSize, setWindowSize] = useState(HISTORY_WINDOW)
   /** The queued job being dragged, and the one it is currently over.
    *
    *  Pointer events rather than HTML5 drag-and-drop: Tauri handles the OS drop
@@ -524,10 +555,16 @@ export function Sidebar({
   )
   // Every term must appear somewhere, so "yeast phospho" narrows rather than
   // widening. Matched case-insensitively across the whole of searchableText.
+  // A new search starts a new window: otherwise scrolling deep into one result
+  // set would leave the next one rendering hundreds of rows for no reason.
+  useEffect(() => {
+    setWindowSize(HISTORY_WINDOW)
+  }, [query])
+
   const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
   const shown = terms.length
     ? history.filter((j) => {
-        const hay = searchableText(j)
+        const hay = searchable(j)
         return terms.every((t) => hay.includes(t))
       })
     : history
@@ -1061,6 +1098,14 @@ export function Sidebar({
         }}
       >
         <div
+          onScroll={(e) => {
+            // Grow when the end comes into view. Cheap to check and it fires
+            // only while scrolling; the guard stops it setting state on every
+            // pixel once everything is already rendered.
+            const el = e.currentTarget
+            if (el.scrollHeight - el.scrollTop - el.clientHeight > 240) return
+            setWindowSize((n) => (n < shown.length ? n + HISTORY_WINDOW : n))
+          }}
           style={{
             flex: 1,
             minHeight: 0,
@@ -1127,7 +1172,23 @@ export function Sidebar({
           )}
           {/* Collapsed, history is deliberately absent: the strip is for what is
               happening now, plus whatever finished while you were not looking. */}
-          {!collapsed && shown.map(renderRow)}
+          {!collapsed && shown.slice(0, windowSize).map(renderRow)}
+          {!collapsed && shown.length > windowSize && (
+            <button
+              type="button"
+              onClick={() => setWindowSize((n) => n + HISTORY_WINDOW)}
+              style={{
+                ...emptyHint,
+                textAlign: 'left',
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                font: "11.5px 'IBM Plex Sans'",
+              }}
+            >
+              {`Showing ${windowSize} of ${shown.length.toLocaleString()} — scroll for more`}
+            </button>
+          )}
         </div>
       </div>
 

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -68,6 +68,8 @@ function searchableText(j: Job): string {
     parts.push(s.download.selected, s.download.dest)
   } else {
     parts.push(s.convert.input, s.convert.outputDir)
+    // So "mzml" finds the mzML conversions among a history of .raw ones.
+    parts.push(s.convert.format === 'mzml' ? 'mzml' : 'raw')
   }
   return parts.filter(Boolean).join(' \u0000 ').toLowerCase()
 }
@@ -1133,12 +1135,24 @@ export function Sidebar({
           than in an About box: the GUI runs whatever distribution it resolved,
           which is not necessarily the one someone thinks they installed, and
           the first question about any odd result is what version produced it.
-          Collapsed, the strip has no room for it -- the title carries it. */}
+          Collapsed, the strip has no room for it -- the title carries it.
+
+          The two numbers are independent: the console is versioned by its own
+          crate and the CLI by the distribution's VERSION file, so shipping a
+          console fix without a Pioneer release makes them diverge. They are
+          released together often enough that printing both every time is
+          mostly noise, so the console number appears only when it differs --
+          which is exactly when it is worth reading. The tooltip always carries
+          both. */}
       {!collapsed && (versions.pioneer || versions.app) && (
         <div
           title={[
             versions.pioneer && `Pioneer CLI and converter ${versions.pioneer}`,
             versions.app && `Console ${versions.app}`,
+            versions.pioneer &&
+              versions.app &&
+              versions.pioneer !== versions.app &&
+              'These were released separately.',
           ]
             .filter(Boolean)
             .join('\n')}
@@ -1155,7 +1169,7 @@ export function Sidebar({
           }}
         >
           {versions.pioneer ? `Pioneer ${versions.pioneer}` : 'Pioneer'}
-          {versions.app && ` \u00b7 console ${versions.app}`}
+          {versions.app && versions.app !== versions.pioneer && ` \u00b7 console ${versions.app}`}
         </div>
       )}
     </aside>

--- a/gui/src/lib/backend.ts
+++ b/gui/src/lib/backend.ts
@@ -60,6 +60,13 @@ export async function inspectPath(path: string): Promise<PathInfo> {
 
 export const readConfig = (path: string): Promise<string> => invoke('read_config', { path })
 
+/** Build the single-file `ms_data` directory for one fanned-out search, and
+ *  return its path. SearchDIA takes a directory and searches everything in it,
+ *  so searching a chosen file on its own means giving it a directory that holds
+ *  only that file — see `paths::stage_ms_file`. */
+export const stageMsFile = (jobId: string, file: string): Promise<string> =>
+  invoke('stage_ms_file', { jobId, file })
+
 /** The downloadable-library catalog, as the JSON that DownloadSpecLib prints.
  *  Captured rather than streamed: it is data, not run output. */
 export const listSpecLibs = (repo?: string): Promise<string> =>
@@ -286,6 +293,26 @@ export async function pickFastaFiles(multiple = true): Promise<string[]> {
 }
 
 /** Native file picker restricted to `extensions`. */
+/** Like pickFile, but returns every file chosen. Used by the SearchDIA file
+ *  list, where picking a batch one file at a time would be the whole cost of
+ *  the feature. */
+export async function pickFiles(
+  title: string,
+  name: string,
+  extensions: string[],
+): Promise<string[]> {
+  const picked = await open({
+    directory: false,
+    multiple: true,
+    title,
+    filters: [{ name, extensions }],
+    defaultPath: lastDir(),
+  })
+  if (!Array.isArray(picked) || picked.length === 0) return []
+  rememberDir(picked[0], false)
+  return picked
+}
+
 export async function pickFile(
   title: string,
   name: string,

--- a/gui/src/lib/backend.ts
+++ b/gui/src/lib/backend.ts
@@ -6,7 +6,7 @@ import { homeDir } from '@tauri-apps/api/path'
 
 import {
   EMPTY_PATH_INFO,
-  type CommandId,
+  type BackendCommand,
   type Invocation,
   type PathInfo,
   type PioneerInfo,
@@ -73,7 +73,7 @@ export interface Started {
 
 export const startJob = (
   jobId: string,
-  command: CommandId,
+  command: BackendCommand,
   invocation: Invocation,
   threads: number,
 ): Promise<Started> => invoke('start_job', { jobId, command, invocation, threads })

--- a/gui/src/lib/backend.ts
+++ b/gui/src/lib/backend.ts
@@ -60,12 +60,15 @@ export async function inspectPath(path: string): Promise<PathInfo> {
 
 export const readConfig = (path: string): Promise<string> => invoke('read_config', { path })
 
-/** Build the single-file `ms_data` directory for one fanned-out search, and
- *  return its path. SearchDIA takes a directory and searches everything in it,
- *  so searching a chosen file on its own means giving it a directory that holds
- *  only that file — see `paths::stage_ms_file`. */
-export const stageMsFile = (jobId: string, file: string): Promise<string> =>
-  invoke('stage_ms_file', { jobId, file })
+/** Build the input directory for one run over a chosen set of files, and return
+ *  its path.
+ *
+ *  No Pioneer program takes a list — each takes one directory and works on
+ *  everything in it — so a chosen set is handed over as a directory of links.
+ *  SearchDIA stages one file per run, which is what makes them separate runs;
+ *  ConvertRAW stages a whole format's worth into one. See `paths::stage_files`. */
+export const stageFiles = (jobId: string, subdir: string, files: string[]): Promise<string> =>
+  invoke('stage_files', { jobId, subdir, files })
 
 /** The downloadable-library catalog, as the JSON that DownloadSpecLib prints.
  *  Captured rather than streamed: it is data, not run output. */

--- a/gui/src/lib/config.ts
+++ b/gui/src/lib/config.ts
@@ -8,7 +8,14 @@
  */
 import { DEFAULT_CLEAVAGE, enzymeByPattern } from './enzymes'
 import { makeFastaRow, matchPreset, presetRegex, unimodLabel } from './fasta'
-import type { BuildParams, ConvertParams, DownloadParams, ModEntry, SearchParams } from './types'
+import type {
+  BuildParams,
+  ConvertFormat,
+  ConvertParams,
+  DownloadParams,
+  ModEntry,
+  SearchParams,
+} from './types'
 
 export type Json = Record<string, unknown>
 
@@ -497,4 +504,55 @@ export function convertCommandLine(s: ConvertParams): string {
   const quote = (a: string) => (/[\s"']/.test(a) ? JSON.stringify(a) : a)
   const exe = s.format === 'mzml' ? 'convertMzML' : 'PioneerConverter'
   return [exe, ...buildConvertArgs(s).map(quote)].join(' ')
+}
+
+/** The format a chosen file will be converted with, or null if neither
+ *  converter can read it.
+ *
+ *  Matched on the name rather than on a stat, because this runs over a list on
+ *  every keystroke. `.gz` is excluded deliberately: `extension_of` on the Rust
+ *  side looks through it, but no converter decompresses. */
+export function formatOfFile(path: string): ConvertFormat | null {
+  const p = path.trim().toLowerCase()
+  if (p.endsWith('.raw')) return 'raw'
+  if (p.endsWith('.mzml')) return 'mzml'
+  return null
+}
+
+/** One run's worth of a chosen file list: a format, and the files of it. */
+export interface ConvertGroup {
+  format: ConvertFormat
+  files: string[]
+}
+
+/** Split a chosen file list into the runs it will become.
+ *
+ *  One run per format present, never per file: both converters batch several
+ *  files internally (`--concurrent-files`), so starting them once each is
+ *  strictly better than starting them N times. `.raw` first when both are
+ *  present, matching the order of the format toggle.
+ *
+ *  Anything neither converter reads is left out entirely; validateConvertRun
+ *  refuses the run rather than letting it be silently dropped here.
+ */
+export function convertGroups(files: string[]): ConvertGroup[] {
+  const raw = files.filter((f) => formatOfFile(f) === 'raw')
+  const mzml = files.filter((f) => formatOfFile(f) === 'mzml')
+  const groups: ConvertGroup[] = []
+  if (raw.length) groups.push({ format: 'raw', files: raw })
+  if (mzml.length) groups.push({ format: 'mzml', files: mzml })
+  return groups
+}
+
+/** The params one group runs with.
+ *
+ *  A group is an ordinary folder-mode conversion whose folder happens to be the
+ *  staging directory built for it -- so it goes through the same
+ *  buildConvertArgs as everything else and the two cannot drift apart. */
+export function groupParams(
+  s: ConvertParams,
+  group: ConvertGroup,
+  stagedDir: string,
+): ConvertParams {
+  return { ...s, format: group.format, inputMode: 'folder', input: stagedDir }
 }

--- a/gui/src/lib/config.ts
+++ b/gui/src/lib/config.ts
@@ -527,10 +527,19 @@ export interface ConvertGroup {
 
 /** Split a chosen file list into the runs it will become.
  *
- *  One run per format present, never per file: both converters batch several
- *  files internally (`--concurrent-files`), so starting them once each is
- *  strictly better than starting them N times. `.raw` first when both are
- *  present, matching the order of the format toggle.
+ *  One run per format present. `.raw` first when both are present, matching the
+ *  order of the format toggle.
+ *
+ *  What happens *inside* a run differs by format, because the two converters
+ *  do. convertMzML reads a directory of links happily and parallelises across
+ *  files, so its group is one invocation over a staging folder. PioneerConverter
+ *  cannot: its Thermo reader memory-maps the file it is given and gets the size
+ *  of the link rather than the target, so a linked `.raw` dies with an
+ *  arithmetic overflow — while the process still exits 0. So the `.raw` group is
+ *  one invocation per file, on real paths, run in sequence as a single job.
+ *  Nothing is lost by that: buildConvertArgs already pins `--concurrent-files 1`
+ *  for `.raw`, so one invocation over N files converted them one at a time
+ *  anyway.
  *
  *  Anything neither converter reads is left out entirely; validateConvertRun
  *  refuses the run rather than letting it be silently dropped here.
@@ -555,4 +564,12 @@ export function groupParams(
   stagedDir: string,
 ): ConvertParams {
   return { ...s, format: group.format, inputMode: 'folder', input: stagedDir }
+}
+
+/** The argv for each invocation a `.raw` group becomes: one per file, on the
+ *  real path, in the order the list holds them. */
+export function rawStepArgs(s: ConvertParams, group: ConvertGroup): string[][] {
+  return group.files.map((f) =>
+    buildConvertArgs({ ...s, format: 'raw', inputMode: 'folder', input: f }),
+  )
 }

--- a/gui/src/lib/config.ts
+++ b/gui/src/lib/config.ts
@@ -435,21 +435,36 @@ export function searchConfigToState(obj: unknown): Partial<SearchParams> | null 
 // ConvertRAW
 // ---------------------------------------------------------------------------
 
-/** Build PioneerConverter's argv.
+/** Build the argv for whichever converter the format selects.
  *
- *  Unlike the two Julia commands this has no params file — the converter takes
- *  a positional RAW path plus flags:
+ *  Neither converter has a params file; both take a positional input path plus
+ *  flags, and the two flag sets only partly overlap:
  *
- *    PioneerConverter RAW_PATH [-o DIR] [--skip-existing]
+ *    PioneerConverter RAW_PATH  [-o DIR] [--skip-existing]
  *                     [-n CONCURRENT] [-t PER_FILE] [-b BATCH] [--scan-chunk-size N]
  *
- *  Flags equal to the converter's own defaults are still emitted, so the logged
+ *    convertMzML      MZML_PATH [-o DIR] [--skip-existing]
+ *                     [-n CONCURRENT] [--skip-header | --include-scan-header]
+ *
+ *  Flags equal to a converter's own defaults are still emitted, so the logged
  *  command line is an exact, re-runnable record of what was executed.
  */
 export function buildConvertArgs(s: ConvertParams): string[] {
   const args: string[] = [s.input.trim()]
   if (s.outputDir.trim()) args.push('--output-dir', s.outputDir.trim())
   if (s.skipExisting) args.push('--skip-existing')
+
+  if (s.format === 'mzml') {
+    // convertMzML parallelises across files only -- there is no within-file
+    // knob to multiply against -- so this one is exposed as-is rather than
+    // pinned the way the RAW path pins it.
+    args.push('--concurrent-files', String(Math.max(1, parseInt(s.concurrentFiles, 10) || 1)))
+    // Emitted either way: --skip-header is the converter's default, but naming
+    // it keeps the logged line unambiguous about which was chosen.
+    args.push(s.includeScanHeader ? '--include-scan-header' : '--skip-header')
+    return args
+  }
+
   // One file at a time, split across `threads` scan readers. The converter can
   // work on several files concurrently, but exposing both knobs meant the two
   // multiplied and it was easy to oversubscribe the machine without noticing.
@@ -480,5 +495,6 @@ export function downloadCommandLine(s: DownloadParams): string {
 /** The command line as a user would type it, for the preview panel. */
 export function convertCommandLine(s: ConvertParams): string {
   const quote = (a: string) => (/[\s"']/.test(a) ? JSON.stringify(a) : a)
-  return ['PioneerConverter', ...buildConvertArgs(s).map(quote)].join(' ')
+  const exe = s.format === 'mzml' ? 'convertMzML' : 'PioneerConverter'
+  return [exe, ...buildConvertArgs(s).map(quote)].join(' ')
 }

--- a/gui/src/lib/fasta.ts
+++ b/gui/src/lib/fasta.ts
@@ -127,8 +127,17 @@ export function unimodLabel(name: string): string {
  *  wrong, and the number is still something the reader can look up.
  */
 export function unimodDisplay(entry: string): string {
-  const sep = entry.indexOf(' on ')
-  const label = unimodLabel(sep === -1 ? entry : entry.slice(0, sep))
+  const { name, pattern } = parseModEntry(entry)
+  const label = unimodLabel(name)
   if (!label) return entry
-  return sep === -1 ? label : label + entry.slice(sep)
+  return pattern ? `${label} on ${pattern}` : label
+}
+
+/** Split a `"<name> on <pattern>"` entry, the shape LibraryInfo reports
+ *  modifications in, into the two fields a ModEntry holds separately. */
+export function parseModEntry(entry: string): { name: string; pattern: string } {
+  const sep = entry.indexOf(' on ')
+  return sep === -1
+    ? { name: entry.trim(), pattern: '' }
+    : { name: entry.slice(0, sep).trim(), pattern: entry.slice(sep + 4).trim() }
 }

--- a/gui/src/lib/styles.ts
+++ b/gui/src/lib/styles.ts
@@ -48,6 +48,35 @@ export const BROWSE: CSSProperties = {
   cursor: 'pointer',
 }
 
+/** One button of a segmented control -- the pill pair that picks between two
+ *  shapes of the same field (single file vs folder, .raw vs .mzML, one folder
+ *  vs chosen files). Was defined inside ConvertRawForm; the SearchDIA file-list
+ *  toggle is the same control, so it lives here rather than being copied.
+ *
+ *  Wrap the buttons in a container with `padding: 3`, a `#EEF1F4` background
+ *  and `borderRadius: 10` -- the raised look comes from the active button
+ *  sitting on that inset track.
+ */
+export const seg = (active: boolean): CSSProperties => ({
+  padding: '7px 14px',
+  border: 'none',
+  borderRadius: 8,
+  font: "600 12.5px 'IBM Plex Sans'",
+  cursor: 'pointer',
+  transition: 'all .12s',
+  ...(active
+    ? { background: '#fff', color: '#1B2A4A', boxShadow: '0 1px 3px rgba(15,20,27,0.12)' }
+    : { background: 'none', color: '#667085' }),
+})
+
+/** The track a `seg` pair sits in. */
+export const SEG_TRACK: CSSProperties = {
+  display: 'inline-flex',
+  padding: 3,
+  background: '#EEF1F4',
+  borderRadius: 10,
+}
+
 /** Space reserved at the top of the window for the macOS traffic lights.
  *
  *  The window sets titleBarStyle "Overlay", so on macOS the webview starts at

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -3,6 +3,12 @@ import { modEntry } from './koinaMods'
 
 export type CommandId = 'searchdia' | 'buildspeclib' | 'downloadspeclib' | 'convertraw'
 
+/** What the Rust side is asked to run. One more value than CommandId: the
+ *  ConvertRAW page drives two different binaries, so the workflow the user
+ *  picked and the program that ends up being spawned are not the same thing.
+ *  Mirrors the Rust `pioneer::Command` enum. */
+export type BackendCommand = CommandId | 'convertmzml'
+
 /** One library offered by the Hugging Face repository, as reported by
  *  `DownloadSpecLib --list --json`. Mirrors LibraryEntry in catalog.jl — the
  *  contract between the two halves of the feature. */
@@ -249,13 +255,29 @@ export const BUILD_DEFAULTS: BuildParams = {
   debugLogging: false,
 }
 
-/** ConvertRAW is a .NET program driven entirely by CLI flags — there is no
- *  params JSON for it. Defaults are PioneerConverter's own. */
+/** Which converter the page drives.
+ *
+ *  Two different programs reach the same destination: Thermo `.raw` goes
+ *  through PioneerConverter (a .NET binary), `.mzML` through Pioneer's own
+ *  `convertMzML` (Julia). They share the input/output/skip-existing shape but
+ *  nothing else -- PioneerConverter's batching and scan-chunk knobs have no
+ *  counterpart in the Julia converter, which instead exposes files-at-a-time
+ *  and whether to carry scan headers into the Arrow file.
+ *
+ *  Held as an explicit field rather than sniffed from the input path, because
+ *  in Folder mode the path says nothing about what is inside it, and a folder
+ *  can hold both. */
+export type ConvertFormat = 'raw' | 'mzml'
+
+/** ConvertRAW's two converters are both driven entirely by CLI flags — there is
+ *  no params JSON for either. Defaults are each converter's own. */
 export interface ConvertParams {
-  /** A single .raw file, or a folder of them. The binary accepts one path. */
+  format: ConvertFormat
+  /** A single input file, or a folder of them. Both binaries accept one path. */
   inputMode: 'file' | 'folder'
   input: string
-  /** Blank means the converter's default of <input_dir>/arrow_out. */
+  /** Blank means the converter's default of <input_dir>/arrow_out. Both
+   *  converters use the same default, so this note holds either way. */
   outputDir: string
   skipExisting: boolean
   /** Scan-reader threads within the single file being converted.
@@ -264,13 +286,26 @@ export interface ConvertParams {
    *  files-at-a-time stays pinned at 1 (see buildConvertArgs) and this is the
    *  only one exposed. It is deliberately not the sidebar thread count: that
    *  drives JULIA_NUM_THREADS, and the converter is a .NET program that never
-   *  reads it. */
+   *  reads it.
+   *
+   *  RAW only — convertMzML has no equivalent. */
   threadsPerFile: string
+  /** RAW only. */
   batchSize: string
+  /** RAW only. */
   scanChunkSize: string
+  /** mzML only: files converted at the same time. The Julia converter has one
+   *  level of parallelism rather than two, so unlike the RAW path this is
+   *  exposed directly instead of being pinned at 1. */
+  concurrentFiles: string
+  /** mzML only. convertMzML omits scan headers by default; they roughly double
+   *  the Arrow file and nothing in SearchDIA reads them, so this stays off
+   *  unless someone wants the output for something else. */
+  includeScanHeader: boolean
 }
 
 export const CONVERT_DEFAULTS: ConvertParams = {
+  format: 'raw',
   inputMode: 'folder',
   input: '',
   outputDir: '',
@@ -278,6 +313,8 @@ export const CONVERT_DEFAULTS: ConvertParams = {
   threadsPerFile: '3',
   batchSize: '10000',
   scanChunkSize: '128',
+  concurrentFiles: '2',
+  includeScanHeader: false,
 }
 
 /** Mirrors the Rust `runner::Invocation` enum. */

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -287,10 +287,20 @@ export type ConvertFormat = 'raw' | 'mzml'
 /** ConvertRAW's two converters are both driven entirely by CLI flags — there is
  *  no params JSON for either. Defaults are each converter's own. */
 export interface ConvertParams {
+  /** Which converter a *folder* is handed to.
+   *
+   *  Only meaningful in folder mode: a directory's path says nothing about
+   *  what is inside it, and it can hold both. In file-list mode every file
+   *  names its own format, so the toggle is hidden and this is ignored. */
   format: ConvertFormat
-  /** A single input file, or a folder of them. Both binaries accept one path. */
-  inputMode: 'file' | 'folder'
+  /** A chosen list of files, or one folder. Neither binary takes a list, so a
+   *  list is handed over as a directory of links -- see paths::stage_files. */
+  inputMode: 'files' | 'folder'
+  /** The folder, in folder mode. */
   input: string
+  /** The chosen files, in file-list mode. May mix .raw and .mzML: they are
+   *  grouped by format at run time, one run per format present. */
+  inputFiles: string[]
   /** Blank means the converter's default of <input_dir>/arrow_out. Both
    *  converters use the same default, so this note holds either way. */
   outputDir: string
@@ -323,6 +333,7 @@ export const CONVERT_DEFAULTS: ConvertParams = {
   format: 'raw',
   inputMode: 'folder',
   input: '',
+  inputFiles: [],
   outputDir: '',
   skipExisting: false,
   threadsPerFile: '3',

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -347,6 +347,8 @@ export const CONVERT_DEFAULTS: ConvertParams = {
 export type Invocation =
   | { kind: 'paramsFile'; json: string }
   | { kind: 'args'; args: string[] }
+  /** Run the same program once per argument set, in order, as one job. */
+  | { kind: 'steps'; steps: string[][] }
 
 /** `interrupted` is not reported by a run — it is inferred at startup for a
  *  row still marked queued or running, which can only mean the app went away

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -178,6 +178,32 @@ export function isPrositModel(id: string): boolean {
   return id.startsWith('prosit')
 }
 
+/** Oxidation on methionine, however the modification is spelled.
+ *
+ *  Accepts the accession or the label, and tolerates the bracketed form a
+ *  pattern is sometimes written in, because this is asked both of a ModEntry
+ *  the user built in the form and of a string parsed back out of a library's
+ *  own config. */
+export function isOxidationOnMet(name: string, pattern: string): boolean {
+  const isOx = /^(unimod:35|oxidation)$/i.test(name.trim())
+  const residues = pattern.replace(/[[\]]/g, '').trim().toUpperCase()
+  return isOx && residues === 'M'
+}
+
+/** The variable modifications the site-localization caveat is actually about.
+ *
+ *  Everything except oxidation on methionine. That one is a variable
+ *  modification in the strict sense, but it is near-universal in bottom-up
+ *  search and is the default this app itself ships with — warning about it
+ *  meant the caveat appeared on an ordinary library doing an ordinary thing,
+ *  which is how a warning stops being read. What the caveat is for is a library
+ *  carrying phospho, acetyl and the like, where which residue is modified is
+ *  the result and Pioneer does not score it.
+ */
+export function unlocalizedMods<T extends { name: string; pattern: string }>(mods: T[]): T[] {
+  return mods.filter((m) => !isOxidationOnMet(m.name, m.pattern))
+}
+
 export function predictionModelById(id: string): PredictionModel {
   return PREDICTION_MODELS.find((m) => m.id === id) ?? PREDICTION_MODELS[0]
 }

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -43,6 +43,19 @@ export const DOWNLOAD_DEFAULTS: DownloadParams = {
 /** Every field the SearchDIA form owns. Kept as strings where the design keeps
  *  strings, so a half-typed number ("0.0") survives a re-render intact. */
 export interface SearchParams {
+  /** How the MS data is given.
+   *
+   *  'folder' is the original and still the default: one directory, searched as
+   *  one experiment, with FDR and match-between-runs spanning every file in it.
+   *
+   *  'files' is for method development, where a batch of files are variations on
+   *  each other rather than replicates of one experiment. Each picked file is
+   *  searched on its own and written to its own results folder — the console
+   *  fans one click out into one run per file, because searching them together
+   *  would pool exactly the files that are meant to be compared. */
+  msDataMode: 'folder' | 'files'
+  /** The chosen files, when msDataMode is 'files'. */
+  msDataFiles: string[]
   msData: string
   library: string
   results: string
@@ -63,6 +76,8 @@ export interface SearchParams {
 }
 
 export const SEARCH_DEFAULTS: SearchParams = {
+  msDataMode: 'folder',
+  msDataFiles: [],
   msData: '',
   library: '',
   results: '',

--- a/gui/src/lib/validate.ts
+++ b/gui/src/lib/validate.ts
@@ -582,10 +582,22 @@ export function convertInputNote(p: ConvertParams, info: PathInfo): Note {
   }
 }
 
-export function convertOutputNote(value: string, info: PathInfo): Note {
-  if (!value.trim()) return NONE // converter defaults to <input_dir>/arrow_out
+/** Takes the whole `convert` object rather than just the path, because whether
+ *  existing output is at risk depends on "Skip existing" as much as on what is
+ *  in the folder. */
+export function convertOutputNote(p: ConvertParams, info: PathInfo): Note {
+  if (!p.outputDir.trim()) return NONE // converter defaults to <input_dir>/arrow_out
   if (info.is_file) return { level: 'error', msg: 'A file exists at this path — choose a folder.' }
   if (info.exists && info.arrow_count > 0) {
+    // Nothing to warn about once the files are being left alone: the warning
+    // existed only to offer this setting, and telling someone to enable what
+    // they have already enabled reads as the app not knowing its own state.
+    if (p.skipExisting) {
+      return {
+        level: '',
+        msg: `This folder already holds ${info.arrow_count} .arrow file${info.arrow_count > 1 ? 's' : ''}. They will be left alone.`,
+      }
+    }
     return {
       level: 'warn',
       msg: `This folder already holds ${info.arrow_count} .arrow file${info.arrow_count > 1 ? 's' : ''} — they may be overwritten. Enable "Skip existing" to keep them.`,

--- a/gui/src/lib/validate.ts
+++ b/gui/src/lib/validate.ts
@@ -537,8 +537,14 @@ export function convertInputNote(p: ConvertParams, info: PathInfo): Note {
 
   if (p.inputMode === 'file') {
     if (info.is_dir) return { level: 'error', msg: 'That is a folder — switch to Folder mode.' }
-    // `extension` looks through a trailing .gz, so a compressed mzML reads as
-    // "mzml" here and is accepted -- convertMzML handles it.
+    // Checked on the typed path, not on `info.extension`: that field looks
+    // through a trailing .gz (right for FASTA, which Pioneer reads compressed)
+    // and would report `run.mzML.gz` as an mzML. No converter here
+    // decompresses, so such a file must be refused rather than handed over to
+    // be silently skipped.
+    if (/\.gz$/i.test(p.input.trim())) {
+      return { level: 'error', msg: 'Compressed files are not supported — decompress it first.' }
+    }
     if (info.extension !== (mzml ? 'mzml' : 'raw')) {
       return {
         level: 'error',

--- a/gui/src/lib/validate.ts
+++ b/gui/src/lib/validate.ts
@@ -270,6 +270,27 @@ export function downloadTargetPath(dest: string, library: string): string {
   return d.endsWith('/') ? `${d}${l}` : `${d}/${l}`
 }
 
+/** The file name without its directory or extension: what a per-file search
+ *  names its run and its results folder after.
+ *
+ *  Splits on both separators rather than the platform's own, because a path can
+ *  reach the console from a drag-and-drop or a stored run rather than from this
+ *  machine's picker. */
+export function fileStem(path: string): string {
+  const name = path.trim().split(/[\\/]/).pop() ?? ''
+  const dot = name.lastIndexOf('.')
+  return dot > 0 ? name.slice(0, dot) : name
+}
+
+/** Join a directory and one child name, tolerating a trailing separator on the
+ *  directory. Same shape as downloadTargetPath, kept separate because that one
+ *  is about a specific pair of fields and this one is not. */
+export function joinPath(dir: string, child: string): string {
+  const d = dir.trim()
+  if (!d) return child
+  return /[\\/]$/.test(d) ? `${d}${child}` : `${d}/${child}`
+}
+
 export function libPathNote(value: string, targetInfo: PathInfo): Note {
   if (!value.trim()) return NONE
   if (!/[\\/]/.test(value)) return { level: 'error', msg: 'Enter a full path.' }
@@ -296,12 +317,32 @@ export interface RunBlock {
  *   job will produce, or null when no such job is waiting.
  */
 export function validateSearchRun(
-  values: { msData: string; library: string; results: string; qValue: string; nIsotopes: string; nce: string; minPeptides: string },
+  values: {
+    msDataMode?: 'folder' | 'files'
+    msDataFiles?: string[]
+    msData: string
+    library: string
+    results: string
+    qValue: string
+    nIsotopes: string
+    nce: string
+    minPeptides: string
+  },
   notes: { msData: Note; library: Note; results: Note },
   pendingLibrary: string | null = null,
 ): RunBlock | null {
-  if (!values.msData.trim()) return { key: 'msData', msg: 'Set the MS data path before running.' }
-  if (notes.msData.level === 'error') return { key: 'msData', msg: notes.msData.msg }
+  // In file-list mode the folder field is unused and its note is meaningless:
+  // what has to be there is at least one file. Everything below is shared --
+  // each fanned-out run gets the same library, the same thresholds, and a
+  // results folder under the same root.
+  if (values.msDataMode === 'files') {
+    if (!(values.msDataFiles ?? []).length) {
+      return { key: 'msData', msg: 'Add at least one file to search.' }
+    }
+  } else {
+    if (!values.msData.trim()) return { key: 'msData', msg: 'Set the MS data path before running.' }
+    if (notes.msData.level === 'error') return { key: 'msData', msg: notes.msData.msg }
+  }
 
   // A library that is still being predicted is not a missing library. With a
   // build or download ahead of it in the queue, the search that consumes its

--- a/gui/src/lib/validate.ts
+++ b/gui/src/lib/validate.ts
@@ -517,14 +517,46 @@ export function modSiteConflict(fixed: ModEntry[], variable: ModEntry[]): string
 // ConvertRAW
 // ---------------------------------------------------------------------------
 
-/** Either converter takes one path: an input file, or a directory of them.
+/** What the Input field is saying about itself.
  *
- *  The format picker, not the path, decides which converter runs -- so a `.raw`
- *  handed to the mzML converter is caught here rather than by the binary, whose
- *  failure would arrive several seconds later as a stack trace. The other
- *  direction is the more likely mistake and gets the same treatment.
+ *  Folder mode: the format picker, not the path, decides which converter runs,
+ *  so a `.raw` folder handed to the mzML converter is caught here rather than
+ *  by the binary, whose failure would arrive seconds later as a stack trace.
+ *
+ *  File-list mode: the format is read off each name instead, so what has to be
+ *  checked is that every file is one a converter can actually read.
  */
 export function convertInputNote(p: ConvertParams, info: PathInfo): Note {
+  if (p.inputMode === 'files') {
+    const files = p.inputFiles
+    if (files.length === 0) return NONE
+    const bad = files.filter((f) => !/\.(raw|mzml)$/i.test(f.trim()))
+    if (bad.length) {
+      // Named, not counted: with a list on screen, "2 files are not supported"
+      // still leaves you hunting for which.
+      const names = bad.slice(0, 3).map((f) => f.trim().split(/[\\/]/).pop())
+      return {
+        level: 'error',
+        msg: `Not a .raw or .mzML file: ${names.join(', ')}${bad.length > 3 ? `, and ${bad.length - 3} more` : ''}.`,
+      }
+    }
+    // Two files of the same name cannot share the one folder each converter is
+    // handed, so they are refused here rather than by paths::stage_files once
+    // the run has already been queued.
+    const seen = new Set<string>()
+    for (const f of files) {
+      const name = (f.trim().split(/[\\/]/).pop() ?? '').toLowerCase()
+      if (seen.has(name)) {
+        return {
+          level: 'error',
+          msg: `Two of these files are named ${name}. Rename one, or convert them separately.`,
+        }
+      }
+      seen.add(name)
+    }
+    return NONE
+  }
+
   if (!p.input.trim()) return NONE
   if (info.error) return { level: 'error', msg: info.error }
   if (!info.exists) return { level: 'error', msg: 'This path does not exist.' }
@@ -535,31 +567,7 @@ export function convertInputNote(p: ConvertParams, info: PathInfo): Note {
   const other = mzml ? info.raw_count : info.mzml_count
   const otherLabel = mzml ? '.raw' : '.mzML'
 
-  if (p.inputMode === 'file') {
-    if (info.is_dir) return { level: 'error', msg: 'That is a folder — switch to Folder mode.' }
-    // Checked on the typed path, not on `info.extension`: that field looks
-    // through a trailing .gz (right for FASTA, which Pioneer reads compressed)
-    // and would report `run.mzML.gz` as an mzML. No converter here
-    // decompresses, so such a file must be refused rather than handed over to
-    // be silently skipped.
-    if (/\.gz$/i.test(p.input.trim())) {
-      return { level: 'error', msg: 'Compressed files are not supported — decompress it first.' }
-    }
-    if (info.extension !== (mzml ? 'mzml' : 'raw')) {
-      return {
-        level: 'error',
-        msg:
-          info.extension === (mzml ? 'raw' : 'mzml')
-            ? `That is a ${otherLabel} file — switch the format to ${otherLabel}.`
-            : mzml
-              ? 'Expected an .mzML file.'
-              : 'Expected a Thermo .raw file.',
-      }
-    }
-    return NONE
-  }
-
-  if (info.is_file) return { level: 'error', msg: 'That is a file — switch to Single file mode.' }
+  if (info.is_file) return { level: 'error', msg: 'That is a file — switch to Files mode.' }
   if (count === 0) {
     return {
       level: 'error',
@@ -612,12 +620,35 @@ export function validateConvertRun(
   inputNote: Note,
   outputNote: Note,
 ): RunBlock | null {
-  if (!p.input.trim()) return { key: 'convertInput', msg: 'Choose the file or folder to convert.' }
+  if (p.inputMode === 'files') {
+    if (p.inputFiles.length === 0) {
+      return { key: 'convertInput', msg: 'Add at least one file to convert.' }
+    }
+    // Each converter is handed a staging folder under the system temp
+    // directory, so its own <input_dir>/arrow_out default would write there --
+    // somewhere nobody would think to look. Required rather than guessed at:
+    // the files can come from several folders and none of them is the obvious
+    // answer.
+    if (!p.outputDir.trim()) {
+      return { key: 'convertOutput', msg: 'Choose an output folder for the converted files.' }
+    }
+  } else if (!p.input.trim()) {
+    return { key: 'convertInput', msg: 'Choose the folder to convert.' }
+  }
   if (inputNote.level === 'error') return { key: 'convertInput', msg: inputNote.msg }
   if (outputNote.level === 'error') return { key: 'convertOutput', msg: outputNote.msg }
-  // Only the fields the chosen converter actually reads: a stale batch size
-  // left over from a RAW run must not block an mzML conversion that ignores it.
-  const keys = p.format === 'mzml' ? MZML_NUM_KEYS : CONVERT_NUM_KEYS
+  // Only the fields the converters that will actually run read. A list can hold
+  // both formats, so it is checked against both; a stale batch size left over
+  // from a RAW run must not block an mzML-only conversion that ignores it.
+  const keys =
+    p.inputMode === 'files'
+      ? [
+          ...(p.inputFiles.some((f) => /\.raw$/i.test(f.trim())) ? CONVERT_NUM_KEYS : []),
+          ...(p.inputFiles.some((f) => /\.mzml$/i.test(f.trim())) ? MZML_NUM_KEYS : []),
+        ]
+      : p.format === 'mzml'
+        ? MZML_NUM_KEYS
+        : CONVERT_NUM_KEYS
   for (const key of keys) {
     const err = numError(key, p[key])
     if (err) return { key, msg: `${NUM_SPECS[key].label}: ${err}.` }

--- a/gui/src/lib/validate.ts
+++ b/gui/src/lib/validate.ts
@@ -66,13 +66,28 @@ export const NUM_SPECS: Record<string, NumSpec> = {
   threadsPerFile: { label: 'Threads per file', min: 1, max: null, step: 1, int: true },
   batchSize: { label: 'Batch size (scans)', min: 1, max: null, step: 1000, int: true },
   scanChunkSize: { label: 'Scan chunk size', min: 1, max: null, step: 16, int: true },
+  // convertMzML's own default is 2.
+  concurrentFiles: {
+    label: 'Files at a time',
+    min: 1,
+    max: null,
+    step: 1,
+    int: true,
+    info: 'How many .mzML files are converted at the same time. Each one is read and written whole, so this is bounded by disk and memory rather than by cores — the default of 2 is a deliberately conservative starting point.',
+  },
 }
 
+/** The numeric fields PioneerConverter reads. */
 export const CONVERT_NUM_KEYS = [
   'threadsPerFile',
   'batchSize',
   'scanChunkSize',
 ] as const
+
+/** The numeric fields convertMzML reads. Deliberately disjoint from
+ *  CONVERT_NUM_KEYS: the two converters share no tuning parameter, and
+ *  validating a field the running binary ignores would block a valid run. */
+export const MZML_NUM_KEYS = ['concurrentFiles'] as const
 
 export const DIGEST_KEYS = [
   'minLen',
@@ -461,25 +476,54 @@ export function modSiteConflict(fixed: ModEntry[], variable: ModEntry[]): string
 // ConvertRAW
 // ---------------------------------------------------------------------------
 
-/** PioneerConverter takes one path: a .raw file, or a directory of them. */
+/** Either converter takes one path: an input file, or a directory of them.
+ *
+ *  The format picker, not the path, decides which converter runs -- so a `.raw`
+ *  handed to the mzML converter is caught here rather than by the binary, whose
+ *  failure would arrive several seconds later as a stack trace. The other
+ *  direction is the more likely mistake and gets the same treatment.
+ */
 export function convertInputNote(p: ConvertParams, info: PathInfo): Note {
   if (!p.input.trim()) return NONE
   if (info.error) return { level: 'error', msg: info.error }
   if (!info.exists) return { level: 'error', msg: 'This path does not exist.' }
 
+  const mzml = p.format === 'mzml'
+  const label = mzml ? '.mzML' : '.raw'
+  const count = mzml ? info.mzml_count : info.raw_count
+  const other = mzml ? info.raw_count : info.mzml_count
+  const otherLabel = mzml ? '.raw' : '.mzML'
+
   if (p.inputMode === 'file') {
     if (info.is_dir) return { level: 'error', msg: 'That is a folder — switch to Folder mode.' }
-    if (info.extension !== 'raw') {
-      return { level: 'error', msg: 'Expected a Thermo .raw file.' }
+    // `extension` looks through a trailing .gz, so a compressed mzML reads as
+    // "mzml" here and is accepted -- convertMzML handles it.
+    if (info.extension !== (mzml ? 'mzml' : 'raw')) {
+      return {
+        level: 'error',
+        msg:
+          info.extension === (mzml ? 'raw' : 'mzml')
+            ? `That is a ${otherLabel} file — switch the format to ${otherLabel}.`
+            : mzml
+              ? 'Expected an .mzML file.'
+              : 'Expected a Thermo .raw file.',
+      }
     }
     return NONE
   }
 
   if (info.is_file) return { level: 'error', msg: 'That is a file — switch to Single file mode.' }
-  if (info.raw_count === 0) return { level: 'error', msg: 'No .raw files in this folder.' }
+  if (count === 0) {
+    return {
+      level: 'error',
+      msg: other
+        ? `No ${label} files in this folder, but ${other} ${otherLabel} file${other > 1 ? 's' : ''} — switch the format to ${otherLabel}.`
+        : `No ${label} files in this folder.`,
+    }
+  }
   return {
     level: '',
-    msg: `${info.raw_count} .raw file${info.raw_count > 1 ? 's' : ''} to convert.`,
+    msg: `${count} ${label} file${count > 1 ? 's' : ''} to convert.`,
   }
 }
 
@@ -524,7 +568,10 @@ export function validateConvertRun(
   if (!p.input.trim()) return { key: 'convertInput', msg: 'Choose the file or folder to convert.' }
   if (inputNote.level === 'error') return { key: 'convertInput', msg: inputNote.msg }
   if (outputNote.level === 'error') return { key: 'convertOutput', msg: outputNote.msg }
-  for (const key of CONVERT_NUM_KEYS) {
+  // Only the fields the chosen converter actually reads: a stale batch size
+  // left over from a RAW run must not block an mzML conversion that ignores it.
+  const keys = p.format === 'mzml' ? MZML_NUM_KEYS : CONVERT_NUM_KEYS
+  for (const key of keys) {
     const err = numError(key, p[key])
     if (err) return { key, msg: `${NUM_SPECS[key].label}: ${err}.` }
   }


### PR DESCRIPTION
Console-only. No Julia or Python changed.

## Features

- **ConvertRAW converts `.mzML`.** A Format toggle routes a folder to `PioneerConverter` or Pioneer's own `convertMzML`, which already shipped in `bin/` with no way in.
- **ConvertRAW takes a file list.** "Single file" becomes "Files": a `+` list that may mix `.raw` and `.mzML`, split by format into one job each.
- **SearchDIA takes a file list.** "Chosen files" fans one click into one run per file, each with its own results folder — for method-development batches, where searching together would pool exactly the files meant to be compared.
- **Sidebar footer** shows the console version only when it differs from the Pioneer version.

## Startup

Measured with generated histories at 50 / 500 / 2,000 / 10,000 runs. Loading is not the cost — 10,000 runs is 5 MiB of snapshots and SQLite + IPC + `JSON.parse` is 40 ms of a 2,670 ms startup. Two other things were:

- The sidebar drew every finished run (2.3 s at 10,000), and paid it again on every re-render — which for a running job is every line of output. It now draws a window of 60, grown by scrolling, with `searchableText` memoised per job.
- The persisted-rows set was seeded with `${id}:${status}` while the effect checked `${id}:${status}:${runNo}`, so nothing ever matched and **every row was written back to SQLite on every launch**.

10,000 runs: 2,670 → 388 ms, against 396 ms for 50. Flat.

## Fixes found while testing

- A chosen list of `.raw` converted nothing while reporting success. Thermo's reader memory-maps the file and gets the *link's* size through a symlink, dying with `System.OverflowException`; PioneerConverter exits 0 anyway. `.raw` is no longer staged — each file goes to its own invocation on a real path, still one job via a new `runner::Invocation::Steps`. Costs nothing, since `--concurrent-files` was already pinned to 1 for `.raw`. A conversion whose output folder holds no `.arrow` is now marked failed.
- `.mzML.gz` was accepted but unconvertible — `convertMzML` matches a literal `.mzml` suffix and never decompresses. `PathInfo.extension` looks *through* `.gz`, which is right for FASTA and wrong for MS data; MS counts now use their own suffix match.
- The Prosit site-localization caveat fired on oxidation on M, i.e. on ordinary libraries including this app's own default.
- The output note ignored "Skip existing" and told you to enable what was already enabled; the overwrite dialog showed BuildSpecLib's wording and path for a conversion.
- The input note went stale on the format toggle, and the path wasn't cleared when switching file/folder mode.

## Testing

32 Rust tests (5 new: group staging, duplicate-name refusal, `.gz` counting). Behavioural checks on grouping, argv, path helpers and validators were run through esbuild but are **not committed** — there's no JS test runner in the repo. Happy to add one if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
