### PR TITLE
Fix three search crashes: zero-PSM files, single-file MBR, and separate traces

### DIFF
--- a/src/Routines/SearchDIA/LibrarySearch.jl
+++ b/src/Routines/SearchDIA/LibrarySearch.jl
@@ -15,6 +15,21 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+# An empty PSM frame carrying the columns the search would have produced.
+#
+# `process_scans_fused!` builds its result from the per-thread scored-PSM
+# struct-of-arrays, so a zero-length view of that same store gives the exact
+# schema with no rows — and cannot drift from it the way a hand-written column
+# list would.
+#
+# The early exits in `library_search` returned a bare `DataFrame()` instead, so a
+# file that matched nothing produced a frame with *no columns at all*, and the
+# first downstream reader of `:precursor_idx` threw `ArgumentError: column name
+# :precursor_idx not found` rather than seeing zero PSMs. Every such reader
+# already handles zero rows; none of them could handle zero columns.
+_empty_scored_psms(search_data, params) =
+    DataFrame(@view(get_scored_psms(first(search_data), params)[1:0]))
+
 """
     library_search(spectra, search_context, params, ms_file_idx) -> DataFrame
 
@@ -67,7 +82,7 @@ function library_search(
 
     # NCE models to iterate: [(calibrated_model, nothing)]
     nce_entries = get_nce_models(search_context, params, ms_file_idx)
-    isempty(nce_entries) && return DataFrame()
+    isempty(nce_entries) && return _empty_scored_psms(search_data, params)
 
     # --- 2. Fragment index search (runs once, shared across all NCE models) ---
     if scan_indices === nothing
@@ -92,7 +107,7 @@ function library_search(
         filter!(tt -> !isempty(last(tt)), thread_tasks)
     end
 
-    isempty(all_scan_idxs) && return DataFrame()
+    isempty(all_scan_idxs) && return _empty_scored_psms(search_data, params)
 
     # Build score filter: use learned LUT if available, otherwise fall back to count_ones
     bitvec_filter = getBitVecFilter(search_context, ms_file_idx)

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/IntegrateChromatogramsSearch.jl
@@ -427,11 +427,13 @@ function process_file!(
             # for quantification and mirror that choice onto the PSM/output
             # columns. Combined mode keeps the upstream PSM isotope metadata.
             selected_quant_trace = select_quant_trace_by_transmission(chromatograms)
-            apply_quant_trace_selection!(
+            # Returns the isotope key; :precursor_fraction_transmitted is
+            # updated in place. The key is not stored on the frame — see
+            # apply_quant_trace_selection!.
+            psm_isotopes_captured = apply_quant_trace_selection!(
                 passing_psms,
                 selected_quant_trace,
             )
-            psm_isotopes_captured = passing_psms[!, :isotopes_captured]
         end
         integrate_precursors(
             chromatograms,

--- a/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
+++ b/src/Routines/SearchDIA/SearchMethods/IntegrateChromatogramsSearch/utils.jl
@@ -286,25 +286,47 @@ function select_quant_trace_by_transmission(chromatograms::DataFrame)
 end
 
 """
-    apply_quant_trace_selection!(psms, selected_quant_trace)
+    apply_quant_trace_selection!(psms, selected_quant_trace) -> Vector{Tuple{Int8, Int8}}
 
