### PR TITLE
feat: include MBR recoveries in pairwise normalization

### DIFF
--- a/src/utils/normalizeQuant.jl
+++ b/src/utils/normalizeQuant.jl
@@ -163,13 +163,14 @@ function _file_precursor_quant_anchors(
     quant = psms[!, quant_col_name]
     irt_obs = psms[!, :irt_obs]
     target = hasproperty(psms, :target) ? psms[!, :target] : nothing
-    mbr_recovered = hasproperty(psms, :mbr_recovered) ?
-        psms[!, :mbr_recovered] : nothing
     anchors = Dict{UInt32, QuantRunAnchor}()
     sizehint!(anchors, length(precursor_idx))
 
     @inbounds for row in eachindex(precursor_idx, quant, irt_obs)
-        _is_normalization_anchor_row(row, target, mbr_recovered) || continue
+        # Pairwise normalization operates on the final passing-PSM tables, so
+        # accepted MBR recoveries are valid run-level quantities. Keep the
+        # target filter, but allow both directly identified and recovered rows.
+        _is_normalization_anchor_row(row, target, nothing) || continue
         quant_raw = quant[row]
         irt_raw = irt_obs[row]
         (ismissing(quant_raw) || ismissing(irt_raw)) && continue
@@ -432,8 +433,8 @@ end
 
 Build a maximum-similarity spanning forest for pairwise quant normalization.
 Candidate run pairs are ordered by the maximum directional containment in the
-existing run-similarity atlas. An edge is accepted only when exact, non-MBR,
-target precursor matches can support the requested RT spline. Kruskal's
+existing run-similarity atlas. An edge is accepted only when exact target
+precursor matches can support the requested RT spline. Kruskal's
 algorithm therefore returns a maximum spanning tree when the supported graph
 is connected, or a maximum spanning forest otherwise.
 
@@ -712,7 +713,8 @@ end
 End-to-end RT-dependent quantification normalization. When a run-similarity
 atlas is supplied, fits exact-match pairwise splines only along a supported
 maximum spanning tree, propagates their differences to run corrections, and
-median-centers the tree at each RT. MBR-recovered rows never serve as anchors.
+median-centers the tree at each RT. Both directly identified and MBR-recovered
+target rows can serve as pairwise anchors.
 
 Without an atlas, retains the experiment-wide matched-precursor estimator as a
 fallback.
@@ -755,7 +757,7 @@ function normalizeQuant(
             return nothing
         end
 
-        @user_warn "No run pair had enough exact non-MBR precursor matches " *
+        @user_warn "No run pair had enough exact precursor matches " *
                    "to support an RT spline. Falling back to the " *
                    "experiment-wide matched-precursor normalizer."
     end

--- a/test/UnitTests/test_normalizeQuant.jl
+++ b/test/UnitTests/test_normalizeQuant.jl
@@ -136,7 +136,7 @@ function _write_mbr_anchor_pair(
     irt_obs = Float32.(LinRange(0.0, 100.0, n_observed + n_recovered))
     recovered = BitVector(vcat(falses(n_observed), trues(n_recovered)))
     run1_log2 = vcat(fill(8.0f0, n_observed), fill(14.0f0, n_recovered))
-    run2_log2 = vcat(fill(10.0f0, n_observed), fill(4.0f0, n_recovered))
+    run2_log2 = vcat(fill(10.0f0, n_observed), fill(16.0f0, n_recovered))
     paths = String[]
     for (run, log2_quant) in enumerate((run1_log2, run2_log2))
         path = joinpath(dir, "mbr_run$(run).arrow")
@@ -282,7 +282,7 @@ end
 
         @test length(tree) == 1
         @test only(tree).nanchors == n_observed + n_recovered
-        @test only(tree).spline(50.0) ≈ 10.0 atol=0.05
+        @test only(tree).spline(50.0) ≈ -2.0 atol=0.05
 
         Pioneer.normalizeQuant(
             paths,

--- a/test/UnitTests/test_normalizeQuant.jl
+++ b/test/UnitTests/test_normalizeQuant.jl
@@ -153,7 +153,8 @@ function _write_mbr_anchor_pair(
         UInt32(1) => copy(precursor_idx),
         UInt32(2) => copy(precursor_idx),
     )
-    return paths, Pioneer.build_run_similarity(observed_ids_by_run), n_observed
+    return paths, Pioneer.build_run_similarity(observed_ids_by_run),
+           n_observed, n_recovered
 end
 
 @testset "normalizeQuant" begin
@@ -261,10 +262,12 @@ end
     end
 end
 
-@testset "MBR-recovered rows are excluded from pairwise anchors" begin
+@testset "MBR-recovered rows are included in pairwise anchors" begin
     mktempdir() do dir
-        paths, atlas, n_observed = _write_mbr_anchor_pair(dir)
+        paths, atlas, n_observed, n_recovered = _write_mbr_anchor_pair(dir)
         run_ids = UInt32[1, 2]
+
+        # The legacy experiment-wide fallback still excludes recovered rows.
         consensus = Pioneer.getPrecursorQuantConsensus(paths, :abundance)
         @test length(consensus) == n_observed
 
@@ -278,8 +281,8 @@ end
         )
 
         @test length(tree) == 1
-        @test only(tree).nanchors == n_observed
-        @test only(tree).spline(50.0) ≈ -2.0 atol=0.05
+        @test only(tree).nanchors == n_observed + n_recovered
+        @test only(tree).spline(50.0) ≈ 10.0 atol=0.05
 
         Pioneer.normalizeQuant(
             paths,
@@ -291,11 +294,12 @@ end
         )
         run1 = DataFrame(Arrow.Table(paths[1]))
         run2 = DataFrame(Arrow.Table(paths[2]))
-        observed_difference = median(
-            log2.(run1.abundance_normalized[1:n_observed]) .-
-            log2.(run2.abundance_normalized[1:n_observed])
+        recovered_rows = (n_observed + 1):(n_observed + n_recovered)
+        recovered_difference = median(
+            log2.(run1.abundance_normalized[recovered_rows]) .-
+            log2.(run2.abundance_normalized[recovered_rows])
         )
-        @test abs(observed_difference) < 0.05
+        @test abs(recovered_difference) < 0.05
     end
 end
 


### PR DESCRIPTION
## Summary

- include accepted MBR-recovered target precursors as exact-match anchors when fitting pairwise RT-dependent normalization splines
- retain the existing direct-identification run-similarity topology and the direct-only experiment-wide fallback behavior
- update normalization documentation, warnings, and the regression fixture to cover the MBR-inclusive anchor path

## Motivation

Sparse runs can have too few direct precursor matches to estimate the pairwise correction reliably. The final passing-PSM tables already contain accepted MBR-recovered target quantities, so allowing those exact matches to contribute increases anchor coverage without changing how nearest-run relationships are selected.

## Testing

- `julia --startup-file=no --project=. test/UnitTests/test_normalizeQuant.jl` — 54/54 tests passed
