### PR TITLE
GUI: batch toggle, droppable file lists, consistent job name

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -472,7 +472,13 @@ export default function App() {
       return job.id
     })
     setCommand(job.cmd)
-    if (job.snapshot.cmd === 'searchdia') setSearch(job.snapshot.search)
+    // Merged for the same reason as the build and convert snapshots below: runs
+    // stored before the file list existed carry no msDataMode or msDataFiles,
+    // and recalling one and then switching to Chosen files would otherwise map
+    // over an undefined list.
+    if (job.snapshot.cmd === 'searchdia') {
+      setSearch({ ...SEARCH_DEFAULTS, ...job.snapshot.search })
+    }
     else if (job.snapshot.cmd === 'buildspeclib') {
       // Stored runs from before digestion specificity was added do not carry
       // the field. Merge defaults so recalling one still renders and emits a

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -649,6 +649,24 @@ export default function App() {
           setBuild((b) => ({ ...b, fastaFiles: [...b.fastaFiles, ...paths.map(makeFastaRow)] }))
           return
         }
+        if (key === 'msData') {
+          // Same shape as convertInput below: a folder selects folder mode, and
+          // files join the list -- all of them, since dropping a batch is the
+          // whole reason the list exists.
+          if (isDir) {
+            setSearch((p) => ({ ...p, msData: path, msDataMode: 'folder' }))
+          } else {
+            setSearch((p) => {
+              const have = new Set(p.msDataFiles)
+              return {
+                ...p,
+                msDataMode: 'files',
+                msDataFiles: [...p.msDataFiles, ...paths.filter((f) => !have.has(f))],
+              }
+            })
+          }
+          return
+        }
         if (key === 'convertInput') {
           // Dropping a folder means folder mode; dropping files means the list,
           // and every dropped path joins it rather than only the first -- the
@@ -1335,6 +1353,12 @@ export default function App() {
    *  params file written for each run does carry the real path. */
   const previewSearch = useMemo(() => {
     if (!isSearch || search.msDataMode !== 'files' || search.msDataFiles.length === 0) return search
+    const n = search.msDataFiles.length
+    // Searched together there is one run and one results folder; only `ms_data`
+    // stands in, because the directory holding the links does not exist yet.
+    if (!search.msDataBatch) {
+      return { ...search, msData: `<${n} staged file${n > 1 ? 's' : ''}>` }
+    }
     const first = search.msDataFiles[0]
     return { ...search, msData: first, results: joinPath(search.results, fileStem(first)) }
   }, [isSearch, search])
@@ -1495,7 +1519,22 @@ export default function App() {
     const added: Job[] = []
     let failure = ''
 
-    if (isSearch && search.msDataMode === 'files') {
+    if (isSearch && search.msDataMode === 'files' && !search.msDataBatch) {
+      // One run over the whole list. The files are staged into a single
+      // directory, exactly as folder mode would have been given one, so the
+      // search sees them as the one experiment they are -- shared FDR, and
+      // match-between-runs across them. Results go to the chosen folder
+      // unsuffixed: there is only one run, so there is nothing to tell apart.
+      const { id, runNo } = await allocate()
+      let msData: string
+      try {
+        msData = await backend.stageFiles(id, 'ms_data', search.msDataFiles)
+      } catch (e) {
+        setRunError(String(e))
+        return
+      }
+      added.push(makeJob(id, runNo, resolveRunName(jobName, taken), { ...search, msData }))
+    } else if (isSearch && search.msDataMode === 'files') {
       // One run per file. Pioneer has no way to be handed a list -- it takes a
       // directory and searches everything in it -- so each run gets a directory
       // of its own holding a single link to its file, plus a results folder
@@ -1909,27 +1948,22 @@ export default function App() {
               </div>
             )}
 
-            {/* SearchDIA carries this inside its Essentials card, beside the
-                paths the run will be remembered alongside. The other commands
-                have no equivalent card to host it, so for them it keeps one of
-                its own. */}
-            {!isSearch && (
-              <section
-                style={{
-                  background: '#fff',
-                  border: '1px solid #E7EAEE',
-                  borderRadius: 13,
-                  padding: '18px 20px',
-                  marginBottom: 14,
-                }}
-              >
-                <JobNameField
-                  value={jobName}
-                  resolved={resolvedJobName}
-                  onChange={setJobName}
-                />
-              </section>
-            )}
+            {/* Above the form on every workflow. It used to sit inside
+                SearchDIA's own Essentials card, below the three paths, which put
+                the same field at the top of three pages and halfway down the
+                fourth -- so on the one page people use most it was the field
+                they had to go looking for. */}
+            <section
+              style={{
+                background: '#fff',
+                border: '1px solid #E7EAEE',
+                borderRadius: 13,
+                padding: '18px 20px',
+                marginBottom: 14,
+              }}
+            >
+              <JobNameField value={jobName} resolved={resolvedJobName} onChange={setJobName} />
+            </section>
 
             {isConvert ? (
               <ConvertRawForm
@@ -1964,14 +1998,12 @@ export default function App() {
                 notes={searchNotes}
                 libInfo={libInfo}
                 recentLibraries={recentLibraryPaths}
-                jobName={jobName}
-                resolvedJobName={resolvedJobName}
                 onParam={onParam}
                 onToggle={onToggle}
                 onBrowse={onBrowseSearch}
                 onAddMsFiles={addMsFiles}
                 onRemoveMsFile={removeMsFile}
-                onJobName={setJobName}
+                onToggleMsBatch={() => onToggle('msDataBatch')}
                 onOpenLoad={() => setLoadOpen(true)}
                 onGoToBuild={() => setCommand('buildspeclib')}
               />

--- a/gui/src/components/ConvertRawForm.tsx
+++ b/gui/src/components/ConvertRawForm.tsx
@@ -14,7 +14,7 @@
  */
 import { NumField } from './NumField'
 import { Toggle } from './Toggle'
-import { BROWSE, LABEL, SEG_TRACK, seg } from '../lib/styles'
+import { BROWSE, BROWSE_BLOCK, LABEL, SEG_TRACK, seg } from '../lib/styles'
 import { convertGroups, formatOfFile, type ConvertGroup } from '../lib/config'
 import type { ConvertFormat, ConvertParams } from '../lib/types'
 import { type Note } from '../lib/validate'
@@ -178,7 +178,7 @@ function ConvertFileList({
           type="button"
           className="pio-browse"
           onClick={onAdd}
-          style={{ ...BROWSE, padding: '7px 13px', display: 'inline-flex', alignItems: 'center', gap: 6 }}
+          style={BROWSE_BLOCK}
         >
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none">
             <path

--- a/gui/src/components/SearchDiaForm.tsx
+++ b/gui/src/components/SearchDiaForm.tsx
@@ -9,7 +9,6 @@
  *  reproduced: the Console variant carries that state on its Component class
  *  but never renders it — everything is on one page.
  */
-import { JobNameField } from './JobNameField'
 import { LibrarySummary } from './LibrarySummary'
 import { NumField } from './NumField'
 import { RecentLibraries } from './RecentLibraries'
@@ -121,13 +120,16 @@ function MsFileList({
   params,
   onAdd,
   onRemove,
+  onToggleBatch,
 }: {
   params: SearchParams
   onAdd: () => void
   onRemove: (index: number) => void
+  onToggleBatch: () => void
 }) {
   const files = params.msDataFiles
   const root = params.results.trim()
+  const batch = params.msDataBatch
   return (
     <div>
       {files.length > 0 && (
@@ -165,9 +167,11 @@ function MsFileList({
                 >
                   {f}
                 </div>
-                <div style={{ ...HINT, marginTop: 2 }}>
-                  {root ? `\u2192 ${root}/${fileStem(f)}` : '\u2192 set a results folder below'}
-                </div>
+                {batch && (
+                  <div style={{ ...HINT, marginTop: 2 }}>
+                    {root ? `\u2192 ${root}/${fileStem(f)}` : '\u2192 set a results folder below'}
+                  </div>
+                )}
               </div>
               <button
                 type="button"
@@ -202,10 +206,37 @@ function MsFileList({
         </button>
         <span style={HINT}>
           {files.length
-            ? `${files.length} file${files.length > 1 ? 's' : ''}, searched separately \u2014 ${files.length} run${files.length > 1 ? 's' : ''} queued.`
-            : 'Each file is searched on its own, into its own results folder.'}
+            ? batch
+              ? `${files.length} file${files.length > 1 ? 's' : ''}, searched separately \u2014 ${files.length} run${files.length > 1 ? 's' : ''} queued.`
+              : `${files.length} file${files.length > 1 ? 's' : ''}, searched together \u2014 1 run queued.`
+            : 'Pick the .arrow files to search.'}
         </span>
       </div>
+      {files.length > 0 && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 14,
+            marginTop: 12,
+            paddingTop: 12,
+            borderTop: '1px solid #EEF1F4',
+          }}
+        >
+          <div>
+            <div style={{ fontSize: 13, fontWeight: 600, color: '#344054' }}>
+              Search each file separately
+            </div>
+            <div style={{ ...HINT, marginTop: 2 }}>
+              {batch
+                ? 'One run per file, each with its own results folder. Nothing is shared between them.'
+                : 'Off: one run over the whole list, sharing FDR and match-between-runs across it.'}
+            </div>
+          </div>
+          <Toggle on={batch} fieldKey="msDataBatch" onClick={onToggleBatch} />
+        </div>
+      )}
     </div>
   )
 }
@@ -271,9 +302,6 @@ interface Props {
   libInfo: LibraryInfo | null
   /** Libraries used by earlier SearchDIA runs, most recent first. */
   recentLibraries: string[]
-  jobName: string
-  /** The name the run will get once collisions are resolved; empty when unset. */
-  resolvedJobName: string
   onParam: (key: string, value: string) => void
   onToggle: (key: string) => void
   onBrowse: (key: 'msData' | 'library' | 'results') => void
@@ -281,7 +309,8 @@ interface Props {
   onAddMsFiles: () => void
   /** Drop one file from the list, by index. */
   onRemoveMsFile: (index: number) => void
-  onJobName: (value: string) => void
+  /** Flip between one run per file and one run over the whole list. */
+  onToggleMsBatch: () => void
   onOpenLoad: () => void
   onGoToBuild: () => void
 }
@@ -291,14 +320,12 @@ export function SearchDiaForm({
   notes,
   libInfo,
   recentLibraries,
-  jobName,
-  resolvedJobName,
   onParam,
   onToggle,
   onBrowse,
   onAddMsFiles,
   onRemoveMsFile,
-  onJobName,
+  onToggleMsBatch,
   onOpenLoad,
   onGoToBuild,
 }: Props) {
@@ -324,7 +351,7 @@ export function SearchDiaForm({
           <LoadPreviousButton onClick={onOpenLoad} />
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-          <div data-key="msData">
+          <div data-drop="msData" data-key="msData">
             <label style={LABEL}>MS data</label>
             <div style={{ ...SEG_TRACK, marginBottom: 10 }}>
               <button type="button" onClick={() => onParam('msDataMode', 'folder')} style={seg(!byFiles)}>
@@ -334,7 +361,14 @@ export function SearchDiaForm({
                 Chosen files
               </button>
             </div>
-            {byFiles ? <MsFileList params={params} onAdd={onAddMsFiles} onRemove={onRemoveMsFile} /> : (
+            {byFiles ? (
+              <MsFileList
+                params={params}
+                onAdd={onAddMsFiles}
+                onRemove={onRemoveMsFile}
+                onToggleBatch={onToggleMsBatch}
+              />
+            ) : (
               <PathRow
                 label=""
                 fieldKey="msData"
@@ -417,7 +451,6 @@ export function SearchDiaForm({
             onChange={onParam}
             onBrowse={() => onBrowse('results')}
           />
-          <JobNameField value={jobName} resolved={resolvedJobName} onChange={onJobName} />
         </div>
       </section>
 

--- a/gui/src/components/SearchDiaForm.tsx
+++ b/gui/src/components/SearchDiaForm.tsx
@@ -14,7 +14,7 @@ import { NumField } from './NumField'
 import { RecentLibraries } from './RecentLibraries'
 import { Toggle } from './Toggle'
 import { parseModEntry, unimodDisplay } from '../lib/fasta'
-import { BROWSE, HINT, LABEL, LABEL_TIGHT, SEG_TRACK, seg } from '../lib/styles'
+import { BROWSE, BROWSE_BLOCK, HINT, LABEL, LABEL_TIGHT, SEG_TRACK, seg } from '../lib/styles'
 import type { LibraryInfo } from '../lib/backend'
 import { isPrositModel, unlocalizedMods } from '../lib/types'
 import type { SearchParams } from '../lib/types'
@@ -201,7 +201,15 @@ function MsFileList({
         </div>
       )}
       <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-        <button type="button" className="pio-browse" onClick={onAdd} style={BROWSE}>
+        <button type="button" className="pio-browse" onClick={onAdd} style={BROWSE_BLOCK}>
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none">
+            <path
+              d="M12 5v14M5 12h14"
+              stroke="currentColor"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+            />
+          </svg>
           {files.length ? 'Add more files' : 'Choose files'}
         </button>
         <span style={HINT}>

--- a/gui/src/components/SearchDiaForm.tsx
+++ b/gui/src/components/SearchDiaForm.tsx
@@ -230,8 +230,8 @@ function MsFileList({
             </div>
             <div style={{ ...HINT, marginTop: 2 }}>
               {batch
-                ? 'One run per file, each with its own results folder. Nothing is shared between them.'
-                : 'Off: one run over the whole list, sharing FDR and match-between-runs across it.'}
+                ? 'One run per file, each with its own results folder and nothing shared between them.'
+                : 'One run over the whole list, sharing FDR and match-between-runs across it.'}
             </div>
           </div>
           <Toggle on={batch} fieldKey="msDataBatch" onClick={onToggleBatch} />

--- a/gui/src/lib/dragdrop.ts
+++ b/gui/src/lib/dragdrop.ts
@@ -13,14 +13,18 @@ import type { UnlistenFn } from '@tauri-apps/api/event'
  *  already carries for validation focus, so nothing new is threaded through
  *  the forms. */
 export const DROP_FIELDS: Record<string, 'dir' | 'file' | 'either'> = {
-  // A .poin library is a directory of tables, not a file.
-  msData: 'dir',
+  // Either, because the field is two fields: a folder in "One folder" mode and
+  // a list of files in "Chosen files" mode. It was 'dir', so dropping a batch
+  // of .arrow onto the list -- the one place a batch is what the field wants --
+  // was refused with "this field takes a folder". The handler decides what to
+  // do with what actually landed, and switches mode to match it.
+  msData: 'either',
   library: 'dir',
   results: 'dir',
   libPath: 'dir',
   convertOutput: 'dir',
   calibrationFile: 'file',
-  // ConvertRAW takes a single .raw or a folder of them.
+  // ConvertRAW likewise takes a list of files or a folder of them.
   convertInput: 'either',
   // The FASTA row's add button: dropping onto it appends rows.
   fastaAdd: 'file',

--- a/gui/src/lib/styles.ts
+++ b/gui/src/lib/styles.ts
@@ -48,6 +48,22 @@ export const BROWSE: CSSProperties = {
   cursor: 'pointer',
 }
 
+/** `BROWSE` for a button that stands on its own rather than beside an input.
+ *
+ *  `BROWSE` has no vertical padding on purpose: in a path row it is a flex item
+ *  next to the input and stretches to the input's height, so padding of its own
+ *  would fight that. A button with no such sibling has nothing to stretch
+ *  against and collapses to the height of its text, which against a 9px-padded
+ *  input reads as a different, rounder control. This restores the same box.
+ */
+export const BROWSE_BLOCK: CSSProperties = {
+  ...BROWSE,
+  padding: '9px 14px',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+}
+
 /** One button of a segmented control -- the pill pair that picks between two
  *  shapes of the same field (single file vs folder, .raw vs .mzML, one folder
  *  vs chosen files). Was defined inside ConvertRawForm; the SearchDIA file-list

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -58,14 +58,16 @@ export interface SearchParams {
   msDataFiles: string[]
   /** With a chosen file list, whether each file is its own search.
    *
-   *  True -- the default and the reason the list exists -- gives one run per
-   *  file, each with its own results folder, so method-development files are
-   *  not pooled with the very files they are meant to be compared against.
+   *  False by default, matching folder mode: a list of files is most often a
+   *  subset of one experiment, and searching it as one -- sharing FDR and
+   *  match-between-runs across it -- is what picking files out of a folder
+   *  usually means. Choosing files does not by itself say the files are
+   *  unrelated.
    *
-   *  False searches the whole list as one experiment, sharing FDR and
-   *  match-between-runs across it. That is the right choice when the list is a
-   *  subset of one experiment rather than a set of alternatives. Ignored in
-   *  folder mode, where a folder is always one experiment. */
+   *  True gives one run per file, each with its own results folder, so
+   *  method-development files are not pooled with the very files they are
+   *  meant to be compared against. Ignored in folder mode, where a folder is
+   *  always one experiment. */
   msDataBatch: boolean
   msData: string
   library: string
@@ -89,7 +91,7 @@ export interface SearchParams {
 export const SEARCH_DEFAULTS: SearchParams = {
   msDataMode: 'folder',
   msDataFiles: [],
-  msDataBatch: true,
+  msDataBatch: false,
   msData: '',
   library: '',
   results: '',

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -56,6 +56,17 @@ export interface SearchParams {
   msDataMode: 'folder' | 'files'
   /** The chosen files, when msDataMode is 'files'. */
   msDataFiles: string[]
+  /** With a chosen file list, whether each file is its own search.
+   *
+   *  True -- the default and the reason the list exists -- gives one run per
+   *  file, each with its own results folder, so method-development files are
+   *  not pooled with the very files they are meant to be compared against.
+   *
+   *  False searches the whole list as one experiment, sharing FDR and
+   *  match-between-runs across it. That is the right choice when the list is a
+   *  subset of one experiment rather than a set of alternatives. Ignored in
+   *  folder mode, where a folder is always one experiment. */
+  msDataBatch: boolean
   msData: string
   library: string
   results: string
@@ -78,6 +89,7 @@ export interface SearchParams {
 export const SEARCH_DEFAULTS: SearchParams = {
   msDataMode: 'folder',
   msDataFiles: [],
+  msDataBatch: true,
   msData: '',
   library: '',
   results: '',

--- a/gui/src/lib/validate.ts
+++ b/gui/src/lib/validate.ts
@@ -320,6 +320,7 @@ export function validateSearchRun(
   values: {
     msDataMode?: 'folder' | 'files'
     msDataFiles?: string[]
+    msDataBatch?: boolean
     msData: string
     library: string
     results: string
@@ -336,8 +337,26 @@ export function validateSearchRun(
   // each fanned-out run gets the same library, the same thresholds, and a
   // results folder under the same root.
   if (values.msDataMode === 'files') {
-    if (!(values.msDataFiles ?? []).length) {
+    const files = values.msDataFiles ?? []
+    if (!files.length) {
       return { key: 'msData', msg: 'Add at least one file to search.' }
+    }
+    // Only when they share one directory. Searched separately, each file gets a
+    // staging directory of its own and two files may safely have the same name;
+    // searched together they cannot, so this is checked here rather than left
+    // to paths::stage_files after the run is already queued.
+    if (values.msDataBatch === false) {
+      const seen = new Set<string>()
+      for (const f of files) {
+        const name = (f.trim().split(/[\\/]/).pop() ?? '').toLowerCase()
+        if (seen.has(name)) {
+          return {
+            key: 'msData',
+            msg: `Two of these files are named ${name}. Searched together they would share one folder — rename one, or search each file separately.`,
+          }
+        }
+        seen.add(name)
+      }
     }
   } else {
     if (!values.msData.trim()) return { key: 'msData', msg: 'Set the MS data path before running.' }


### PR DESCRIPTION
A chosen file list can now be searched either as one experiment (the new default, matching what folder mode does with the same files) or as one run per file, via a toggle on the list.

Dropping a group of files onto the MS data field did nothing but report "this field takes a folder" — the field was declared dir-only, which stopped being true when it gained a list; it takes either now, and all dropped paths join the list rather than just the first. The job name field also moves above the form on SearchDIA, where it sat below the three paths while the other three workflows had it at the top, and the standalone "Choose files" buttons get the same box as Browse (`BROWSE` has no vertical padding, since in a path row it stretches to the input beside it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)