-Mirror the selected separate-trace quantification channel onto the PSM table.
-This updates the final `:isotopes_captured` and
-`:precursor_fraction_transmitted` output columns for separate-trace runs.
+Apply the selected separate-trace quantification channel to the PSM table.
+
+Updates `:precursor_fraction_transmitted` in place — that is a real output
+column, and in separate-trace mode it must report the fraction of the trace
+actually quantified — and RETURNS the per-PSM isotope-capture key rather than
+writing it into the frame.
+
+The isotope key is deliberately not a column. `:isotopes_captured` was retired
+from the PSM schema, and its only live consumer here is
+`chromatogram_index_key(::SeperateTraces, ...)`, which uses it to look rows up
+in the chromatogram index. Nothing reads it back out: the output alias in
+writeCSVTables maps `:isotopes_captured` to a source column
+`:isotopes_captured_traces` that nothing in the pipeline produces, so the rename
+guarded on its presence never fires. Materialising a column would therefore add
+a per-PSM field to the staged table that only this function writes and only this
+function reads — and would make the separate-trace output schema differ from
+combined for no gain. A local vector costs two bytes a row and only in separate
+mode.
+
+Precursors with no chromatogram row get an unmatchable `(-1, -1)` key. That is
+the correct outcome rather than a fallback: there is no extracted chromatogram
+to integrate, so the precursor keeps zero area and is not quantifiable.
 """
 function apply_quant_trace_selection!(psms::DataFrame, selected_quant_trace::Dict{UInt32, Tuple{Tuple{Int8, Int8}, Float32}})
     prec_col = psms[!, :precursor_idx]::AbstractVector{UInt32}
-    iso_col = psms[!, :isotopes_captured]::AbstractVector{Tuple{Int8, Int8}}
     fraction_col = psms[!, :precursor_fraction_transmitted]::AbstractVector{Float32}
+    isotopes_captured = Vector{Tuple{Int8, Int8}}(undef, length(prec_col))
 
-    for i in eachindex(prec_col)
+    @inbounds for i in eachindex(prec_col)
         selected = get(selected_quant_trace, prec_col[i], nothing)
-        selected === nothing && continue
-        iso_col[i] = selected[1]
+        if selected === nothing
+            isotopes_captured[i] = (Int8(-1), Int8(-1))
+            continue
+        end
+        isotopes_captured[i] = selected[1]
         fraction_col[i] = selected[2]
     end
 
-    return psms
+    return isotopes_captured
 end
 
 function combined_trace_seed_score_column(psms::DataFrame)

--- a/src/Routines/SearchDIA/SearchMethods/MBR/rescoring.jl
+++ b/src/Routines/SearchDIA/SearchMethods/MBR/rescoring.jl
@@ -98,7 +98,30 @@ function load_postintegration_mbr_candidates(
         end
         push!(parts, frame)
     end
-    candidates = isempty(parts) ? DataFrame() : vcat(parts...; cols = :union)
+    # Typed and empty rather than bare. With no surviving candidate anywhere,
+    # _write_mbr_recovery_sidecars_from_candidates! still runs -- it must, since
+    # it writes one recovery sidecar per file and pipeline.jl errors with
+    # "Missing MBR recovery sidecar" if any is absent -- and it reads
+    # :precursor_idx and :scan_idx off this frame. The other nine columns it
+    # needs are supplied by apply_postintegration_mbr_rescoring!, which sizes
+    # them to nrow *before* its own `n == 0` early return. A bare DataFrame()
+    # has no columns at all, so those two reads threw ArgumentError; zero rows
+    # is a state every consumer here already handles.
+    candidates = if isempty(parts)
+        DataFrame(
+            precursor_idx = UInt32[],
+            scan_idx = UInt32[],
+            ms_file_idx = UInt32[],
+            cv_fold = UInt8[],
+            target = Bool[],
+            qval = Float32[],
+            global_qval = Float32[],
+            trace_prob_prepass = Float32[],
+            trace_prob_infold = Float32[],
+        )
+    else
+        vcat(parts...; cols = :union)
+    end
     return (
         candidates = candidates,
         masks = masks,

--- a/test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_postintegration_pipeline.jl
+++ b/test/Routines/SearchDIA/SearchMethods/PrecursorScoringSearch/test_mbr_postintegration_pipeline.jl
@@ -186,3 +186,85 @@ end
         @test staged_pass1.scan_idx == staged_run1.scan_idx
     end
 end
+
+# Regression: a search where no MBR candidate survives the q-value mask.
+#
+# This is the NORMAL outcome for a single-file search. The candidate predicate is
+# `global_pass && !run_pass`, so a precursor identified in its own run is never a
+# transfer candidate — with only one run, nothing is.
+#
+# `load_postintegration_mbr_candidates` used to return a bare `DataFrame()` for
+# that case, with no columns at all, and `_write_mbr_recovery_sidecars_from_candidates!`
+# read `:precursor_idx` off it and threw `ArgumentError`. Every single-file search
+# therefore died at Chromatogram Integration, after MainSearch, scoring and Huber
+# calibration had all succeeded.
+#
+# The writer must still run rather than return early: it emits one recovery
+# sidecar per file, and `finalize_postintegration_mbr!` errors with "Missing MBR
+# recovery sidecar" if any is absent. The correct output is an all-false,
+# all-NaN sidecar, not a skipped one.
+@testset "post-integration MBR handles a run with no transfer candidates" begin
+    mktempdir() do directory
+        n = 4
+        main_path = joinpath(directory, "run1.arrow")
+        prec = UInt32.(1:n)
+        scan = UInt32.(100 .+ (1:n))
+
+        # Every row passes BOTH q-values, so `!run_pass` is false throughout and
+        # the candidate mask is empty — the single-file case.
+        Arrow.write(main_path, DataFrame(
+            precursor_idx = prec,
+            scan_idx = scan,
+            ms_file_idx = fill(UInt32(1), n),
+            cv_fold = UInt8.(prec .% UInt32(2)),
+            target = trues(n),
+            qval = fill(0.001f0, n),
+            global_qval = fill(0.001f0, n),
+        ))
+        Arrow.write(main_path * Pioneer.PASS1_SIDECAR_SUFFIX, DataFrame(
+            precursor_idx = prec,
+            scan_idx = scan,
+            trace_prob_prepass = fill(0.9f0, n),
+            trace_prob_infold = fill(0.9f0, n),
+        ))
+        Arrow.write(main_path * Pioneer.MBR_SIDECAR_SUFFIX, DataFrame(
+            precursor_idx = prec,
+            scan_idx = scan,
+            MBR_best_is_missing_true = falses(n),
+        ))
+
+        loaded = Pioneer.load_postintegration_mbr_candidates([main_path], 0.01f0)
+        candidates = loaded.candidates
+
+        # The contract the writer depends on: zero rows, but real columns.
+        @test nrow(candidates) == 0
+        @test hasproperty(candidates, :precursor_idx)
+        @test hasproperty(candidates, :scan_idx)
+        @test !any(loaded.masks[1])
+
+        # Supplies the nine further columns the writer reads, sized to nrow,
+        # before its own `n == 0` early return.
+        Pioneer.apply_postintegration_mbr_rescoring!(
+            candidates;
+            alpha = 0.01f0,
+            q_value_threshold = 0.01f0,
+            baseline_counts = (loaded.base_targets, loaded.base_decoys),
+            frame_is_candidates = true,
+        )
+
+        written = Pioneer._write_mbr_recovery_sidecars_from_candidates!(
+            candidates, loaded.masks, loaded.n_rows, [main_path])
+        @test written == 1
+
+        sidecar_path = main_path * Pioneer.RECOVERY_SIDECAR_SUFFIX
+        @test isfile(sidecar_path)
+        sidecar = DataFrame(Arrow.Table(sidecar_path))
+        @test nrow(sidecar) == n
+        @test !any(sidecar.mbr_recovered)
+        @test !any(sidecar.MBR_transfer_candidate)
+        @test all(isnan, sidecar.mbr_target_decoy_prob)
+        # Row identity must still line up with the file the sidecar describes.
+        @test sidecar.precursor_idx == prec
+        @test sidecar.scan_idx == scan
+    end
+end

--- a/test/UnitTests/test_chromatogram_integration_trace_order.jl
+++ b/test/UnitTests/test_chromatogram_integration_trace_order.jl
@@ -68,16 +68,21 @@ end
         intensity = Float32[1.0, 10.0, 2.0, 20.0, 3.0],
         precursor_fraction_transmitted = Float32[0.35, 0.82, 0.40, 0.80, 0.55],
     )
+    # Deliberately WITHOUT :isotopes_captured. The real passing_psms table does
+    # not carry it — it was retired from the PSM schema — and this fixture used
+    # to supply it, which is why `apply_quant_trace_selection!` reading it went
+    # unnoticed until a real separate-trace run threw ArgumentError.
     passing_psms = DataFrame(
         precursor_idx = UInt32[10, 20],
-        isotopes_captured = [(Int8(1), Int8(2)), (Int8(1), Int8(2))],
         precursor_fraction_transmitted = Float32[0.35, 0.1],
     )
 
     selected = Pioneer.select_quant_trace_by_transmission(chromatograms)
-    Pioneer.apply_quant_trace_selection!(passing_psms, selected)
+    isotopes_captured = Pioneer.apply_quant_trace_selection!(passing_psms, selected)
 
-    @test passing_psms.isotopes_captured == [(Int8(0), Int8(1)), (Int8(0), Int8(1))]
+    # Returned as the chromatogram-index lookup key, not written onto the frame.
+    @test isotopes_captured == [(Int8(0), Int8(1)), (Int8(0), Int8(1))]
+    @test !hasproperty(passing_psms, :isotopes_captured)
     @test passing_psms.precursor_fraction_transmitted == Float32[0.82, 0.55]
 end
 

--- a/test/UnitTests/test_empty_search_results.jl
+++ b/test/UnitTests/test_empty_search_results.jl
@@ -1,0 +1,47 @@
+# Regression tests for searches that find nothing.
+#
+# A file that matches nothing is a normal outcome — the wrong library, a blank
+# run, or a gradient with no usable MS2 scans — and it must not take the rest of
+# the search with it. `library_search` used to return a bare `DataFrame()` on
+# its two early exits, so such a file produced a frame with NO COLUMNS, and the
+# first downstream reader of `:precursor_idx` (`_add_psm_features!`, via
+# `prepare_psm_features!`) threw `ArgumentError: column name :precursor_idx not
+# found in the data frame`. One dud file aborted a whole multi-file run.
+#
+# The fix returns a zero-ROW frame carrying the real schema, taken as a
+# zero-length view of the same scored-PSM store the non-empty path uses. These
+# tests pin the property that makes that work: the schema comes from the
+# element type, so an empty store still yields every column.
+#
+# Run standalone: julia --project=. test/UnitTests/test_empty_search_results.jl
+if !@isdefined(Pioneer)
+    using Test
+    using Pioneer
+    using DataFrames
+end
+
+@testset "empty search results carry the full schema" begin
+    # Both stores `get_scored_psms` can dispatch to.
+    for T in (
+        Pioneer.MainSearchScoredPSM{Float32, Float16},
+        Pioneer.TuningScoredPSM{Float32, Float16},
+    )
+        store = T[]
+        empty_frame = DataFrame(@view(store[1:0]))
+
+        @test nrow(empty_frame) == 0
+        # Not a bare DataFrame(): the columns are what the crash was about.
+        @test ncol(empty_frame) > 0
+        # Every field of the row type, so the schema cannot drift from the
+        # non-empty path the way a hand-written column list would.
+        @test Set(Symbol.(names(empty_frame))) == Set(fieldnames(T))
+    end
+
+    # The four columns `_add_psm_features!` reads off the frame before doing
+    # anything else. If any of these ever leaves MainSearchScoredPSM, the
+    # feature pass needs revisiting, not just this test.
+    main_frame = DataFrame(@view((Pioneer.MainSearchScoredPSM{Float32, Float16}[])[1:0]))
+    for col in (:precursor_idx, :scan_idx, :error, :total_ions)
+        @test hasproperty(main_frame, col)
+    end
+end

--- a/test/UnitTests/test_quant_trace_selection.jl
+++ b/test/UnitTests/test_quant_trace_selection.jl
@@ -1,0 +1,62 @@
+# Regression tests for separate-trace quantification.
+#
+# `trace_mode: "separate"` crashed in IntegrateChromatogramsSearch with
+# `ArgumentError: column name :isotopes_captured not found in the data frame`.
+# `:isotopes_captured` had been retired from the PSM schema — a passing_psms
+# table carries 118 columns and that is not among them — but
+# `apply_quant_trace_selection!` still wrote the chosen isotope trace into it.
+# Combined mode never calls that function, so only separate-trace runs broke,
+# on every dataset.
+#
+# The key is now returned rather than stored. It has exactly one live consumer,
+# `chromatogram_index_key(::SeperateTraces, ...)`, which uses it to look rows up
+# in the chromatogram index; nothing reads it back off the frame. So a column
+# would add a per-PSM field that only one function writes and only one function
+# reads, and would make the separate-trace output schema differ from combined
+# for no gain.
+#
+# Run standalone: julia --project=. test/UnitTests/test_quant_trace_selection.jl
+if !@isdefined(Pioneer)
+    using Test
+    using Pioneer
+    using DataFrames
+end
+
+@testset "separate-trace quant selection returns the key without adding a column" begin
+    # Deliberately without :isotopes_captured — the real passing_psms schema.
+    psms = DataFrame(
+        precursor_idx = UInt32[10, 20, 30],
+        precursor_fraction_transmitted = Float32[0.10, 0.10, 0.10],
+    )
+    before = Set(Symbol.(names(psms)))
+
+    selected = Dict{UInt32, Tuple{Tuple{Int8, Int8}, Float32}}(
+        UInt32(10) => ((Int8(0), Int8(1)), 0.80f0),
+        UInt32(20) => ((Int8(1), Int8(2)), 0.65f0),
+        # 30 deliberately absent: a precursor with no chromatogram row.
+    )
+
+    keys_out = Pioneer.apply_quant_trace_selection!(psms, selected)
+
+    # The crash was writing this onto the frame; it must stay off it.
+    @test Set(Symbol.(names(psms))) == before
+    @test !hasproperty(psms, :isotopes_captured)
+
+    @test keys_out isa Vector{Tuple{Int8, Int8}}
+    @test length(keys_out) == nrow(psms)
+    @test keys_out[1] == (Int8(0), Int8(1))
+    @test keys_out[2] == (Int8(1), Int8(2))
+    # Unmatchable, so the precursor finds no chromatogram group and keeps zero
+    # area — not quantifiable, which is correct when nothing was extracted.
+    @test keys_out[3] == (Int8(-1), Int8(-1))
+
+    # This one IS a real output column and must reflect the selected trace.
+    @test psms.precursor_fraction_transmitted[1] ≈ 0.80f0
+    @test psms.precursor_fraction_transmitted[2] ≈ 0.65f0
+    # Untouched where nothing was selected.
+    @test psms.precursor_fraction_transmitted[3] ≈ 0.10f0
+end
+
+# The transmission-ranking rule itself is covered by
+# test_chromatogram_integration_trace_order.jl, which also pins the no-column
+# contract against a fixture matching the real PSM schema.

--- a/test/runtests_part2_units.jl
+++ b/test/runtests_part2_units.jl
@@ -26,6 +26,7 @@ println("dir ", @__DIR__)
 include("./UnitTests/test_whittaker_henderson.jl")
 include("./UnitTests/test_retention_time_index.jl")
 include("./UnitTests/test_arrow_psm_container.jl")
+include("./UnitTests/test_empty_search_results.jl")
 include("./UnitTests/test_buildpionlib_index_filters.jl")
 include("./UnitTests/test_enzymatic_termini_metadata.jl")
 

--- a/test/runtests_part2_units.jl
+++ b/test/runtests_part2_units.jl
@@ -27,6 +27,7 @@ include("./UnitTests/test_whittaker_henderson.jl")
 include("./UnitTests/test_retention_time_index.jl")
 include("./UnitTests/test_arrow_psm_container.jl")
 include("./UnitTests/test_empty_search_results.jl")
+include("./UnitTests/test_quant_trace_selection.jl")
 include("./UnitTests/test_buildpionlib_index_filters.jl")
 include("./UnitTests/test_enzymatic_termini_metadata.jl")
 


### PR DESCRIPTION
Three searches died with `ArgumentError: column name ... not found in the data frame`, each because a producer signalled "nothing here" with a bare `DataFrame()` — which has no columns at all — or wrote to a column that had been retired from the schema. A file matching nothing aborted an entire multi-file run at MainSearch; a single-file search with MBR on always died at Chromatogram Integration, since with one run nothing is ever a transfer candidate; and `trace_mode: "separate"` was broken on every dataset.

All three are fixed by returning zero-row frames with real schemas, or by returning the value rather than storing it: the separate-trace isotope key has one live consumer and is now a local vector instead of a PSM column, so combined mode and the output schema are untouched. All three were reproduced end to end before the fix and verified after; the full test suite passes, and the existing separate-trace test — which had masked the bug by inventing a column the real table lacks — now uses a fixture matching the real schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)